### PR TITLE
fix: copy schema.sql to exact path expected by database service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,8 @@ RUN bun install @opentelemetry/auto-instrumentations-node
 # Copy built application from builder stage
 COPY --from=builder /app/build ./build
 
-# Copy database schema file to the correct location relative to built JS
-COPY src/core/database/schema.sql ./build/core/database/
+# Copy database schema file from builder stage to the exact location where it's expected
+COPY --from=builder /app/src/core/database/schema.sql ./build/schema.sql
 
 # Copy package.json for runtime metadata
 COPY package.json ./


### PR DESCRIPTION
## Summary
- Fixed Docker database initialization by copying schema.sql to exact expected path
- Database service looks for schema.sql at `/app/build/schema.sql`, not in subdirectory
- Copy schema.sql directly to build root to match database service expectations

## Test plan
- [ ] Build Docker image successfully
- [ ] Run container and verify database initializes without schema file errors
- [ ] Confirm sync operations work correctly without ENOENT errors

🤖 Generated with [Claude Code](https://claude.ai/code)