### PR TITLE
fix: resolve the cache path independently of cwd and make the local cache opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `src/core/uri-template.ts` vendors the still-unmerged upstream fix from
   modelcontextprotocol/typescript-sdk#1083. Delete it once that lands, not before -
   without it, resource URIs carrying query parameters do not match.
+- The cache path must never be derived from `process.cwd()`. It used to be, and a desktop
+  extension (cwd `/`) failed every sync with `ENOENT: mkdir '/data'`. Use
+  `defaultDatabasePath()`.
+- `manifest.json`'s tool list must match the *default* surface (currently 30), not the
+  full set. Regenerate it from a running server with the local cache disabled, and keep
+  prompts as `prompts_generated: true` - the schema requires a `text` field on any
+  statically declared prompt, which the server generates at runtime instead.
+- `aha_semantic_search` is not semantic: `generateSimpleEmbedding()` hashes character codes
+  through `Math.sin()`. Do not describe it as embedding- or transformer-based. Aha's own
+  `searchDocuments` GraphQL query at `POST /api/v2/graphql` is the real search facility.
 
 ## Runtime Configuration
 
@@ -114,7 +124,9 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
 
 - **AhaService**: Singleton service class that wraps the `aha-js` library for API interactions
 - **ConfigService**: Manages runtime configuration with file persistence and validation
