### PR TITLE
fix: update aha-js library method names after reorganization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "aha-mcp",
       "dependencies": {
-        "@cedricziel/aha-js": "github:cedricziel/aha-js",
+        "@cedricziel/aha-js": "^1.0.4",
         "@modelcontextprotocol/sdk": "^1.15.1",
         "axios": "^1.9.0",
         "cors": "^2.8.5",
@@ -30,7 +30,7 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
-    "@cedricziel/aha-js": ["@cedricziel/aha-js@github:cedricziel/aha-js#d1836b2", { "dependencies": { "axios": "^1.6.1" } }, "cedricziel-aha-js-d1836b2"],
+    "@cedricziel/aha-js": ["@cedricziel/aha-js@1.0.4", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-RQpZCAqjhJiBL5wGyckVHl9CuL1qIkMtkuaf4HyICsjWKlDJxlT3x4FSapvRicyd7xD+H8ubh3EdHWunFB0MAg=="],
 
     "@commitlint/cli": ["@commitlint/cli@19.8.1", "", { "dependencies": { "@commitlint/format": "^19.8.1", "@commitlint/lint": "^19.8.1", "@commitlint/load": "^19.8.1", "@commitlint/read": "^19.8.1", "@commitlint/types": "^19.8.1", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA=="],
 
@@ -455,8 +455,6 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
-
-    "@cedricziel/aha-js/axios": ["axios@1.9.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg=="],
 
     "@commitlint/config-validator/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.1",
-    "@cedricziel/aha-js": "github:cedricziel/aha-js",
+    "@cedricziel/aha-js": "^1.0.4",
     "axios": "^1.9.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -504,7 +504,7 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasIdGet({ id: ideaId });
+      const response = await ideasApi.ideasGetById({ id: ideaId });
       return response.data;
     } catch (error) {
       console.error(`Error getting idea ${ideaId}:`, error);
@@ -553,7 +553,7 @@ export class AhaService {
       const params: any = {};
       if (updatedSince) params.updatedSince = updatedSince;
 
-      const response = await productsApi.productsGet(params);
+      const response = await productsApi.productsList(params);
       return response.data;
     } catch (error) {
       console.error('Error listing products:', error);
@@ -570,7 +570,7 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesIdGet({ id: initiativeId });
+      const response = await initiativesApi.initiativesGet({ id: initiativeId });
       return response.data;
     } catch (error) {
       console.error(`Error getting initiative ${initiativeId}:`, error);
@@ -601,7 +601,7 @@ export class AhaService {
       if (assignedToUser) params.assignedToUser = assignedToUser;
       if (onlyActive !== undefined) params.onlyActive = onlyActive;
 
-      const response = await initiativesApi.initiativesGet(params);
+      const response = await initiativesApi.initiativesList(params);
       return response.data;
     } catch (error) {
       console.error('Error listing initiatives:', error);
@@ -1295,7 +1295,7 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.productsProductIdInitiativesPost({
+      const response = await initiativesApi.initiativesCreate({
         productId: productId,
         initiativeCreateRequest: initiativeData
       });
@@ -1406,7 +1406,7 @@ export class AhaService {
         featuresIdScorePutRequest: {
           feature: {
             // Note: Need to check exact structure for score updates
-            value: score
+            score_facts: [{ value: score }]
           }
         }
       });
@@ -1491,7 +1491,7 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.productsProductIdIdeasPost({
+      const response = await ideasApi.ideasCreate({
         productId: productId,
         ideaCreateRequest: ideaData
       });
@@ -1553,7 +1553,7 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      await ideasApi.ideasIdDelete({ id: ideaId });
+      await ideasApi.ideasDelete({ id: ideaId });
     } catch (error) {
       console.error(`Error deleting idea ${ideaId}:`, error);
       throw error;
@@ -1672,7 +1672,7 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.productsProductIdIdeasPost({
+      const response = await ideasApi.ideasCreate({
         productId: productId,
         ideaCreateRequest: ideaData
       });


### PR DESCRIPTION
- Fix method names to match reorganized aha-js library v1.0.4
- Update ideasIdGet → ideasGetById
- Update productsGet → productsList
- Update initiativesIdGet → initiativesGet
- Update initiativesGet → initiativesList
- Update initiativesPost → initiativesCreate
- Update ideasPost → ideasCreate
- Update ideasIdDelete → ideasDelete
- Fix feature score structure to use score_facts array
- Add required productId parameters to create methods

🤖 Generated with [Claude Code](https://claude.ai/code)