### PR TITLE
fix: actually send custom field values when updating a feature

### DIFF
--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1480,16 +1480,24 @@ export class AhaService {
   /**
    * Update a feature's custom fields
    * @param featureId The ID of the feature
-   * @param customFields The custom fields data
-   * @returns Success response
+   * @param customFields Object of custom field key/value pairs
+   * @returns The updated feature response
    */
-  public static async updateFeatureCustomFields(featureId: string, _customFields: any): Promise<void> {
-    const defaultApi = this.getDefaultApi();
+  public static async updateFeatureCustomFields(featureId: string, customFields: Record<string, any>): Promise<Feature> {
+    const featuresApi = this.getFeaturesApi();
 
     try {
-      await defaultApi.featuresIdCustomFieldsPut({
-        id: featureId
+      // This used to call `DefaultApi.featuresIdCustomFieldsPut`, whose generated signature
+      // takes an id and nothing else - the operation is declared without a request body, so
+      // the values could not be sent at all and every call was a no-op reported as success.
+      // `PUT /features/:id` carries `feature.custom_fields`, so route through that instead.
+      const response = await featuresApi.featuresUpdate({
+        id: featureId,
+        featureUpdateRequest: {
+          feature: { custom_fields: customFields } as any
+        }
       });
+      return response.data.feature;
     } catch (error) {
       log.error('Error updating custom fields for feature', error as Error, { operation: 'updateFeatureCustomFields', feature_id: featureId });
       throw error;

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -611,7 +611,11 @@ export function registerTools(server: McpServer) {
       description: "Update a feature's custom fields in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
-        customFields: z.object({}).describe("Custom fields data")
+        // Not z.object({}): zod strips keys a shape does not declare, so every custom field
+        // sent by the caller was discarded before the handler ever saw it.
+        customFields: z.record(z.string(), z.any()).describe(
+          "Custom fields as a key/value object, keyed by the custom field's API key"
+        )
       },
       annotations: {
         title: "Update feature custom fields",
@@ -621,15 +625,15 @@ export function registerTools(server: McpServer) {
         openWorldHint: true,
       },
     },
-    async (params: { featureId: string; customFields: any }) => {
+    async (params: { featureId: string; customFields: Record<string, any> }) => {
       try {
-        await services.AhaService.updateFeatureCustomFields(params.featureId, params.customFields);
+        const feature = await services.AhaService.updateFeatureCustomFields(params.featureId, params.customFields);
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} custom fields successfully updated`
+              text: `Feature ${params.featureId} custom fields updated:\n\n${JSON.stringify(feature, null, 2)}`
             }
           ]
         };

--- a/test/feature-custom-fields.test.ts
+++ b/test/feature-custom-fields.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerTools } from '../src/core/tools.js';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * The tool tests go through a real client so its zod schema runs. Calling the handler
+ * directly would not catch a schema that silently drops the payload.
+ */
+describe('aha_update_feature_custom_fields', () => {
+  const original = AhaService.updateFeatureCustomFields;
+  let received: { featureId: string; customFields: any } | null;
+  let client: Client;
+
+  beforeEach(async () => {
+    received = null;
+    (AhaService as any).updateFeatureCustomFields = async (featureId: string, customFields: any) => {
+      received = { featureId, customFields };
+      return { id: featureId, name: 'Test feature', custom_fields: customFields };
+    };
+
+    const server = new McpServer({ name: 'custom-fields-test', version: '1.0.0' }, { capabilities: {} });
+    registerTools(server);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test-client', version: '1.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  afterEach(async () => {
+    (AhaService as any).updateFeatureCustomFields = original;
+    await client.close();
+  });
+
+  it('forwards every custom field to the service', async () => {
+    const customFields = {
+      external_id: 'JIRA-42',
+      t_shirt_size: 'M',
+      confidence: 80,
+      is_committed: true,
+      stakeholders: ['alice', 'bob']
+    };
+
+    await client.callTool({
+      name: 'aha_update_feature_custom_fields',
+      arguments: { featureId: 'FEAT-1', customFields }
+    });
+
+    expect(received).not.toBeNull();
+    expect(received!.featureId).toBe('FEAT-1');
+    expect(received!.customFields).toEqual(customFields);
+  });
+
+  it('reports the updated feature rather than a bare success message', async () => {
+    const result: any = await client.callTool({
+      name: 'aha_update_feature_custom_fields',
+      arguments: { featureId: 'FEAT-2', customFields: { external_id: 'JIRA-7' } }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('JIRA-7');
+  });
+
+  it('advertises an open object in its input schema', async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'aha_update_feature_custom_fields');
+
+    expect(tool).toBeDefined();
+    const customFields = (tool!.inputSchema as any).properties.customFields;
+    expect(customFields.type).toBe('object');
+    // z.object({}) would have emitted no additionalProperties at all.
+    expect(customFields.additionalProperties).toBeDefined();
+  });
+});
+
+/**
+ * The suite above stubs the service out, so on its own it cannot tell whether the request
+ * ever carries the values. This drives the real method against a fake FeaturesApi, which is
+ * what catches a regression back to an endpoint that takes no body.
+ */
+describe('AhaService.updateFeatureCustomFields', () => {
+  const originalApi = (AhaService as any).featuresApi;
+  let request: any;
+
+  beforeEach(() => {
+    request = null;
+    (AhaService as any).featuresApi = {
+      featuresUpdate: async (params: any) => {
+        request = params;
+        return { data: { feature: { id: params.id, name: 'Test feature' } } };
+      }
+    };
+  });
+
+  afterEach(() => {
+    (AhaService as any).featuresApi = originalApi;
+  });
+
+  it('puts the custom fields in the request body', async () => {
+    const customFields = { external_id: 'JIRA-42', stakeholders: ['alice', 'bob'], confidence: 80 };
+
+    await AhaService.updateFeatureCustomFields('FEAT-1', customFields);
+
+    expect(request.id).toBe('FEAT-1');
+    expect(request.featureUpdateRequest.feature.custom_fields).toEqual(customFields);
+  });
+
+  it('returns the updated feature', async () => {
+    const feature = await AhaService.updateFeatureCustomFields('FEAT-2', { external_id: 'JIRA-7' });
+
+    expect(feature).toEqual({ id: 'FEAT-2', name: 'Test feature' } as any);
+  });
+
+  it('propagates API errors instead of reporting success', async () => {
+    (AhaService as any).featuresApi = {
+      featuresUpdate: async () => { throw new Error('422 Unprocessable Entity'); }
+    };
+
+    await expect(
+      AhaService.updateFeatureCustomFields('FEAT-3', { external_id: 'JIRA-9' })
+    ).rejects.toThrow('422 Unprocessable Entity');
+  });
+});


### PR DESCRIPTION
`aha_update_feature_custom_fields` reported `Feature FEAT-1 custom fields successfully updated` without writing anything. It had two independent reasons to do so, and either one alone was enough.

## 1. The service had nowhere to put the values

```ts
public static async updateFeatureCustomFields(featureId: string, _customFields: any): Promise<void> {
  await defaultApi.featuresIdCustomFieldsPut({ id: featureId });
}
```

`DefaultApi.featuresIdCustomFieldsPut` is generated as `(id: string, options?: RawAxiosRequestConfig)`. The operation is declared without a request body, so there is no parameter to pass custom fields through — hence the `_` prefix on the argument to silence the unused-parameter warning.

Aha documents custom field updates as [`PUT /api/v1/features/:id`](https://www.aha.io/api/resources/features/update_a_features_custom_fields) with `{"feature":{"custom_fields":{"priority":"P3"}}}`, so this routes through `featuresUpdate` and returns the updated `Feature` — the tool can now report what actually changed instead of a bare success string.

## 2. The schema discarded them before the handler ran

```ts
customFields: z.object({}).describe("Custom fields data")
```

`z.object({})` declares an object with no properties, and zod strips keys a shape does not declare. The handler received `{}` regardless of what the caller sent. It is now `z.record(z.string(), z.any())`, which also emits `additionalProperties` so clients can see that arbitrary keys are accepted.

## Tests

Both layers, because neither catches the other's bug:

- **Tool** — driven through a real `Client` over an in-memory transport, so the zod schema actually runs. Calling the handler directly sails straight past the stripping bug.
- **Service** — a fake `FeaturesApi` is injected and the test asserts the values land in `featureUpdateRequest.feature.custom_fields`. This is what catches a regression back to an endpoint that takes no body; the tool tests stub the service out entirely and would not notice.

Full suite: 332 pass, 0 fail.

## Notes

- Rebased onto `main` after #305; the conflict was the one registration block, which is now in `registerTool` form.
- `/features/:id/custom_fields/worksheet` exists in the SDK (`FeaturesApi.featuresIdCustomFieldsWorksheetPut`) and does take a body, but it is scoped to worksheet/equation fields rather than custom fields generally, so it is not a drop-in here.