### PR TITLE
feat: tell clients what this server is and to link the records it returns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,18 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
   local state
 - **Resources**: 40+ resource types for accessing Aha.io entities via URI schemes
 - **Prompts**: 14 domain-specific workflow prompts with context-aware responses
+- **Instructions**: `src/core/instructions.ts`, passed to `McpServer` and returned in the
+  `initialize` response. The only always-on context the server gets - prompts need
+  invoking and tool descriptions are per-tool - so it is where session-wide guidance
+  lives: what Aha is, that `reference_num` rather than `id` is the identifier people
+  recognise, and that records should be linked by their absolute `url`. It costs context
+  in every session, so keep it to what a client cannot infer from the tool list, and treat
+  it as guidance: clients differ in how prominently they surface it, and anything that
+  must hold belongs in the data instead. `buildServerInstructions()` interpolates the
+  configured company subdomain, which is fixed at `initialize` time - a later
+  `configure_server` cannot revise instructions the client already holds, so never let
+  anything depend on that host being current. Record `url`s always reflect live
+  credentials.
 - **Authentication**: Runtime configuration with environment variables and config file support
 
 Tool, resource and prompt counts are also mirrored in `manifest.json` for the desktop

--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -1,0 +1,36 @@
+/**
+ * Server instructions, returned in the `initialize` response and surfaced by clients as
+ * standing context for the whole session - no tool call or prompt needed.
+ *
+ * Two jobs: say what this server is connected to, and get records linked rather than
+ * described. Every byte here costs context in every session, so keep it to things a client
+ * cannot work out from the tool list: the identity of the system, which identifier a human
+ * recognises, and what to do with `url`.
+ *
+ * Guidance, not enforcement - clients vary in how prominently they surface this. Anything
+ * that must hold belongs in the data instead.
+ */
+
+/**
+ * Build the instructions for a configured company.
+ *
+ * The subdomain is interpolated so the client knows which account it is looking at, and can
+ * recognise a record link on sight. Note this is fixed at `initialize` time: a later
+ * `configure_server` call that changes the company cannot revise instructions the client has
+ * already been handed, so the named host can go stale within a session. The `url` on each
+ * record always reflects the live credentials, which is why the text points at that rather
+ * than asking anyone to assemble links from the host.
+ *
+ * @param subdomain The configured Aha.io company subdomain, if there is one
+ */
+export function buildServerInstructions(subdomain?: string | null): string {
+  const account = subdomain
+    ? `the account at https://${subdomain}.aha.io`
+    : 'the account this server is configured against';
+
+  return `Aha! (aha.io) is the product management tool used for ${account}, and these tools read and write it directly. Its records are the live, shared source of truth rather than a scratch copy: ideas are incoming customer requests, features and epics are planned work, releases group work by date, and goals and initiatives hold the strategy that work rolls up to.
+
+Records carry two identifiers. \`reference_num\` - PROJA-134, IDEASB-I-6375 - is the one people use and the one the Aha UI shows. \`id\` is an internal number nobody recognises. Name a record by its reference number.
+
+Every record also carries an absolute \`url\` to its page in Aha. Use it. When you mention a feature, idea, epic, release, goal or initiative, render a markdown link to that \`url\`, labelled with the reference number and name - the user's next step is usually to open the record. Report search results as a list of such links rather than as raw JSON. \`resource\` is the REST endpoint for a record, not a page a person can read, so never offer it as the link.`;
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,6 +3,7 @@ import { registerResources } from "../core/resources.js";
 import { registerTools } from "../core/tools.js";
 import { registerPrompts } from "../core/prompts.js";
 import { registerSampling } from "../core/sampling.js";
+import { buildServerInstructions } from "../core/instructions.js";
 import * as services from "../core/services/index.js";
 import { ConfigService } from "../core/config.js";
 import { log } from "../core/logger.js";
@@ -114,15 +115,19 @@ async function startServer() {
     }
     
     // Create a new MCP server instance with enhanced metadata
-    const server = new McpServer({
-      name: "Aha.io MCP Server",
-      version: packageJson.version,
-      description: packageJson.description,
-      author: packageJson.author,
-      homepage: packageJson.homepage,
-      repository: packageJson.repository,
-      license: packageJson.license
-    });
+    const server = new McpServer(
+      {
+        name: "Aha.io MCP Server",
+        version: packageJson.version,
+        description: packageJson.description,
+        author: packageJson.author,
+        homepage: packageJson.homepage,
+        repository: packageJson.repository,
+        license: packageJson.license
+      },
+      // Returned in the initialize response, so clients have this before the first call.
+      { instructions: buildServerInstructions(config.company) }
+    );
 
     // Add health check tool
     server.registerTool(

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -99,6 +99,22 @@ describe('E2E Streamable HTTP Transport', () => {
     }, 20000);
   });
 