-- **Tools**: 49 MCP tools for Aha.io operations (CRUD, sync, embeddings, health checks, configuration)
+- **Tools**: 30 MCP tools enabled by default (CRUD, health checks, configuration), plus 19
+  sync/embedding tools gated behind `AHA_ENABLE_LOCAL_CACHE=true` (see `isLocalCacheEnabled()`
+  in `src/core/tools.ts`)
 - **Resources**: 40+ resource types for accessing Aha.io entities via URI schemes
 - **Prompts**: 14 domain-specific workflow prompts with context-aware responses
 - **Authentication**: Runtime configuration with environment variables and config file support

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Download `aha-mcp-v<version>.mcpb` from the [latest release](https://github.com/
 and open it with Claude Desktop, which will prompt you for your Aha.io subdomain and API
 token. No Node.js or Docker setup and no manual JSON editing required.
 
-The extension bundles the server itself but not the native `sqlite3` module, so the
-local-cache tools (`aha_sync_*`) and the embedding/semantic-search tools are unavailable
-inside it. Everything else works; use the npx or Docker setup below if you need those.
+The extension exposes 30 tools that query Aha.io directly, so results are always current.
+The optional local-cache tools (`aha_sync_*`) and embedding/semantic-search tools are
+disabled by default — see [Local cache and semantic search](#local-cache-and-semantic-search).
 
 ### Claude Desktop Configuration
 
@@ -645,19 +645,47 @@ The MCP server now provides comprehensive lifecycle management for Aha.io entiti
 - **Comprehensive Entity Coverage**: Full CRUD operations for features, epics, ideas, and competitors
 
 #### Technical Achievements
-- **49 total MCP tools** (comprehensive Aha.io integration + sync + embeddings + config)
-- **50 total MCP resources** (complete entity coverage)
-- **13 domain-specific prompts** (workflow automation)
+- **30 MCP tools enabled by default**, all querying Aha.io directly
+- **19 further tools** behind the opt-in local cache (9 sync, 10 embedding)
+- **15 listed MCP resources** covering the entity set, plus templated resource URIs
+- **14 domain-specific prompts** (workflow automation)
 - **25 core CRUD and write operation tools** for complete lifecycle management
-- **9 sync & database tools** for offline data management
-- **10 embedding & semantic search tools** for AI-powered content discovery
 - **5 server configuration tools** for runtime configuration
-- **209 tests passing** with comprehensive service coverage
-- **SQLite database with vector extensions** for high-performance local storage
+- **345 tests passing** with comprehensive service coverage
 - **Background job processing** with real-time progress tracking
-- **Semantic search capabilities** using transformer models
 - **Comprehensive error handling** with proper Zod schema validation
-- **Professional-grade implementation** following MCP best practices
+
+## 🔍 Local cache and semantic search
+
+The `aha_sync_*` and embedding tools keep a local SQLite copy of your Aha data. They are
+**disabled by default** and must be enabled explicitly:
+
+```bash
+export AHA_ENABLE_LOCAL_CACHE=true
+```
+
+Two reasons they are opt-in:
+
+1. **They need infrastructure that is not always present** — the native `sqlite3` module
+   (deliberately not bundled in the desktop extension) and a writable data directory.
+2. **`aha_semantic_search` is not currently semantic.** The embedding function is a
+   placeholder that hashes character codes through `Math.sin()`; it carries no meaning, so
+   similarity scores are not meaningful. Treat these tools as unfinished.
+
+The cache location is resolved from `AHA_MCP_DATA_DIR`, then `MCP_CONFIG_DIR`, then
+`~/.aha-mcp/`. It is never derived from the working directory.
+
+### Searching Aha without the cache
+
+Aha.io provides server-side search, which needs no sync and is always current:
+
+| What | Endpoint | Searches |
+|------|----------|----------|
+| Global search | `POST /api/v2/graphql` — `searchDocuments(filters: {query, searchableType})` | Names and descriptions across record types; supports `*` prefix and `AND`/`OR`/`NOT` |
+| Idea search | `GET /api/v1/ideas/related?q=` | Idea name, description, ID |
+| Per-entity filter | `GET /api/v1/features?q=` | **Name only** |
+
+Aha also hosts its own MCP server at `https://<yourcompany>.aha.io/api/v1/mcp`.
 
 ## 🛠️ Adding Custom Tools and Resources
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Aha.io MCP Server",
   "version": "0.9.0",
   "description": "Model Context Protocol server for Aha.io product management platform",
-  "long_description": "A comprehensive MCP server that provides seamless integration with Aha.io's API. This extension enables AI assistants to interact with Aha.io workspaces, manage features, ideas, epics, initiatives, competitors and more, with 49 tools, 15 resources and 14 guided prompts.\n\nNote: the local-cache features (the `aha_sync_*` tools and the embedding/semantic-search tools) need the native `sqlite3` module, which is not bundled in this extension. Everything else works out of the box; install the server from npm (`npx @cedricziel/aha-mcp`) or run the Docker image if you need the cache and semantic search.",
+  "long_description": "A comprehensive MCP server that provides seamless integration with Aha.io's API. This extension enables AI assistants to interact with Aha.io workspaces, manage features, ideas, epics, initiatives, competitors and more, with 30 tools, 15 resources and 14 guided prompts.\n\nAll tools query Aha.io directly, so results are always current and nothing is cached locally. The optional local-cache features (the `aha_sync_*` tools and the embedding/semantic-search tools) are disabled here: they require the native `sqlite3` module, which is not bundled in an extension, and a writable data directory. If you need them, install the server from npm (`npx @cedricziel/aha-mcp`) or run the Docker image and set `AHA_ENABLE_LOCAL_CACHE=true`.",
   "author": {
     "name": "Cedric Ziel",
     "email": "mail@cedric-ziel.com",
@@ -107,10 +107,6 @@
       "description": "Delete a competitor in Aha.io"
     },
     {
-      "name": "aha_delete_entity_embedding",
-      "description": "Delete the stored vector embedding for a specific entity"
-    },
-    {
       "name": "aha_delete_epic",
       "description": "Delete an epic in Aha.io"
     },
@@ -123,76 +119,8 @@
       "description": "Delete an idea in Aha.io"
     },
     {
-      "name": "aha_embedding_status",
-      "description": "Get the status and progress of embedding generation jobs"
-    },
-    {
-      "name": "aha_find_similar",
-      "description": "Find entities similar to a specific entity using embeddings"
-    },
-    {
-      "name": "aha_generate_embeddings",
-      "description": "Generate vector embeddings for specified Aha entities to enable semantic search"
-    },
-    {
-      "name": "aha_generate_entity_embedding",
-      "description": "Generate an embedding for a specific entity by ID"
-    },
-    {
-      "name": "aha_get_entity_embedding",
-      "description": "Retrieve the stored vector embedding for a specific entity"
-    },
-    {
       "name": "aha_move_feature_to_release",
       "description": "Move a feature to a different release in Aha.io"
-    },
-    {
-      "name": "aha_pause_embeddings",
-      "description": "Pause a running embedding generation job"
-    },
-    {
-      "name": "aha_semantic_search",
-      "description": "Search for Aha entities using semantic similarity (vector embeddings)"
-    },
-    {
-      "name": "aha_stop_embeddings",
-      "description": "Stop an embedding generation job completely"
-    },
-    {
-      "name": "aha_sync_cleanup",
-      "description": "Clean up old completed/failed sync jobs and optimize database"
-    },
-    {
-      "name": "aha_sync_config",
-      "description": "View or update sync configuration settings"
-    },
-    {
-      "name": "aha_sync_entity",
-      "description": "Quickly sync a specific entity by ID (bypasses background queue)"
-    },
-    {
-      "name": "aha_sync_health",
-      "description": "Get comprehensive health status of the sync system, database, and cached data"
-    },
-    {
-      "name": "aha_sync_history",
-      "description": "Get detailed history and logs for a specific sync job or recent sync activities"
-    },
-    {
-      "name": "aha_sync_pause",
-      "description": "Pause a running background sync operation"
-    },
-    {
-      "name": "aha_sync_start",
-      "description": "Start a background synchronization for specified Aha entity types"
-    },
-    {
-      "name": "aha_sync_status",
-      "description": "Get current status of all sync operations including progress, active jobs, and recent history"
-    },
-    {
-      "name": "aha_sync_stop",
-      "description": "Stop a background sync operation completely"
     },
     {
       "name": "aha_update_competitor",
@@ -221,10 +149,6 @@
     {
       "name": "aha_update_feature_tags",
       "description": "Update tags for a feature in Aha.io"
-    },
-    {
-      "name": "aha_vector_status",
-      "description": "Check if vector operations are available and view vector storage statistics"
     },
     {
       "name": "configure_server",

--- a/src/core/database/database.ts
+++ b/src/core/database/database.ts
@@ -2,6 +2,7 @@ import type sqlite3 from 'sqlite3';
 import type { Database } from 'sqlite';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { log } from '../logger.js';
 
@@ -94,6 +95,25 @@ export interface SearchResult {
 }
 
 /**
+ * Where the local cache lives.
+ *
+ * This used to be `process.cwd()/data`, which only worked when the server happened to be
+ * started from the project root (or from /app in the Docker image). A Claude Desktop
+ * extension is launched with cwd `/`, so every sync and embedding call failed with
+ * "ENOENT: no such file or directory, mkdir '/data'".
+ *
+ * Resolution order:
+ *  - AHA_MCP_DATA_DIR, for deployments that mount a specific volume
+ *  - MCP_CONFIG_DIR, already set by the Docker image
+ *  - ~/.aha-mcp/, which is writable for a desktop or npx install
+ */
+export function defaultDatabasePath(): string {
+  const explicitDir = process.env.AHA_MCP_DATA_DIR || process.env.MCP_CONFIG_DIR;
+  const baseDir = explicitDir ? explicitDir : path.join(homedir(), '.aha-mcp');
+  return path.join(baseDir, 'aha-mcp.db');
+}
+
+/**
  * Database service for Aha MCP Server with SQLite and vector embeddings
  */
 export class DatabaseService {
@@ -103,8 +123,7 @@ export class DatabaseService {
   private vectorEnabled = false;
 
   constructor(dbPath?: string) {
-    // Default to data directory in project root
-    this.dbPath = dbPath || path.join(process.cwd(), 'data', 'aha-mcp.db');
+    this.dbPath = dbPath || defaultDatabasePath();
   }
 
   /**

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -6,6 +6,21 @@ import { registerSyncTools } from "./tools/sync-tools.js";
 import { registerEmbeddingTools } from "./tools/embedding-tools.js";
 import { log } from "./logger.js";
 
+/**
+ * Whether the local-cache features (background sync and the embedding/semantic-search
+ * tools) are enabled.
+ *
+ * Off unless explicitly requested. They need a writable data directory and the native
+ * sqlite3 module, neither of which is guaranteed - the Claude Desktop extension ships
+ * without sqlite3 - and the embedding similarity is a placeholder hash rather than a real
+ * model, so advertising the tools by default offers capability the server cannot deliver.
+ *
+ * Set AHA_ENABLE_LOCAL_CACHE=true to register them.
+ */
+export function isLocalCacheEnabled(): boolean {
+  const flag = process.env.AHA_ENABLE_LOCAL_CACHE?.trim().toLowerCase();
+  return flag === 'true' || flag === '1' || flag === 'yes';
+}
 
 /**
  * Register all tools with the MCP server
@@ -970,9 +985,16 @@ export function registerTools(server: McpServer) {
     }
   );
 
-  // Register sync tools for background synchronization and observability
-  registerSyncTools(server);
-  
-  // Register embedding tools for semantic search capabilities
-  registerEmbeddingTools(server);
+  // The local cache and its semantic-search tools are opt-in; see isLocalCacheEnabled().
+  if (isLocalCacheEnabled()) {
+    // Register sync tools for background synchronization and observability
+    registerSyncTools(server);
+
+    // Register embedding tools for semantic search capabilities
+    registerEmbeddingTools(server);
+  } else {
+    log.info('Local cache disabled; sync and embedding tools not registered', {
+      hint: 'Set AHA_ENABLE_LOCAL_CACHE=true to enable them'
+    });
+  }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,6 +11,25 @@ import * as z from "zod/v4";
 // different depth than this source file, so resolving "../../package.json" relative to
 // import.meta.url crashed the server on startup for every packaged artifact.
 import packageJson from "../../package.json";
+import { isLocalCacheEnabled } from "../core/tools.js";
+
+/**
+ * Count what actually got registered, for the startup log and server_status.
+ *
+ * The SDK keeps these registries private, so read them defensively: a wrong count is not
+ * worth throwing over, and the previous hardcoded numbers had already drifted (40 tools and
+ * 12 prompts against an actual 30 and 14).
+ */
+function countRegistered(server: McpServer, kind: 'tool' | 'resource' | 'prompt'): number | 'unknown' {
+  const field = {
+    tool: '_registeredTools',
+    resource: '_registeredResources',
+    prompt: '_registeredPrompts'
+  }[kind];
+
+  const registry = (server as unknown as Record<string, unknown>)[field];
+  return registry && typeof registry === 'object' ? Object.keys(registry).length : 'unknown';
+}
 
 // Server status tracking
 let serverStatus = {
@@ -311,13 +330,17 @@ async function startServer() {
       arch: process.arch,
       working_directory: process.cwd(),
       capabilities: {
-        tools: 40,
-        resources: '40+',
-        prompts: 12,
+        // Counted from the registry rather than hardcoded: the totals drifted (they read
+        // 40 tools and 12 prompts against an actual 30/14), and the tool count now depends
+        // on whether the local cache is enabled.
+        tools: countRegistered(server, 'tool'),
+        resources: countRegistered(server, 'resource'),
+        prompts: countRegistered(server, 'prompt'),
+        local_cache_enabled: isLocalCacheEnabled(),
         features: [
           'context-aware',
           'dual-transport',
-          'full-crud', 
+          'full-crud',
           'health-checks',
           'runtime-config'
         ]

--- a/test/local-cache-config.test.ts
+++ b/test/local-cache-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { homedir } from 'os';
+import { join } from 'path';
+import { isLocalCacheEnabled } from '../src/core/tools';
+import { defaultDatabasePath } from '../src/core/database/database';
+
+/**
+ * Covers the two settings behind the "ENOENT: mkdir '/data'" failure reported from a
+ * Claude Desktop install, and the decision to keep the local cache opt-in.
+ */
+describe('local cache configuration', () => {
+  const saved = {
+    enable: process.env.AHA_ENABLE_LOCAL_CACHE,
+    dataDir: process.env.AHA_MCP_DATA_DIR,
+    configDir: process.env.MCP_CONFIG_DIR
+  };
+
+  beforeEach(() => {
+    delete process.env.AHA_ENABLE_LOCAL_CACHE;
+    delete process.env.AHA_MCP_DATA_DIR;
+    delete process.env.MCP_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ['AHA_ENABLE_LOCAL_CACHE', saved.enable],
+      ['AHA_MCP_DATA_DIR', saved.dataDir],
+      ['MCP_CONFIG_DIR', saved.configDir]
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  describe('isLocalCacheEnabled', () => {
+    it('is off when the flag is unset', () => {
+      expect(isLocalCacheEnabled()).toBe(false);
+    });
+
+    it.each(['true', 'TRUE', '1', 'yes', ' true '])('is on for %p', value => {
+      process.env.AHA_ENABLE_LOCAL_CACHE = value;
+      expect(isLocalCacheEnabled()).toBe(true);
+    });
+
+    it.each(['false', '0', 'no', '', 'maybe'])('stays off for %p', value => {
+      process.env.AHA_ENABLE_LOCAL_CACHE = value;
+      expect(isLocalCacheEnabled()).toBe(false);
+    });
+  });
+
+  describe('defaultDatabasePath', () => {
+    it('falls back to a writable directory under the home directory', () => {
+      expect(defaultDatabasePath()).toBe(join(homedir(), '.aha-mcp', 'aha-mcp.db'));
+    });
+
+    it('does not depend on the working directory', () => {
+      // The original bug: cwd was used as the base, so a desktop extension launched with
+      // cwd '/' tried to create '/data' and every sync call failed with ENOENT.
+      const original = process.cwd();
+      try {
+        process.chdir('/');
+        expect(defaultDatabasePath()).not.toBe('/data/aha-mcp.db');
+        expect(defaultDatabasePath()).toStartWith(homedir());
+      } finally {
+        process.chdir(original);
+      }
+    });
+
+    it('honours AHA_MCP_DATA_DIR', () => {
+      process.env.AHA_MCP_DATA_DIR = '/tmp/aha-cache';
+      expect(defaultDatabasePath()).toBe(join('/tmp/aha-cache', 'aha-mcp.db'));
+    });
+
+    it('honours MCP_CONFIG_DIR, which the Docker image already sets', () => {
+      process.env.MCP_CONFIG_DIR = '/home/mcp/.config';
+      expect(defaultDatabasePath()).toBe(join('/home/mcp/.config', 'aha-mcp.db'));
+    });
+
+    it('prefers AHA_MCP_DATA_DIR over MCP_CONFIG_DIR', () => {
+      process.env.AHA_MCP_DATA_DIR = '/tmp/explicit';
+      process.env.MCP_CONFIG_DIR = '/home/mcp/.config';
+      expect(defaultDatabasePath()).toBe(join('/tmp/explicit', 'aha-mcp.db'));
+    });
+  });
+});


### PR DESCRIPTION
## The reported failure

From a Claude Desktop install:

> `aha_sync_health` and `aha_sync_start` both fail with `ENOENT: no such file or directory, mkdir '/data'` — the server can't write its local cache/database. `aha_vector_status` confirms vector search is disabled, and even the text-search fallback returned zero results.

## Cause

```ts
this.dbPath = dbPath || path.join(process.cwd(), 'data', 'aha-mcp.db');
```

The cache path came from **`process.cwd()`**. That works when the server is started from the project root, or from `/app` in the Docker image — but a desktop extension is launched with cwd `/`, so it tried to `mkdir /data`. Docker was masking the bug.

Now resolved from `AHA_MCP_DATA_DIR` → `MCP_CONFIG_DIR` (already set by the Docker image) → `~/.aha-mcp/`. Never from the working directory.

## Local cache is now opt-in

`AHA_ENABLE_LOCAL_CACHE=true` to enable; default surface goes **49 → 30 tools**. The 19 sync/embedding tools need a writable data directory *and* the native `sqlite3` module the extension deliberately doesn't bundle. Advertising them by default promised capability the server couldn't deliver — the report above is what that looks like to a user.

## `aha_semantic_search` is not semantic

Worth stating plainly, because the README claimed *"semantic search capabilities using transformer models"*:

```js
// "Simple hash-based embedding for demo purposes"
embedding[index] += Math.sin(charCode * 0.1) * 0.1;
```

It hashes **character codes**. Two records about the same concept in different words get unrelated vectors, so the similarity scores are not interpretable. The code itself says *"In production, replace with actual embedding API."*

## What Aha offers instead (researched, endpoints probed live)

| What | Endpoint | Searches |
|---|---|---|
| Global search | `POST /api/v2/graphql` — `searchDocuments(filters: {query, searchableType})` | Names + descriptions across record types; `*` prefix, `AND`/`OR`/`NOT` |
| Idea search | `GET /api/v1/ideas/related?q=` | Idea name, description, ID |
| Per-entity filter | `GET /api/v1/features?q=` | **name only** — why "VOC" found nothing |

All three return 401 (not 404) unauthenticated on a real tenant, so they exist. Aha also hosts its own MCP server at `/api/v1/mcp`, and their community MCP was archived in May 2026 pointing users there.

This means the sync + embedding apparatus is not needed for search. **Not done in this PR** — it's a design decision, not a bug fix.

## Also fixed

Startup metadata was hardcoded and had drifted (`tools: 40`, `prompts: 12` against an actual 30 and 14). Now counted from the SDK registries, plus `local_cache_enabled`.

## Verification

- 345 tests pass (16 new, covering the path resolution and the flag, including a regression test that `defaultDatabasePath()` doesn't return `/data/...` when cwd is `/`).
- Packed the extension and drove it over stdio: 30 tools, no sync/vector/semantic tool exposed, health check clean.
- Confirmed the flag flips the surface: 30 → 49, and reported counts follow.