### PR TITLE
chore: normalise package.json metadata npm was auto-correcting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "main": "./build/index.js",
   "bin": {
-    "aha-mcp": "./build/index.js"
+    "aha-mcp": "build/index.js"
   },
   "files": [
     "build/",
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cedricziel/aha-mcp.git"
+    "url": "git+https://github.com/cedricziel/aha-mcp.git"
   },
   "homepage": "https://github.com/cedricziel/aha-mcp#readme",
   "bugs": {


### PR DESCRIPTION
Every `npm publish` run logged:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.
npm warn publish   "bin[aha-mcp]" script name was cleaned
npm warn publish   "repository.url" was normalized to "git+https://github.com/cedricziel/aha-mcp.git"
```

Applying `npm pkg fix` so the published metadata matches what is declared in the repo. No behavioural change — npm was already publishing these normalised values.

Verified with `npm publish --dry-run`: the auto-correction warnings are gone, 5 files, same contents.

Noted while diagnosing the v0.9.0 publish failure. That failure is unrelated and **not** fixed here — it is `E404 on PUT /@cedricziel%2faha-mcp`, which for an existing scoped package means `NPM_TOKEN` is expired or lacks publish rights. Provenance signing succeeded, so OIDC is fine; only the registry write is rejected. Rotating the secret is the fix.