### PR TITLE
fix: copy database schema.sql file to Docker build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,9 @@ RUN bun install @opentelemetry/auto-instrumentations-node
 # Copy built application from builder stage
 COPY --from=builder /app/build ./build
 
+# Copy database schema file to the correct location relative to built JS
+COPY src/core/database/schema.sql ./build/core/database/
+
 # Copy package.json for runtime metadata
 COPY package.json ./
 COPY package.json /package.json


### PR DESCRIPTION
## Summary
- Fixed Docker database initialization error where schema.sql was missing from build output
- Added COPY instruction to place schema.sql in the correct location relative to compiled JavaScript
- Resolves "ENOENT: no such file or directory, open '/app/build/schema.sql'" error

## Test plan
- [ ] Build Docker image successfully
- [ ] Run container and verify database initializes without schema file errors
- [ ] Confirm sync operations work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)