### PR TITLE
feat: autocomplete prompt arguments that name an Aha record

### DIFF
--- a/src/core/completions.ts
+++ b/src/core/completions.ts
@@ -1,0 +1,214 @@
+import * as services from "./services/index.js";
+import { ahaGraphQLClient, type AhaGraphQLClient } from "./services/aha-graphql.js";
+import { log } from "./logger.js";
+
+/**
+ * Autocompletion for prompt arguments that name an Aha record.
+ *
+ * Prompts are user-controlled, so someone is typing these by hand. Without completion,
+ * `product_id` and `feature_id` require knowing `ADAPTTELE` or `FEO11Y-134` from memory,
+ * which nobody does past their own team's workspace.
+ *
+ * A completer never throws. A picker that errors is worse than one that offers nothing, and
+ * these run against the network on a keystroke, so a rate limit or an expired token has to
+ * degrade to an empty list.
+ */
+
+/** The response caps at 100; stay well under, since a long list is not browsable anyway. */
+const MAX_COMPLETIONS = 50;
+
+/** Workspaces fetched for `product_id` / `product_name` completion. */
+const PRODUCT_PAGE_SIZE = 200;
+
+/** Long enough that typing does not refetch per keystroke, short enough to notice new workspaces. */
+const PRODUCT_CACHE_MS = 60_000;
+
+/** Reference-number search results per keystroke. Aha allows 20 requests/second. */
+const SEARCH_PAGE_SIZE = 25;
+
+export interface Product {
+  reference_prefix?: string;
+  name?: string;
+}
+
+export interface RecordHit {
+  name: string | null;
+  url: string;
+}
+
+/**
+ * Where completions get their data. Injectable so tests do not need an account, and so a
+ * completer can be exercised without a live token.
+ */
+export interface CompletionSources {
+  listProducts(): Promise<Product[]>;
+  searchRecords(searchableType: string, query: string): Promise<RecordHit[]>;
+}
+
+export function defaultCompletionSources(
+  graphQLClient: AhaGraphQLClient = ahaGraphQLClient
+): CompletionSources {
+  let cached: { at: number; products: Product[] } | null = null;
+
+  return {
+    async listProducts() {
+      // Cached because every keystroke in a workspace field would otherwise be a request,
+      // and the set of workspaces changes on the order of weeks.
+      if (cached && Date.now() - cached.at < PRODUCT_CACHE_MS) return cached.products;
+
+      // getAhaService() rather than AhaService, so a client connected against the mock gets
+      // completions too instead of silently empty lists.
+      const response: any = await services
+        .getAhaService()
+        .listProducts(undefined, 1, PRODUCT_PAGE_SIZE);
+      const products: Product[] = response?.products ?? [];
+      cached = { at: Date.now(), products };
+      return products;
+    },
+
+    async searchRecords(searchableType: string, query: string) {
+      const result = await graphQLClient.searchDocuments({
+        query,
+        searchableType: [searchableType],
+        per: SEARCH_PAGE_SIZE
+      });
+      return result.results.map(hit => ({ name: hit.name, url: hit.url }));
+    }
+  };
+}
+
+/** Case-insensitive substring match, which is what someone half-remembering a name needs. */
+function matches(candidate: string, typed: string): boolean {
+  return candidate.toLowerCase().includes(typed.toLowerCase());
+}
+
+/**
+ * The reference number is the last path segment of a record's URL -
+ * `https://acme.aha.io/features/PRJ1-1` yields `PRJ1-1`.
+ *
+ * Aha's search results carry no `referenceNum` field, and the numeric `searchableId` is not
+ * what a prompt argument wants, so this is the only route to the identifier a person uses.
+ */
+export function referenceNumberFromUrl(url: string): string | null {
+  try {
+    const segments = new URL(url).pathname.split("/").filter(Boolean);
+    const last = segments[segments.length - 1];
+    return last ? decodeURIComponent(last) : null;
+  } catch {
+    return null;
+  }
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)].slice(0, MAX_COMPLETIONS);
+}
+
+/**
+ * Put reference numbers that actually start with what was typed first.
+ *
+ * Aha tokenises the query, so `FEO11Y-13*` also matches `FEO11Y-2` and `FEO11Y-53`. Those
+ * are worth keeping - the same search is what makes typing a *name* work - but someone
+ * halfway through a reference number should see it at the top rather than fifth.
+ */
+function prefixMatchesFirst(references: string[], typed: string): string[] {
+  const needle = typed.toUpperCase();
+  const starts: string[] = [];
+  const rest: string[] = [];
+
+  for (const reference of references) {
+    (reference.toUpperCase().startsWith(needle) ? starts : rest).push(reference);
+  }
+  return [...starts, ...rest];
+}
+
+/**
+ * Complete a workspace by its reference prefix (`ADAPTTELE`) or its name.
+ *
+ * Both are offered whichever field is being completed: someone who knows the name but not
+ * the prefix is the whole reason this exists. `by` decides what gets inserted.
+ */
+export function completeProduct(
+  by: "reference_prefix" | "name",
+  sources: CompletionSources = defaultCompletionSources()
+) {
+  return async (value: string | undefined): Promise<string[]> => {
+    try {
+      const products = await sources.listProducts();
+      const typed = (value ?? "").trim();
+
+      const hits = products.filter(product => {
+        if (!typed) return true;
+        return (
+          (product.reference_prefix && matches(product.reference_prefix, typed)) ||
+          (product.name && matches(product.name, typed))
+        );
+      });
+
+      return unique(hits.map(product => product[by]).filter((v): v is string => !!v));
+    } catch (error) {
+      log.error("Product completion failed", error as Error, { operation: "completeProduct", by });
+      return [];
+    }
+  };
+}
+
+/**
+ * Complete a record reference number by searching for what has been typed so far.
+ *
+ * Search matches reference numbers as well as names, verified against a live account:
+ * `FEO11Y-134*` returns that feature first. An empty value returns nothing rather than a
+ * wildcard search - the first 25 records of an arbitrary 10000 are not a useful offer, and
+ * this way opening the field costs no request.
+ */
+export function completeRecordReference(
+  searchableType: "Feature" | "Epic" | "Idea",
+  sources: CompletionSources = defaultCompletionSources()
+) {
+  return async (value: string | undefined): Promise<string[]> => {
+    const typed = (value ?? "").trim();
+    if (!typed) return [];
+
+    try {
+      // Prefix matching, so a half-typed reference number still finds its record.
+      const hits = await sources.searchRecords(searchableType, `${typed}*`);
+      const references = hits
+        .map(hit => referenceNumberFromUrl(hit.url))
+        .filter((ref): ref is string => !!ref);
+
+      return unique(prefixMatchesFirst(references, typed));
+    } catch (error) {
+      log.error("Record completion failed", error as Error, {
+        operation: "completeRecordReference",
+        searchable_type: searchableType
+      });
+      return [];
+    }
+  };
+}
+
+/**
+ * Complete the last entry of a comma-separated list of reference numbers, keeping the
+ * entries already typed.
+ *
+ * `idea_ids` takes `PRJ1-I-1,PRJ1-I-2`, so completing the whole value would replace what the
+ * user has already listed.
+ */
+export function completeRecordReferenceList(
+  searchableType: "Feature" | "Epic" | "Idea",
+  sources: CompletionSources = defaultCompletionSources()
+) {
+  const completeOne = completeRecordReference(searchableType, sources);
+
+  return async (value: string | undefined): Promise<string[]> => {
+    const raw = value ?? "";
+    const separator = raw.lastIndexOf(",");
+    const prefix = separator === -1 ? "" : raw.slice(0, separator + 1);
+    const partial = raw.slice(separator + 1);
+
+    // Preserve the user's spacing after the comma, e.g. "A-1, " stays "A-1, ".
+    const leadingSpace = partial.match(/^\s*/)![0];
+    const completions = await completeOne(partial.trim());
+
+    return completions.map(reference => `${prefix}${leadingSpace}${reference}`);
+  };
+}

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -1,7 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { completable } from "@modelcontextprotocol/sdk/server/completable.js";
 import * as z from "zod/v4";
 import * as services from "./services/index.js";
 import { getSamplingPrimer } from "./sampling.js";
