### PR TITLE
fix: return absolute record links from aha_search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@ Behaviours measured against a live account, not documented upstream - keep the c
 - `per` defaults to 20 and is clamped server-side to 10..200. Requests below 10 come back
   with 10, so the client raises them rather than promising something it will not deliver.
 - `totalCount` saturates at 10000; surfaced as `total_count_is_capped`.
+- `url` on a search hit is an app path (`/features/PRJ1-1`), not a URL. The client resolves
+  it against the account host so `SearchHit.url` is always absolute and a client can open
+  it. REST responses differ here - they already carry an absolute `url` (the web page) plus
+  `resource` (the API endpoint), so nothing rewrites those.
 - Argument and scoping errors arrive as GraphQL errors with an HTTP **200**. A genuine
   permission or licensing problem is an HTTP **403** - do not conflate them.
 - Most other list queries (`goals`, `initiatives`, `keyResults`, ...) require a `filters`

--- a/src/core/services/aha-graphql.ts
+++ b/src/core/services/aha-graphql.ts
@@ -61,6 +61,11 @@ export interface SearchHit {
   searchableType: string;
   searchableId: string | null;
   projectId: string | null;
+  /**
+   * Absolute link to the record in Aha, e.g. `https://acme.aha.io/features/PRJ1-1`.
+   * `searchDocuments` returns an app path rather than a URL, so the client resolves it
+   * against the account host before handing it out - see `toAbsoluteUrl`.
+   */
   url: string;
   updatedAt: string;
 }
@@ -121,6 +126,22 @@ export class AhaGraphQLClient {
     return `https://${subdomain}.aha.io/api/v2/graphql`;
   }
 
+  /** The account's Aha host, e.g. `https://acme.aha.io`. */
+  host(): string {
+    return new URL(this.endpoint()).origin;
+  }
+
+  /**
+   * `searchDocuments` returns app paths - `/features/PRJ1-1`, not a URL - which is no use to
+   * a caller that wants to open the record. Resolve against the account host. Anything that
+   * already carries a scheme is passed through, in case Aha starts returning absolute URLs.
+   */
+  private toAbsoluteUrl(url: string, host: string): string {
+    if (!url) return url;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return url;
+    return `${host}${url.startsWith('/') ? '' : '/'}${url}`;
+  }
+
   /**
    * Search across Aha records.
    *
@@ -155,13 +176,17 @@ export class AhaGraphQLClient {
     }>(SEARCH_DOCUMENTS_QUERY, { filters, page, per });
 
     const page_ = data.searchDocuments;
+    const host = this.host();
     return {
       totalCount: page_.totalCount,
       totalCountIsCapped: page_.totalCount >= TOTAL_COUNT_CEILING,
       currentPage: page_.currentPage,
       totalPages: page_.totalPages,
       isLastPage: page_.isLastPage,
-      results: page_.nodes ?? []
+      results: (page_.nodes ?? []).map(node => ({
+        ...node,
+        url: this.toAbsoluteUrl(node.url, host)
+      }))
     };
   }
 

--- a/test/aha-graphql.test.ts
+++ b/test/aha-graphql.test.ts
@@ -56,7 +56,8 @@ const page = (over: Record<string, unknown> = {}) => ({
           searchableId: '123',
           searchableType: 'Idea',
           projectId: 'p1',
-          url: 'https://acme.aha.io/ideas/IDEA-1',
+          // Aha returns an app path here, not a URL.
+          url: '/ideas/ideas/IDEA-1',
           updatedAt: '2026-08-01T00:00:00Z'
         }
       ],
@@ -207,6 +208,50 @@ describe('AhaGraphQLClient', () => {
     it('tolerates a null node list', async () => {
       const { client } = stub(page({ nodes: null }));
       expect((await client.searchDocuments({ query: 'a' })).results).toEqual([]);
+    });
+  });
+
+  describe('record links', () => {
+    const withUrl = (url: unknown) =>
+      page({
+        nodes: [
+          {
+            name: 'Alerting: silence by label',
+            searchableId: '123',
+            searchableType: 'Idea',
+            projectId: 'p1',
+            url,
+            updatedAt: '2026-08-01T00:00:00Z'
+          }
+        ]
+      });
+
+    const firstUrl = async (url: unknown) => {
+      const { client } = stub(withUrl(url));
+      return (await client.searchDocuments({ query: 'alert' })).results[0].url;
+    };
+
+    it('resolves the app path against the account host', async () => {
+      expect(await firstUrl('/ideas/ideas/IDEA-1')).toBe('https://acme.aha.io/ideas/ideas/IDEA-1');
+    });
+
+    it('leaves an absolute url alone, should Aha start returning one', async () => {
+      expect(await firstUrl('https://acme.aha.io/features/PRJ1-1')).toBe(
+        'https://acme.aha.io/features/PRJ1-1'
+      );
+    });
+
+    it('does not lose the separator on a path with no leading slash', async () => {
+      expect(await firstUrl('features/PRJ1-1')).toBe('https://acme.aha.io/features/PRJ1-1');
+    });
+
+    it('passes an empty url through rather than emitting a bare host', async () => {
+      expect(await firstUrl('')).toBe('');
+    });
+
+    it('exposes the account host', () => {
+      const { client } = stub(page());
+      expect(client.host()).toBe('https://acme.aha.io');
     });
   });
 


### PR DESCRIPTION
Followup on "returned objects should contain absolute URLs so the user can go there". I probed a live account to find out where that was and was not already true.

## Where it was broken: `aha_search`

`searchDocuments` returns Aha's **app path**, not a URL, so the tool answered with:

```json
{ "name": "...", "type": "Feature", "url": "/features/FEO11Y-134" }
```

A client cannot turn that into somewhere the user can go — the account subdomain appears nowhere in the tool output. The GraphQL client now resolves hit paths against the account host, so `SearchHit.url` is absolute by contract:

```json
{ "name": "...", "type": "Feature", "url": "https://grafana-labs.aha.io/features/FEO11Y-134" }
```

Anything already carrying a scheme passes through untouched, in case Aha starts returning absolute URLs.

## Where it was already fine: everything REST-backed

Worth stating so nobody re-fixes it. Aha's REST responses already include both, and the tools return the payload verbatim:

```
url      : https://grafana-labs.aha.io/features/FEO11Y-134     ← the web page
resource : https://grafana-labs.aha.io/api/v1/features/FEO11Y-134  ← the API endpoint
```

Confirmed live for features, ideas and goals; nested records carry it too (`project.url`, `release.url`). No rewriting needed, so none was added.

## Why no test caught this

The fixture asserted hits came back as `https://acme.aha.io/ideas/IDEA-1`, which is not what the API does. It now uses a path, and five cases cover resolution, pass-through of absolute URLs, a path with no leading slash, an empty URL, and the exposed host.

Suite: 337 pass, 0 fail. Verified end to end against the live account before and after.

## One gap I did not close

`Comment`, `Competitor` and `Requirement` have no `url` in the generated models. I could not confirm what the API returns for them — the workspace I probed had no requirements on the features I sampled, and there is no `getFeatureComments` on the service to test a comment with. Since the generated models are demonstrably incomplete (see #304), absence from the model does not mean absence from the response, and any `url` Aha does return already reaches the caller because responses are serialized verbatim. Synthesizing links for those three would mean guessing at URL shapes, which seemed worse than leaving it. Happy to follow up if you hit a case where one is missing.