### PR TITLE
feat: annotate every MCP tool with behaviour hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,24 @@ When working with this MCP server, follow these key principles from the Model Co
 - Return structured responses with appropriate content types
 - Use annotations to describe tool behaviors and side effects
 
+#### Tool annotations
+
+Every tool is registered with an annotations argument, and the e2e suite fails if one is
+missing. Conventions used here:
+
+- `title` is a short human-readable label for client UIs.
+- `readOnlyHint` is true only for tools that never write: `aha_search`, `server_status`,
+  `get_server_config`, `server_health_check`, `test_configuration`.
+- `destructiveHint` and `idempotentHint` are **omitted** when `readOnlyHint` is true - the
+  spec only gives them meaning for writers.
+- `destructiveHint: true` covers the deletes plus the two PUT endpoints that replace a whole
+  collection: `aha_update_feature_tags` and `aha_associate_feature_with_goals` drop anything
+  left out of the request.
+- `openWorldHint: true` for anything that reaches Aha.io. That includes
+  `server_health_check`, which calls `/me` when credentials are configured.
+- `idempotentHint` is false for the `create_*` tools (a repeated call creates another record)
+  and true for updates and associations.
+
 ### Resources
 
 - Use unique URIs for resource identification (e.g., `aha://idea/{id}`)

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -19,6 +19,13 @@ export function registerTools(server: McpServer) {
       featureId: z.string().describe("ID of the feature"),
       body: z.string().describe("Comment body")
     },
+    {
+      title: "Create feature comment",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { featureId: string; body: string }) => {
       try {
         const comment = await services.AhaService.createFeatureComment(params.featureId, params.body);
@@ -57,6 +64,13 @@ export function registerTools(server: McpServer) {
       featureId: z.string().describe("ID of the feature"),
       epicId: z.string().describe("ID or name of the epic")
     },
+    {
+      title: "Associate feature with epic",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { featureId: string; epicId: string }) => {
       try {
         const feature = await services.AhaService.associateFeatureWithEpic(params.featureId, params.epicId);
@@ -90,6 +104,13 @@ export function registerTools(server: McpServer) {
     {
       featureId: z.string().describe("ID of the feature"),
       releaseId: z.string().describe("ID or key of the target release")
+    },
+    {
+      title: "Move feature to release",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { featureId: string; releaseId: string }) => {
       try {
@@ -125,6 +146,14 @@ export function registerTools(server: McpServer) {
       featureId: z.string().describe("ID of the feature"),
       goalIds: z.array(z.number()).describe("Array of goal IDs to associate with the feature")
     },
+    // destructive: PUT /features/:id/goals replaces the goal set, so goals left out are unlinked.
+    {
+      title: "Set feature goals",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { featureId: string; goalIds: number[] }) => {
       try {
         const feature = await services.AhaService.associateFeatureWithGoals(params.featureId, params.goalIds);
@@ -158,6 +187,14 @@ export function registerTools(server: McpServer) {
     {
       featureId: z.string().describe("ID of the feature"),
       tags: z.array(z.string()).describe("Array of tag strings to associate with the feature")
+    },
+    // destructive: PUT /features/:id/tags replaces the tag set, so tags left out are removed.
+    {
+      title: "Set feature tags",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { featureId: string; tags: string[] }) => {
       try {
@@ -198,6 +235,13 @@ export function registerTools(server: McpServer) {
         }).describe("Epic data object")
       }).describe("Epic creation data")
     },
+    {
+      title: "Create epic in product",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { productId: string; epicData: any }) => {
       try {
         const epic = await services.AhaService.createEpicInProduct(params.productId, params.epicData);
@@ -237,6 +281,13 @@ export function registerTools(server: McpServer) {
         }).describe("Epic data object")
       }).describe("Epic creation data")
     },
+    {
+      title: "Create epic in release",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { releaseId: string; epicData: any }) => {
       try {
         const epic = await services.AhaService.createEpicInRelease(params.releaseId, params.epicData);
@@ -275,6 +326,13 @@ export function registerTools(server: McpServer) {
           description: z.string().optional().describe("Description of the initiative")
         }).describe("Initiative data object")
       }).describe("Initiative creation data")
+    },
+    {
+      title: "Create initiative in product",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
     },
     async (params: { productId: string; initiativeData: any }) => {
       try {
@@ -319,6 +377,13 @@ export function registerTools(server: McpServer) {
         }).describe("Feature data object")
       }).describe("Feature creation data")
     },
+    {
+      title: "Create feature",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { releaseId: string; featureData: any }) => {
       try {
         const feature = await services.AhaService.createFeature(params.releaseId, params.featureData);
@@ -358,6 +423,13 @@ export function registerTools(server: McpServer) {
         }).describe("Feature data object")
       }).describe("Feature update data")
     },
