### PR TITLE
feat: migrate resources to ResourceTemplate for parameter discovery

### DIFF
--- a/test/mcp-accessibility.test.ts
+++ b/test/mcp-accessibility.test.ts
@@ -76,7 +76,21 @@ describe('MCP Server Accessibility', () => {
     promptHandlers = new Map();
     
     server = {
-      resource: (name: string, _template: string, handler: Function) => {
+      resource: (name: string, templateOrUri: any, handlerOrMetadata?: any, possibleHandler?: Function) => {
+        // Handle both old signature (string, handler) and new signature (ResourceTemplate, metadata, handler)
+        let handler: Function;
+        if (typeof templateOrUri === 'string' && typeof handlerOrMetadata === 'function') {
+          // Old signature: resource(name, uri, handler)
+          handler = handlerOrMetadata;
+        } else if (typeof templateOrUri === 'object' && typeof possibleHandler === 'function') {
+          // New signature: resource(name, ResourceTemplate, metadata, handler)
+          handler = possibleHandler;
+        } else if (typeof templateOrUri === 'object' && typeof handlerOrMetadata === 'function') {
+          // New signature without metadata: resource(name, ResourceTemplate, handler)
+          handler = handlerOrMetadata;
+        } else {
+          handler = handlerOrMetadata;
+        }
         resourceHandlers.set(name, handler);
       },
       prompt: (name: string, _description: string, _schema: any, handler: Function) => {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -121,7 +121,21 @@ describe('Resources', () => {
     // Create a mock server that captures resource registrations
     resourceHandlers = new Map();
     server = {
-      resource: (name: string, template: string, handler: Function) => {
+      resource: (name: string, templateOrUri: any, handlerOrMetadata?: any, possibleHandler?: Function) => {
+        // Handle both old signature (string, handler) and new signature (ResourceTemplate, metadata, handler)
+        let handler: Function;
+        if (typeof templateOrUri === 'string' && typeof handlerOrMetadata === 'function') {
+          // Old signature: resource(name, uri, handler)
+          handler = handlerOrMetadata;
+        } else if (typeof templateOrUri === 'object' && typeof possibleHandler === 'function') {
+          // New signature: resource(name, ResourceTemplate, metadata, handler)
+          handler = possibleHandler;
+        } else if (typeof templateOrUri === 'object' && typeof handlerOrMetadata === 'function') {
+          // New signature without metadata: resource(name, ResourceTemplate, handler)
+          handler = handlerOrMetadata;
+        } else {
+          handler = handlerOrMetadata;
+        }
         resourceHandlers.set(name, handler);
       }
     } as any;


### PR DESCRIPTION
## Summary
- Migrates MCP resources to use ResourceTemplate for better parameter discovery
- Enables MCP clients to discover and auto-complete resource parameters
- Maintains full backward compatibility with existing code and tests

## Changes
- Import ResourceTemplate from MCP SDK
- Convert 9 paginated resources to use ResourceTemplate with query parameters:
  * `aha_features` - query, updatedSince, tag, assignedToUser, page, perPage
  * `aha_products` - updatedSince, page, perPage  
  * `aha_initiatives` - query, updatedSince, assignedToUser, onlyActive, page, perPage
  * `aha_goals` - query, updatedSince, assignedToUser, status, page, perPage
  * `aha_releases` - query, updatedSince, assignedToUser, status, parkingLot, page, perPage
  * `aha_strategic_models` - query, type, updatedSince, page, perPage
  * `aha_idea_organizations` - query, emailDomain, page, perPage
  * `aha_ideas` - query, updatedSince, assignedToUser, status, category, page, perPage
  * `aha_product_releases` - product_id (path), query, updatedSince, status, parkingLot, page, perPage
- Convert 2 path-variable resources as examples:
  * `aha_idea` - uses {id} path variable
  * `aha_feature` - uses {id} path variable
- Add completion callbacks for pagination and boolean parameters
- Add metadata (title, description, mimeType) to all converted resources
- Update test mocks to handle both old and new resource signatures
- Ensure backward compatibility for direct handler calls

## Benefits
- **Parameter Discovery** - MCP clients can now discover all available parameters for each resource
- **Auto-completion** - Clients get suggestions for parameter values like page numbers and boolean flags
- **Better Documentation** - Each resource now has title, description, and MIME type metadata
- **Type Safety** - Parameters are explicitly defined in URI templates
- **Backward Compatibility** - Existing URIs and direct handler calls continue to work

## Test Plan
- [x] All existing tests pass (209 tests)
- [x] Build succeeds without errors
- [x] Server starts successfully
- [x] Resources work with both old URIs and new ResourceTemplate patterns
- [x] Test mocks handle both signatures correctly