### PR TITLE
fix: grant write permissions for release asset upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release_created }}
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Checkout


### PR DESCRIPTION
The publish job needs 'contents: write' permission to upload DXT files
to GitHub releases using the gh CLI. Changed from 'contents: read' to
'contents: write' to fix the upload failure.