+    {
+      title: "Update feature",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { featureId: string; featureData: any }) => {
       try {
         const feature = await services.AhaService.updateFeature(params.featureId, params.featureData);
@@ -390,6 +462,13 @@ export function registerTools(server: McpServer) {
     "Delete a feature in Aha.io",
     {
       featureId: z.string().describe("ID of the feature")
+    },
+    {
+      title: "Delete feature",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { featureId: string }) => {
       try {
@@ -425,6 +504,13 @@ export function registerTools(server: McpServer) {
       featureId: z.string().describe("ID of the feature"),
       progress: z.number().min(0).max(100).describe("Progress percentage (0-100)")
     },
+    {
+      title: "Update feature progress",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { featureId: string; progress: number }) => {
       try {
         const feature = await services.AhaService.updateFeatureProgress(params.featureId, params.progress);
@@ -459,6 +545,13 @@ export function registerTools(server: McpServer) {
       featureId: z.string().describe("ID of the feature"),
       score: z.number().describe("Score value")
     },
+    {
+      title: "Update feature score",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { featureId: string; score: number }) => {
       try {
         const feature = await services.AhaService.updateFeatureScore(params.featureId, params.score);
@@ -492,6 +585,13 @@ export function registerTools(server: McpServer) {
     {
       featureId: z.string().describe("ID of the feature"),
       customFields: z.object({}).describe("Custom fields data")
+    },
+    {
+      title: "Update feature custom fields",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { featureId: string; customFields: any }) => {
       try {
@@ -536,6 +636,13 @@ export function registerTools(server: McpServer) {
         }).describe("Epic data object")
       }).describe("Epic update data")
     },
+    {
+      title: "Update epic",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { epicId: string; epicData: any }) => {
       try {
         const epic = await services.AhaService.updateEpic(params.epicId, params.epicData);
@@ -568,6 +675,13 @@ export function registerTools(server: McpServer) {
     "Delete an epic in Aha.io",
     {
       epicId: z.string().describe("ID of the epic")
+    },
+    {
+      title: "Delete epic",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { epicId: string }) => {
       try {
@@ -613,6 +727,13 @@ export function registerTools(server: McpServer) {
         }).describe("Idea data object")
       }).describe("Idea creation data")
     },
+    {
+      title: "Create idea",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdea(params.productId, params.ideaData);
@@ -653,6 +774,13 @@ export function registerTools(server: McpServer) {
           skip_portal: z.boolean().optional().describe("Skip portal submission (default: false)")
         }).describe("Idea data object")
       }).describe("Idea creation data with category")
+    },
+    {
+      title: "Create idea with category",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
     },
     async (params: { productId: string; ideaData: any }) => {
       try {
@@ -695,6 +823,13 @@ export function registerTools(server: McpServer) {
         }).describe("Idea data object")
       }).describe("Idea creation data with score")
     },
+    {
+      title: "Create idea with score",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdeaWithScore(params.productId, params.ideaData);
@@ -727,6 +862,13 @@ export function registerTools(server: McpServer) {
     "Delete an idea in Aha.io",
     {
       ideaId: z.string().describe("ID of the idea")
+    },
+    {
+      title: "Delete idea",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { ideaId: string }) => {
       try {
@@ -772,6 +914,13 @@ export function registerTools(server: McpServer) {
         }).describe("Competitor data object")
       }).describe("Competitor creation data")
     },
+    {
+      title: "Create competitor",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { productId: string; competitorData: any }) => {
       try {
         const competitor = await services.AhaService.createCompetitor(params.productId, params.competitorData);
@@ -812,6 +961,13 @@ export function registerTools(server: McpServer) {
         }).describe("Competitor data object")
       }).describe("Competitor update data")
     },
+    {
+      title: "Update competitor",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params: { competitorId: string; competitorData: any }) => {
       try {
         const competitor = await services.AhaService.updateCompetitor(params.competitorId, params.competitorData);
@@ -844,6 +1000,13 @@ export function registerTools(server: McpServer) {
     "Delete a competitor in Aha.io",
     {
       competitorId: z.string().describe("ID of the competitor")
+    },
+    {
+      title: "Delete competitor",
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     async (params: { competitorId: string }) => {
       try {
@@ -898,6 +1061,13 @@ export function registerTools(server: McpServer) {
         }).describe("Idea data object")
       }).describe("Idea creation data by portal user")
     },
+    {
+      title: "Create idea as portal user",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdeaByPortalUser(params.productId, params.ideaData);
@@ -940,6 +1110,13 @@ export function registerTools(server: McpServer) {
           score: z.number().optional().describe("Score for the idea")
         }).describe("Idea data object")
       }).describe("Idea creation data with portal settings")
+    },
+    {
+      title: "Create idea with portal settings",
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
     },
     async (params: { productId: string; ideaData: any }) => {
       try {

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -56,6 +56,11 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
             `anything below ${MIN_PER_PAGE} to ${MIN_PER_PAGE}.`
         )
     },
+    {
+      title: "Search Aha.io",
+      readOnlyHint: true,
+      openWorldHint: true,
+    },
     async ({ query, workspaceId, recordTypes, page, perPage }) => {
       try {
         const result = await client.searchDocuments({

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -129,6 +129,12 @@ async function startServer() {
       "server_health_check",
       "Get server health status and diagnostics",
       {},
+      // openWorld: the check calls Aha's /me endpoint when credentials are present.
+      {
+        title: "Check server health",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
       async () => {
         const healthCheck = await performHealthCheck();
         return {
@@ -145,6 +151,11 @@ async function startServer() {
       "server_status",
       "Get detailed server status and configuration",
       {},
+      {
+        title: "Get server status",
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
       async () => {
         updateServerStatus(serverStatus.status);
         return {
@@ -183,6 +194,14 @@ async function startServer() {
         mode: z.enum(["stdio", "streamable-http"]).optional().describe("Transport mode"),
         port: z.number().optional().describe("Port number for the streamable-http transport"),
         host: z.string().optional().describe("Host address for the streamable-http transport")
+      },
+      // non-destructive: only the fields supplied are merged into ~/.aha-mcp-config.json.
+      {
+        title: "Configure server",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
       },
       async (params) => {
         try {
@@ -230,6 +249,11 @@ async function startServer() {
       "get_server_config",
       "Get current server configuration",
       {},
+      {
+        title: "Get server configuration",
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
       async () => {
         const configSummary = ConfigService.getConfigSummary();
         const currentConfig = ConfigService.getConfig();
@@ -257,6 +281,11 @@ async function startServer() {
       "test_configuration",
       "Test current Aha.io configuration",
       {},
+      {
+        title: "Test Aha.io configuration",
+        readOnlyHint: true,
+        openWorldHint: true,
+      },
       async () => {
         try {
           const config = ConfigService.getConfig();

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -113,6 +113,43 @@ describe('E2E Streamable HTTP Transport', () => {
       }, { mode: 'streamable-http', timeout: 15000 });
     }, 20000);
 
+    it('should annotate every tool with behaviour hints', async () => {
+      await withTestClient(async (client) => {
+        const tools = await client.listTools();
+
+        const unannotated = tools.filter(t => !t.annotations).map(t => t.name);
+        expect(unannotated).toEqual([]);
+
+        for (const tool of tools) {
+          const annotations = tool.annotations!;
+          expect(typeof annotations.title).toBe('string');
+          expect(typeof annotations.readOnlyHint).toBe('boolean');
+          expect(typeof annotations.openWorldHint).toBe('boolean');
+
+          // destructiveHint and idempotentHint are only meaningful for writers,
+          // so read-only tools deliberately leave them unset.
+          if (annotations.readOnlyHint) {
+            expect(annotations.destructiveHint).toBeUndefined();
+            expect(annotations.idempotentHint).toBeUndefined();
+          } else {
+            expect(typeof annotations.destructiveHint).toBe('boolean');
+            expect(typeof annotations.idempotentHint).toBe('boolean');
+          }
+        }
+
+        const search = tools.find(t => t.name === 'aha_search');
+        expect(search?.annotations?.readOnlyHint).toBe(true);
+
+        const deleteFeature = tools.find(t => t.name === 'aha_delete_feature');
+        expect(deleteFeature?.annotations?.readOnlyHint).toBe(false);
+        expect(deleteFeature?.annotations?.destructiveHint).toBe(true);
+
+        const createFeature = tools.find(t => t.name === 'aha_create_feature');
+        expect(createFeature?.annotations?.destructiveHint).toBe(false);
+        expect(createFeature?.annotations?.idempotentHint).toBe(false);
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+
     it('should call a tool via HTTP', async () => {
       await withTestClient(async (client) => {
         // Use a simple tool that doesn't require complex setup


### PR DESCRIPTION
None of the 31 tools carried annotations, so a client had no way to tell `aha_search` apart from `aha_delete_feature` without parsing the description. `CLAUDE.md` has listed *"use annotations to describe tool behaviors and side effects"* as a best practice since the beginning without it ever being implemented.

Each registration now passes a `ToolAnnotations` argument via the SDK's `(name, description, paramsSchema, annotations, cb)` overload.

## Conventions

| Group | readOnly | destructive | idempotent | openWorld |
| --- | --- | --- | --- | --- |
| `aha_search`, `server_status`, `get_server_config`, `server_health_check`, `test_configuration` | `true` | — | — | `true` except `server_status` / `get_server_config` |
| `aha_create_*` | `false` | `false` | `false` | `true` |
| `aha_update_*`, `aha_associate_feature_with_epic`, `aha_move_feature_to_release`, `configure_server` | `false` | `false` | `true` | `true` (`false` for `configure_server`) |
| `aha_delete_*` | `false` | **`true`** | `true` | `true` |
| `aha_update_feature_tags`, `aha_associate_feature_with_goals` | `false` | **`true`** | `true` | `true` |

Per the spec, `destructiveHint` and `idempotentHint` are only meaningful when `readOnlyHint` is false, so they are omitted on the read-only tools rather than set to their defaults.

## Two judgement calls, both commented inline

- `aha_update_feature_tags` and `aha_associate_feature_with_goals` are **destructive** because the service PUTs a full collection to `/features/:id/tags` and `/features/:id/goals` — anything left out of the request is unlinked, not merged.
- `server_health_check` is **open-world** despite reading like a local diagnostic: `performHealthCheck()` calls Aha's `/me` whenever credentials are configured.

## Verification

- 326 tests pass (was 325). The new e2e test fails if any tool ships without annotations, or if a read-only tool sets the two hints that do not apply to it.
- `tsc --noEmit` error count unchanged at 8, all pre-existing.
- `bun run mcpb:validate` still passes; no tool names or descriptions changed, so `manifest.json` stays accurate.
- Connected a client over stdio and confirmed all 31 tools return annotations in `tools/list`.

## Not in scope

`server.tool()` is `@deprecated` in SDK 1.30.0 in favour of `registerTool()`. The annotations work fine on the existing overload; the migration follows separately.