+import {
+  completeProduct,
+  completeRecordReference,
+  completeRecordReferenceList
+} from "./completions.js";
 
 /**
  * Helper function to fetch context from Aha.io resources
@@ -88,7 +94,10 @@ export function registerPrompts(server: McpServer) {
         product_context: z.string().optional().describe("Product context and goals"),
         existing_features: z.string().optional().describe("Comma-separated list of related existing features"),
         target_users: z.string().optional().describe("Target user segments"),
-        feature_id: z.string().optional().describe("Existing feature ID from Aha.io for context (e.g., PROJ-123)")
+        feature_id: completable(
+          z.string().optional().describe("Existing feature ID from Aha.io for context (e.g., PROJ-123)"),
+          completeRecordReference("Feature")
+        )
       }
     },
     async (params: { feature_name: string; feature_description?: string; product_context?: string; existing_features?: string; target_users?: string; feature_id?: string }) => {
@@ -135,13 +144,19 @@ Format your response with clear sections and actionable recommendations.`
       title: "Plan a product roadmap",
       description: "Generate product roadmap recommendations and strategic planning",
       argsSchema: {
-        product_name: z.string().describe("Name of the product"),
+        product_name: completable(
+          z.string().describe("Name of the product"),
+          completeProduct("name")
+        ),
         current_version: z.string().optional().describe("Current product version"),
         business_goals: z.string().describe("Business goals and objectives"),
         time_horizon: z.string().describe("Roadmap time horizon (quarter, half-year, year)"),
         key_features: z.string().optional().describe("Comma-separated list of key features to consider"),
         market_constraints: z.string().optional().describe("Market constraints and competitive landscape"),
-        product_id: z.string().optional().describe("Existing product ID from Aha.io for context (e.g., PROJ)")
+        product_id: completable(
+          z.string().optional().describe("Existing product ID from Aha.io for context (e.g., PROJ)"),
+          completeProduct("reference_prefix")
+        )
       }
     },
     async (params: { product_name: string; current_version?: string; business_goals: string; time_horizon: string; key_features?: string; market_constraints?: string; product_id?: string }) => {
@@ -367,7 +382,10 @@ Format as a actionable sprint plan with clear assignments and timelines.`
         user_types: z.string().describe("Comma-separated list of user types affected"),
         constraints: z.string().optional().describe("Technical or business constraints"),
         timeline: z.string().optional().describe("Target timeline or deadline"),
-        epic_id: z.string().optional().describe("Existing epic ID from Aha.io for context (e.g., PROJ-E-123)")
+        epic_id: completable(
+          z.string().optional().describe("Existing epic ID from Aha.io for context (e.g., PROJ-E-123)"),
+          completeRecordReference("Epic")
+        )
       }
     },
     async (params: { epic_name: string; epic_description: string; business_value: string; user_types: string; constraints?: string; timeline?: string; epic_id?: string }) => {
@@ -421,7 +439,10 @@ Structure as a hierarchical breakdown with clear relationships and dependencies.
         evaluation_criteria: z.string().optional().describe("Comma-separated list of evaluation criteria"),
         constraints: z.string().optional().describe("Resource or timeline constraints"),
         market_context: z.string().optional().describe("Market context and competitive landscape"),
-        idea_ids: z.string().optional().describe("Comma-separated list of Aha.io idea IDs for context (e.g., PROJ-I-123,PROJ-I-456)")
+        idea_ids: completable(
+          z.string().optional().describe("Comma-separated list of Aha.io idea IDs for context (e.g., PROJ-I-123,PROJ-I-456)"),
+          completeRecordReferenceList("Idea")
+        )
       }
     },
     async (params: { ideas_list: string; business_goals: string; evaluation_criteria?: string; constraints?: string; market_context?: string; idea_ids?: string }) => {
@@ -653,8 +674,14 @@ Focus on actionable, measurable metrics that align with business objectives.`
       description: "Discover and analyze ideas within products/workspaces based on topics, themes, or keywords",
       argsSchema: {
         search_topic: z.string().describe("The topic, theme, or keyword to search for (e.g., 'Node.js', 'mobile', 'API')"),
-        product_name: z.string().optional().describe("Name of the product/workspace to search in (e.g., 'VoC', 'Platform')"),
-        product_id: z.string().optional().describe("Specific product ID to search in (e.g., 'VOC-1')"),
+        product_name: completable(
+          z.string().optional().describe("Name of the product/workspace to search in (e.g., 'VoC', 'Platform')"),
+          completeProduct("name")
+        ),
+        product_id: completable(
+          z.string().optional().describe("Specific product ID to search in (e.g., 'VOC-1')"),
+          completeProduct("reference_prefix")
+        ),
         analysis_focus: z.string().optional().describe("What aspect to focus on (e.g., 'customer pain points', 'feature gaps', 'enhancement opportunities')"),
         time_filter: z.string().optional().describe("Time filter for ideas (e.g., 'last 6 months', 'recent', 'all time')"),
         include_status: z.string().optional().describe("Comma-separated list of idea statuses to include (e.g., 'new,under review,planned')")

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  completeProduct,
+  completeRecordReference,
+  completeRecordReferenceList,
+  referenceNumberFromUrl,
+  type CompletionSources
+} from '../src/core/completions.js';
+
+const PRODUCTS = [
+  { reference_prefix: 'ADAPTTELE', name: 'Adaptive Telemetry' },
+  { reference_prefix: 'ALERT', name: 'Alerting' },
+  { reference_prefix: 'APPO11Y', name: 'Application Observability' }
+];
+
+/** Records what was asked for, so the tests can assert the query as well as the result. */
+function sources(over: Partial<CompletionSources> = {}) {
+  const searches: Array<{ type: string; query: string }> = [];
+  const base: CompletionSources = {
+    listProducts: async () => PRODUCTS,
+    searchRecords: async (type, query) => {
+      searches.push({ type, query });
+      return [];
+    }
+  };
+  return { sources: { ...base, ...over }, searches };
+}
+
+const hits = (...refs: string[]) =>
+  refs.map(ref => ({ name: ref, url: `https://acme.aha.io/features/${ref}` }));
+
+describe('referenceNumberFromUrl', () => {
+  it('takes the reference number from the last path segment', () => {
+    expect(referenceNumberFromUrl('https://acme.aha.io/features/PRJ1-1')).toBe('PRJ1-1');
+  });
+
+  it('handles the nested path ideas use', () => {
+    expect(referenceNumberFromUrl('https://acme.aha.io/ideas/ideas/PRJ1-I-9')).toBe('PRJ1-I-9');
+  });
+
+  it('decodes an escaped segment', () => {
+    expect(referenceNumberFromUrl('https://acme.aha.io/features/PRJ1%2D1')).toBe('PRJ1-1');
+  });
+
+  it('returns null rather than throwing on something that is not a url', () => {
+    expect(referenceNumberFromUrl('/features/PRJ1-1')).toBeNull();
+    expect(referenceNumberFromUrl('')).toBeNull();
+  });
+});
+
+describe('completeProduct', () => {
+  it('matches on the reference prefix and inserts the prefix', async () => {
+    const { sources: s } = sources();
+    expect(await completeProduct('reference_prefix', s)('APP')).toEqual(['APPO11Y']);
+  });
+
+  it('matches on the name and inserts the name', async () => {
+    const { sources: s } = sources();
+    expect(await completeProduct('name', s)('alert')).toEqual(['Alerting']);
+  });
+
+  it('finds a workspace by name even when completing the prefix field', async () => {
+    // The point of the feature: knowing "Alerting" but not that it is ALERT.
+    const { sources: s } = sources();
+    expect(await completeProduct('reference_prefix', s)('Alerting')).toEqual(['ALERT']);
+  });
+
+  it('offers everything when nothing has been typed', async () => {
+    const { sources: s } = sources();
+    expect(await completeProduct('reference_prefix', s)('')).toEqual([
+      'ADAPTTELE',
+      'ALERT',
+      'APPO11Y'
+    ]);
+  });
+
+  it('returns nothing rather than throwing when the account cannot be reached', async () => {
+    const { sources: s } = sources({
+      listProducts: async () => {
+        throw new Error('401 Unauthorized');
+      }
+    });
+    expect(await completeProduct('name', s)('a')).toEqual([]);
+  });
+});
+
+describe('completeRecordReference', () => {
+  it('searches the typed value as a prefix, scoped to the record type', async () => {
+    const { sources: s, searches } = sources();
+    await completeRecordReference('Epic', s)('PRJ1-E');
+
+    expect(searches).toEqual([{ type: 'Epic', query: 'PRJ1-E*' }]);
+  });
+
+  it('costs no request when nothing has been typed', async () => {
+    const { sources: s, searches } = sources();
+
+    expect(await completeRecordReference('Feature', s)('')).toEqual([]);
+    expect(searches).toEqual([]);
+  });
+
+  it('derives reference numbers from the hit urls', async () => {
+    const { sources: s } = sources({ searchRecords: async () => hits('PRJ1-1', 'PRJ1-2') });
+    expect(await completeRecordReference('Feature', s)('PRJ1')).toEqual(['PRJ1-1', 'PRJ1-2']);
+  });
+
+  it('puts prefix matches first, since Aha search is fuzzy', async () => {
+    // Typing PRJ1-13 really does return PRJ1-2 and PRJ1-53 from a live account.
+    const { sources: s } = sources({
+      searchRecords: async () => hits('PRJ1-2', 'PRJ1-134', 'PRJ1-53', 'PRJ1-13')
+    });
+
+    expect(await completeRecordReference('Feature', s)('PRJ1-13')).toEqual([
+      'PRJ1-134',
+      'PRJ1-13',
+      'PRJ1-2',
+      'PRJ1-53'
+    ]);
+  });
+
+  it('drops duplicates and hits whose url yields nothing', async () => {
+    const { sources: s } = sources({
+      searchRecords: async () => [
+        ...hits('PRJ1-1', 'PRJ1-1'),
+        { name: 'broken', url: 'not-a-url' }
+      ]
+    });
+    expect(await completeRecordReference('Feature', s)('PRJ1')).toEqual(['PRJ1-1']);
+  });
+
+  it('returns nothing rather than throwing when search fails', async () => {
+    const { sources: s } = sources({
+      searchRecords: async () => {
+        throw new Error('429 Too Many Requests');
+      }
+    });
+    expect(await completeRecordReference('Idea', s)('PRJ1-I')).toEqual([]);
+  });
+});
+
+describe('completeRecordReferenceList', () => {
+  it('completes the only entry when the list has one', async () => {
+    const { sources: s } = sources({ searchRecords: async () => hits('PRJ1-I-9') });
+    expect(await completeRecordReferenceList('Idea', s)('PRJ1-I')).toEqual(['PRJ1-I-9']);
+  });
+
+  it('keeps the entries already listed', async () => {
+    const { sources: s } = sources({ searchRecords: async () => hits('PRJ1-I-9') });
+
+    expect(await completeRecordReferenceList('Idea', s)('PRJ1-I-1,PRJ1-I')).toEqual([
+      'PRJ1-I-1,PRJ1-I-9'
+    ]);
+  });
+
+  it('preserves the spacing the user typed after the comma', async () => {
+    const { sources: s } = sources({ searchRecords: async () => hits('PRJ1-I-9') });
+
+    expect(await completeRecordReferenceList('Idea', s)('PRJ1-I-1, PRJ1-I')).toEqual([
+      'PRJ1-I-1, PRJ1-I-9'
+    ]);
+  });
+
+  it('searches only the last entry, not the whole list', async () => {
+    const { sources: s, searches } = sources();
+    await completeRecordReferenceList('Idea', s)('PRJ1-I-1,PRJ1-I-2');
+
+    expect(searches).toEqual([{ type: 'Idea', query: 'PRJ1-I-2*' }]);
+  });
+
+  it('offers nothing for a trailing comma rather than searching the whole list', async () => {
+    const { sources: s, searches } = sources();
+
+    expect(await completeRecordReferenceList('Idea', s)('PRJ1-I-1,')).toEqual([]);
+    expect(searches).toEqual([]);
+  });
+});

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -105,6 +105,23 @@ describe('E2E Streamable HTTP Transport', () => {
       }, { mode: 'streamable-http', timeout: 15000 });
     }, 20000);
 
