### PR TITLE
fix: resolve Docker permission denied error for /app/data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,9 +83,9 @@ COPY --from=builder /app/build ./build
 COPY package.json ./
 COPY package.json /package.json
 
-# Create directory for configuration with proper permissions
-RUN mkdir -p /home/mcp/.config && \
-    chown -R mcp:mcp /home/mcp
+# Create directories for configuration and data with proper permissions
+RUN mkdir -p /home/mcp/.config /app/data && \
+    chown -R mcp:mcp /home/mcp /app/data
 
 # Copy the built entry point and make it executable
 RUN chmod +x ./build/index.js


### PR DESCRIPTION
## Summary
- Fixed Docker permission denied error (EACCES) when creating /app/data directory
- Added proper ownership of /app/data to the mcp user in Dockerfile
- Ensures database initialization can create necessary directory structure

## Test plan
- [ ] Build Docker image successfully
- [ ] Run container and verify no permission errors during sync operations
- [ ] Confirm database can initialize and create files in /app/data

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker container setup by ensuring both configuration and data directories are created with the correct permissions for the application user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->