+  describe('Server Instructions', () => {
+    it('should return instructions in the initialize response', async () => {
+      await withTestClient(async (client) => {
+        const instructions = client.getInstructions();
+
+        expect(instructions).toBeDefined();
+        // Says what the server is, and asks for links rather than descriptions.
+        expect(instructions).toContain('reference_num');
+        expect(instructions).toMatch(/markdown link/i);
+        // The spawned server runs with AHA_COMPANY=test-company, so the configured
+        // subdomain should have made it into the initialize response.
+        expect(instructions).toContain('https://test-company.aha.io');
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+  });
+
   describe('Tool Operations', () => {
     it('should list tools via HTTP', async () => {
       await withTestClient(async (client) => {

--- a/test/instructions.test.ts
+++ b/test/instructions.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'bun:test';
+import { buildServerInstructions } from '../src/core/instructions.js';
+
+describe('buildServerInstructions', () => {
+  it('names the configured account so the client knows which Aha it is talking to', () => {
+    expect(buildServerInstructions('acme')).toContain('https://acme.aha.io');
+  });
+
+  it('stays generic when no company is configured', () => {
+    const instructions = buildServerInstructions(null);
+
+    expect(instructions).not.toContain('aha.io/');
+    expect(instructions).toContain('configured against');
+  });
+
+  it('treats an empty subdomain as unconfigured rather than emitting https://.aha.io', () => {
+    expect(buildServerInstructions('')).not.toContain('https://.aha.io');
+  });
+
+  it('asks for records to be linked by their url, labelled with the reference number', () => {
+    const instructions = buildServerInstructions('acme');
+
+    expect(instructions).toMatch(/markdown link/i);
+    expect(instructions).toContain('reference_num');
+    // `resource` is the API endpoint; offering it as a link sends the user to JSON.
+    expect(instructions).toMatch(/never offer it as the link/i);
+  });
+});

--- a/test/utils/mcp-client-helper.ts
+++ b/test/utils/mcp-client-helper.ts
@@ -372,6 +372,14 @@ export class TestMCPClient {
   }
 
   /**
+   * The server's instructions, as returned in the initialize response.
+   */
+  getInstructions(): string | undefined {
+    this.ensureConnected();
+    return this.client!.getInstructions();
+  }
+
+  /**
    * List all available tools
    */
   async listTools(): Promise<Tool[]> {


### PR DESCRIPTION
The server returned no `instructions`, so a client arrived knowing only 31 tool names. Nothing said what Aha is, that `reference_num` rather than `id` is the identifier a person recognises, or that every record carries a `url` worth linking — so answers described records instead of linking them, and cited internal numeric ids nobody can look up.

## Why `instructions` and not something else

It is the only always-on channel the protocol gives a server: it comes back in the `initialize` response, before the first call. The alternatives cannot carry session-wide guidance — the 14 prompts in `src/core/prompts.ts` only fire when a user explicitly picks one, and tool descriptions are per-tool, so shared rules would have to be repeated 31 times and would drift.

## What a client now receives

```
Aha! (aha.io) is the product management tool used for the account at
https://test.aha.io, and these tools read and write it directly. Its records are
the live, shared source of truth rather than a scratch copy: ideas are incoming
customer requests, features and epics are planned work, releases group work by
date, and goals and initiatives hold the strategy that work rolls up to.

Records carry two identifiers. `reference_num` - PROJA-134, IDEASB-I-6375 - is the
one people use and the one the Aha UI shows. `id` is an internal number nobody
recognises. Name a record by its reference number.

Every record also carries an absolute `url` to its page in Aha. Use it. When you
mention a feature, idea, epic, release, goal or initiative, render a markdown link
to that `url`, labelled with the reference number and name - the user's next step
is usually to open the record. Report search results as a list of such links
rather than as raw JSON. `resource` is the REST endpoint for a record, not a page
a person can read, so never offer it as the link.
```

That is a real client's `getInstructions()`, not the source.

## The subdomain is interpolated

`buildServerInstructions(config.company)` names the account — `https://acme.aha.io` — rather than referring to it abstractly, so the agent knows which Aha it is talking to and can recognise a record link on sight. It falls back to generic wording when no company is configured, and treats an empty string as unconfigured rather than emitting `https://.aha.io`.

One limit, documented in the source and in `CLAUDE.md`: this is fixed at `initialize` time. A later `configure_server` that changes the company cannot revise instructions the client already holds, so the named host can go stale mid-session. That is exactly why the text points at each record's `url` — which always reflects live credentials — instead of asking anyone to assemble links from the host.

## Length

It costs context in *every* session, so it covers only what a client cannot infer from the tool list: the identity of the system, which identifier a human recognises, and what to do with `url`. Three paragraphs, and I would rather defend cutting it than growing it.

## Tests

- `test/instructions.test.ts` — interpolation, the unconfigured fallback, the empty-string edge, and that the linking guidance is actually present.
- `test/e2e-streamable-http.test.ts` — asserts the instructions reach a real client through the initialize response, carrying the spawned server's configured subdomain. Needed a `getInstructions()` passthrough on the test helper.

342 pass, 0 fail. `tsc --noEmit` unchanged at 8 pre-existing errors; `mcpb:validate` passes.

## Note

This is guidance, not enforcement — clients differ in how prominently they surface it. Anything that must hold belongs in the data, which is what #306 did for absolute URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added session-wide server guidance during initialization.
  - Guidance identifies the configured Aha! account and explains record types, reference numbers, and URL usage.
  - Record references are directed to appear as Markdown links using their human-readable identifiers and absolute URLs.

- **Tests**
  - Added coverage for configured and unconfigured accounts, URL formatting, and initialization responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->