+    it('should complete a workspace argument via HTTP', async () => {
+      await withTestClient(async (client) => {
+        // The spawned server runs against MockAhaService, whose workspaces are PROD1..PROD3.
+        const values = await client.complete('product_roadmap', 'product_id', 'PROD');
+
+        expect(values).toContain('PROD1');
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+
+    it('should offer nothing for an unknown workspace rather than erroring', async () => {
+      await withTestClient(async (client) => {
+        const values = await client.complete('product_roadmap', 'product_id', 'zzzznope');
+
+        expect(values).toEqual([]);
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+
     it('should get a prompt via HTTP', async () => {
       await withTestClient(async (client) => {
         const messages = await client.getPrompt('aha_resource_discovery', {

--- a/test/utils/mcp-client-helper.ts
+++ b/test/utils/mcp-client-helper.ts
@@ -380,6 +380,24 @@ export class TestMCPClient {
   }
 
   /**
+   * Complete a prompt argument, returning the offered values.
+   */
+  async complete(promptName: string, argumentName: string, value: string): Promise<string[]> {
+    this.ensureConnected();
+
+    try {
+      const response = await this.client!.complete({
+        ref: { type: 'ref/prompt', name: promptName },
+        argument: { name: argumentName, value }
+      });
+      return response.completion.values;
+    } catch (error) {
+      console.error(`Error completing ${promptName}.${argumentName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
    * List all available tools
    */
   async listTools(): Promise<Tool[]> {


### PR DESCRIPTION
> Stacked on #308 — both edit the same 14 prompt configs. GitHub retargets this to `main` when #308 merges.

Second of the prompt gaps from that spec revision. Six arguments take an identifier only Aha knows — `product_id`, `product_name`, `feature_id`, `epic_id`, `idea_ids` — and nothing offered any values, so using them meant remembering that Alerting is `ALERT` and that the feature is `PROJ-134`.

## Working against the live account

```
product_roadmap.product_id      "APP"            -> ["APPO11Y"]
product_roadmap.product_name    "alert"          -> ["Alerting"]
feature_analysis.feature_id     "FEO11Y-13"      -> ["FEO11Y-13", "FEO11Y-18", "FEO11Y-2", ...]
epic_breakdown.epic_id          "FEO11Y-E"       -> ["APPO11Y-E-4", "FEO11Y-E-12"]
idea_prioritization.idea_ids    "…-6375, …-I-63" -> ["…-6375, …-I-5181", …]   (keeps entry 1)
```

## How each works

**Workspaces** come from `listProducts()`, matched against the reference prefix *and* the name whichever field is being completed — knowing the name but not the prefix is the reason this is worth building. Cached for a minute: otherwise every keystroke in a workspace field is a request, and the set of workspaces changes on the order of weeks.

**Reference numbers** come from searching what has been typed. I verified against a live account that search matches reference numbers and not just names — `FEO11Y-134*` returns that feature first. The value is read off each hit's URL, because search returns no `referenceNum` field and the numeric `searchableId` is not what the argument wants.

**`idea_ids`** is a comma-separated list, so only the last entry is completed and the earlier ones are preserved, along with whatever spacing was typed.

## Two behaviours worth knowing

- **Aha tokenises the query**, so `FEO11Y-13*` also returns `FEO11Y-2` and `FEO11Y-53`. I kept those, because the same fuzziness is what makes typing a *name* work — filtering to strict prefixes would break name search entirely. Instead, reference numbers that really start with the typed value sort first.
- **An empty value returns nothing** for reference numbers rather than wildcard-searching. Opening a field costs no request, and the first 25 of an arbitrary 10000 records is not a useful offer. Workspaces do list everything on an empty value, since there are few and they are cached.

## Failure behaviour

A completer never throws. These run against the network on a keystroke, so a rate limit or an expired token degrades to an empty list — a picker that errors is worse than one that offers nothing. Both paths are tested with a throwing source.

## Tests

- `test/completions.test.ts` — 20 cases against an injected source: prefix vs name matching, insertion field, the fuzzy-ranking order, dedupe, URL parsing edge cases, list-entry preservation and spacing, no-request-when-empty, and the two error paths.
- `test/e2e-streamable-http.test.ts` — completes `product_id` through a real client over the protocol. The spawned server runs against `MockAhaService`, so this asserts real values (`PROD1`) rather than an empty array; that is why `defaultCompletionSources` goes through `getAhaService()` rather than `AhaService`.

360 pass, 0 fail. `tsc --noEmit` back to the 8 pre-existing errors — note that optional prompt arguments type the completer parameter as `string | undefined`, which is why the completers take the wider type.

## Caps, stated rather than silent

- Workspace completion covers the first 200 workspaces (`PRODUCT_PAGE_SIZE`).
- At most 50 values are returned (`MAX_COMPLETIONS`), against a protocol cap of 100.
- `release_name` is **not** completed: releases need a workspace to scope the lookup, and `release_planning` has no workspace argument to scope it by. Adding one would change that prompt's shape, so it is out of scope here.