### PR TITLE
fix: explain Aha's REST failures instead of leaking the axios message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,26 @@ A previous local-cache implementation (SQLite plus a placeholder embedding that 
 character codes through `Math.sin()`) was removed in favour of this. Do not reintroduce
 client-side "semantic" ranking without a real embedding model.
 
+### Error handling
+
+Aha's REST failures are mapped by `src/core/services/aha-errors.ts` rather than surfaced
+raw. `aha-js` throws axios errors whose message is `Request failed with status code 403`,
+which names neither what was refused nor why, and reads like a bug in this server.
+
+- Tools call `describeAhaError(error)` in their catch branch. The existing per-tool prefix
+  already names the operation, so the mapper only explains the status.
+- Resources throw `toMcpError(error, uri.toString())`. A record the token cannot reach is
+  `InvalidParams` (-32602), matching the SDK's own code for an unrecognised URI; only
+  genuine server-side or unclassified failures stay `InternalError` (-32603). Letting a raw
+  error escape produced -32603 for everything, which claims a server bug for what is
+  usually a permissions problem.
+- **404 must not be reported as "does not exist".** Aha returns 404 both for a missing
+  record and for one the token cannot see, so the message says so. Do not tighten it.
+- Errors this server raises itself (missing credentials and the like) pass through
+  untouched - they already say what to do.
+- Nothing retries. A 429 is reported with Aha's `retry_after` and the documented limits;
+  whether to wait belongs to the caller.
+
 ## Runtime Configuration
 
 The server supports runtime configuration through three key parameters:

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { toMcpError } from "./services/aha-errors.js";
 import { ResourceTemplate } from "./uri-template.js";
 import type { ServerRequest, ServerNotification } from "@modelcontextprotocol/sdk/types.js";
 import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
@@ -113,7 +114,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving idea ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -152,7 +153,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving feature ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -190,7 +191,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving user ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -228,7 +229,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving epic ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -258,7 +259,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error(`Error retrieving features list:`, error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -318,7 +319,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving users list:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -360,7 +361,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving epics list for product ${productId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -398,7 +399,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving product ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -425,7 +426,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error(`Error retrieving products list:`, error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -497,7 +498,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving initiative ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -531,7 +532,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error(`Error retrieving initiatives list:`, error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -633,7 +634,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving ideas list for product ${productId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -675,7 +676,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for epic ${epicId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -717,7 +718,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for idea ${ideaId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -759,7 +760,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for initiative ${initiativeId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -801,7 +802,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for product ${productId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -843,7 +844,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for goal ${goalId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -885,7 +886,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for release ${releaseId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -927,7 +928,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for release phase ${releasePhaseId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -969,7 +970,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for requirement ${requirementId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1011,7 +1012,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving comments for todo ${todoId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1049,7 +1050,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving goal ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1079,7 +1080,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error(`Error retrieving goals list:`, error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -1155,7 +1156,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving epics for goal ${goalId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1193,7 +1194,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving release ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1228,7 +1229,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error(`Error retrieving releases list:`, error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -1305,7 +1306,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving features for release ${releaseId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1347,7 +1348,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving epics for release ${releaseId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1385,7 +1386,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving release phase ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1411,7 +1412,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving release phases list:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1449,7 +1450,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving requirement ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1487,7 +1488,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving competitor ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1525,7 +1526,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving todo ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1563,7 +1564,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving competitors for product ${productId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1601,7 +1602,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving strategic model ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1629,7 +1630,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error('Error retrieving strategic models list:', error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -1688,7 +1689,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error('Error retrieving todos list:', error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1726,7 +1727,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving idea organization ${id}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1753,7 +1754,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error('Error retrieving idea organizations list:', error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -1812,7 +1813,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error('Error retrieving user profile:', error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1837,7 +1838,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error('Error retrieving assigned records:', error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1862,7 +1863,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error('Error retrieving pending tasks:', error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1914,7 +1915,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving endorsements for idea ${ideaId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -1961,7 +1962,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving votes for idea ${ideaId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -2002,7 +2003,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving watchers for idea ${ideaId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -2051,7 +2052,7 @@ export function registerResources(server: McpServer) {
       };
     } catch (error) {
       console.error('Error retrieving global ideas list:', error);
-      throw error;
+      throw toMcpError(error, uri.toString());
     }
   };
 
@@ -2143,7 +2144,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving releases list for product ${productId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -2185,7 +2186,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving epics for initiative ${initiativeId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -2211,7 +2212,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error('Error retrieving custom fields list:', error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );
@@ -2253,7 +2254,7 @@ export function registerResources(server: McpServer) {
         };
       } catch (error) {
         console.error(`Error retrieving options for custom field ${customFieldId}:`, error);
-        throw error;
+        throw toMcpError(error, uri.toString());
       }
     }
   );

--- a/src/core/services/aha-errors.ts
+++ b/src/core/services/aha-errors.ts
@@ -1,0 +1,144 @@
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Turning Aha's REST failures into something a caller can act on.
+ *
+ * The REST paths used to surface axios' own wording - `Request failed with status code 403` -
+ * which says nothing about what was refused or why, and is indistinguishable from a bug in
+ * this server. The GraphQL client in `aha-graphql.ts` has always mapped its statuses; this is
+ * the same courtesy for the 31 tools and 40+ resources that go through `aha-js`.
+ *
+ * Deliberately no retrying here. Aha's limits are 300 requests/minute and 20/second and a 429
+ * carries `retry_after`, but whether to wait or fail belongs to the caller, so a 429 is
+ * reported with the header's value rather than slept on.
+ */
+
+/** Aha's documented rate limits, worth stating when one is hit. */
+const RATE_LIMITS = "300 requests per minute and 20 per second";
+
+interface AxiosLikeError {
+  isAxiosError?: boolean;
+  response?: { status?: number; headers?: Record<string, unknown> };
+  message?: string;
+}
+
+function asAxiosLike(error: unknown): AxiosLikeError | null {
+  return error && typeof error === "object" ? (error as AxiosLikeError) : null;
+}
+
+/** HTTP status of a failed Aha call, or null if the error is not an HTTP response. */
+export function statusOf(error: unknown): number | null {
+  const status = asAxiosLike(error)?.response?.status;
+  return typeof status === "number" ? status : null;
+}
+
+/** The `retry_after` Aha sends with a 429, if it sent one. */
+export function retryAfterOf(error: unknown): string | null {
+  const headers = asAxiosLike(error)?.response?.headers;
+  if (!headers) return null;
+
+  const value = headers["retry_after"] ?? headers["retry-after"];
+  return value === undefined || value === null ? null : String(value);
+}
+
+/** True when the request never got a response at all, rather than an error response. */
+function isTransportFailure(error: unknown): boolean {
+  const candidate = asAxiosLike(error);
+  return candidate?.isAxiosError === true && !candidate.response;
+}
+
+function fallbackMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Explain a failed Aha call.
+ *
+ * `subject` names what was being reached for - a resource URI, or a record reference - so the
+ * message identifies the thing that failed rather than just the fact that something did.
+ *
+ * Errors this server raises itself (missing credentials, for instance) already say something
+ * useful, so they are passed through untouched.
+ */
+export function describeAhaError(error: unknown, subject?: string): string {
+  const status = statusOf(error);
+  const what = subject ? `${subject}` : "the requested record";
+
+  switch (status) {
+    case 400:
+      return `Aha.io rejected the request as invalid (HTTP 400): ${fallbackMessage(error)}`;
+
+    case 401:
+      return (
+        "Aha.io rejected the credentials (HTTP 401). The token may be wrong, expired or " +
+        "revoked - check AHA_TOKEN, or run configure_server."
+      );
+
+    case 403:
+      return (
+        `Aha.io denied access to ${what} (HTTP 403). This token may not have permission for ` +
+        "it, or the account may not include the product it belongs to. A 403 is a genuine " +
+        "permission problem, not a bad request."
+      );
+
+    case 404: {
+      // Worth spelling out: Aha does not distinguish these, so neither can this server.
+      return (
+        `${what} was not found (HTTP 404). Aha returns 404 both for a record that does not ` +
+        "exist and for one this token cannot see, so it may exist in a workspace you do not " +
+        "have access to."
+      );
+    }
+
+    case 422:
+      return (
+        `Aha.io would not accept the change to ${what} (HTTP 422). A field is likely invalid ` +
+        `for its type, or a required one is missing: ${fallbackMessage(error)}`
+      );
+
+    case 429: {
+      const retryAfter = retryAfterOf(error);
+      return (
+        "Aha.io rate limit reached (HTTP 429)" +
+        (retryAfter ? `; retry after ${retryAfter}` : "") +
+        `. The limits are ${RATE_LIMITS}.`
+      );
+    }
+  }
+
+  if (status !== null && status >= 500) {
+    return (
+      `Aha.io returned a server error (HTTP ${status}) for ${what}. This is on Aha's side ` +
+      "rather than in the request; retrying later is usually the fix."
+    );
+  }
+
+  if (isTransportFailure(error)) {
+    return (
+      `Could not reach Aha.io: ${fallbackMessage(error)}. Check network access and that the ` +
+      "configured company subdomain is right."
+    );
+  }
+
+  return fallbackMessage(error);
+}
+
+/**
+ * The same explanation as an `McpError`, for resources.
+ *
+ * Resources used to let a raw error escape, which the SDK reported as `-32603` Internal
+ * error - wrong for a record that simply is not available to this token, and inconsistent
+ * with the SDK's own `-32602` for an unrecognised URI. A reference the caller cannot use is
+ * `InvalidParams`; anything genuinely on Aha's side or unclassified stays `InternalError`.
+ */
+export function toMcpError(error: unknown, subject?: string): McpError {
+  if (error instanceof McpError) return error;
+
+  const status = statusOf(error);
+  const code =
+    status === 403 || status === 404 || status === 400
+      ? ErrorCode.InvalidParams
+      : ErrorCode.InternalError;
+
+  return new McpError(code, describeAhaError(error, subject));
+}

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -456,7 +456,6 @@ export class AhaService {
   ): Promise<FeaturesListResponse> {
     const featuresApi = this.getFeaturesApi();
 
-    const startTime = Date.now();
     try {
       const response = await featuresApi.featuresList({
         page,
@@ -466,13 +465,11 @@ export class AhaService {
         tag,
         assignedToUser
       });
-      const duration = Date.now() - startTime;
-      // API call automatically traced by auto-instrumentation
       return response.data;
     } catch (error) {
-      const duration = Date.now() - startTime;
-      const statusCode = (error as any)?.response?.status || 500;
-      // API call automatically traced by auto-instrumentation
+      // This method alone used to time itself and read a status code off the error, then use
+      // neither - leftovers from tracing that was removed. The status travels with the error
+      // instead, for describeAhaError to read at the boundary.
       log.error('Error listing features', error as Error, { operation: 'listFeatures' });
       throw error;
     }

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -3,6 +3,7 @@ import * as z from "zod/v4";
 import * as services from "./services/index.js";
 import { registerSearchTools } from "./tools/search-tools.js";
 import { log } from "./logger.js";
+import { describeAhaError } from "./services/aha-errors.js";
 
 /**
  * Register all tools with the MCP server
@@ -45,7 +46,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating comment: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating comment: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -92,7 +93,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error associating feature with epic: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error associating feature with epic: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -135,7 +136,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error moving feature to release: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error moving feature to release: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -179,7 +180,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error associating feature with goals: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error associating feature with goals: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -223,7 +224,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating feature tags: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating feature tags: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -271,7 +272,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating epic in product: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating epic in product: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -319,7 +320,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating epic in release: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating epic in release: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -367,7 +368,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating initiative in product: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating initiative in product: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -419,7 +420,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating feature: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating feature: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -467,7 +468,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating feature: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating feature: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -509,7 +510,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error deleting feature: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error deleting feature: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -552,7 +553,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating feature progress: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating feature progress: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -595,7 +596,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating feature score: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating feature score: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -642,7 +643,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating feature custom fields: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating feature custom fields: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -694,7 +695,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating epic: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating epic: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -736,7 +737,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error deleting epic: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error deleting epic: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -789,7 +790,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating idea: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating idea: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -839,7 +840,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating idea with category: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating idea with category: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -889,7 +890,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating idea with score: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating idea with score: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -931,7 +932,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error deleting idea: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error deleting idea: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -984,7 +985,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating competitor: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating competitor: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -1033,7 +1034,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error updating competitor: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error updating competitor: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -1075,7 +1076,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error deleting competitor: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error deleting competitor: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -1137,7 +1138,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating idea by portal user: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating idea by portal user: ${describeAhaError(error)}`
             }
           ],
           isError: true
@@ -1189,7 +1190,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Error creating idea with portal settings: ${error instanceof Error ? error.message : String(error)}`
+              text: `Error creating idea with portal settings: ${describeAhaError(error)}`
             }
           ],
           isError: true

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -8,6 +8,7 @@ import {
   SEARCHABLE_TYPES
 } from "../services/aha-graphql.js";
 import { log } from "../logger.js";
+import { describeAhaError } from "../services/aha-errors.js";
 
 /**
  * Register search tools.
@@ -104,7 +105,7 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
           ]
         };
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = describeAhaError(error);
         log.error("Search failed", error);
         return {
           content: [{ type: "text" as const, text: `Search failed: ${message}` }],

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import { buildServerInstructions } from "../core/instructions.js";
 import * as services from "../core/services/index.js";
 import { ConfigService } from "../core/config.js";
 import { log } from "../core/logger.js";
+import { describeAhaError } from "../core/services/aha-errors.js";
 import * as z from "zod/v4";
 // Imported rather than read from disk at runtime: the bundled build/index.js sits at a
 // different depth than this source file, so resolving "../../package.json" relative to
@@ -83,7 +84,7 @@ async function performHealthCheck() {
       serverStatus.ahaConnection.status = "not-initialized";
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = describeAhaError(error);
     healthCheck.checks.aha = { status: "error", message: `Aha.io connection failed: ${errorMessage}` } as any;
     serverStatus.ahaConnection.status = "error";
     healthCheck.status = "degraded";
@@ -248,7 +249,7 @@ async function startServer() {
               type: "text",
               text: JSON.stringify({
                 success: false,
-                error: error instanceof Error ? error.message : String(error)
+                error: describeAhaError(error)
               }, null, 2)
             }]
           };
@@ -340,7 +341,7 @@ async function startServer() {
             }]
           };
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
+          const errorMessage = describeAhaError(error);
           return {
             content: [{
               type: "text",
@@ -402,7 +403,7 @@ async function startServer() {
       });
     } catch (error) {
       log.warn('Initial health check encountered issues', {
-        error: error instanceof Error ? error.message : String(error)
+        error: describeAhaError(error)
       });
     }
     

--- a/test/aha-errors.test.ts
+++ b/test/aha-errors.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'bun:test';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import {
+  describeAhaError,
+  retryAfterOf,
+  statusOf,
+  toMcpError
+} from '../src/core/services/aha-errors.js';
+
+/** An axios-shaped failure, which is what `aha-js` throws. */
+const httpError = (status: number, headers: Record<string, unknown> = {}) =>
+  Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    response: { status, headers }
+  });
+
+/** A request that never got a response - DNS failure, offline, wrong subdomain. */
+const transportError = () =>
+  Object.assign(new Error('getaddrinfo ENOTFOUND nope.aha.io'), { isAxiosError: true });
+
+describe('statusOf', () => {
+  it('reads the status off an axios error', () => {
+    expect(statusOf(httpError(403))).toBe(403);
+  });
+
+  it('returns null for errors that are not HTTP responses', () => {
+    expect(statusOf(transportError())).toBeNull();
+    expect(statusOf(new Error('boom'))).toBeNull();
+    expect(statusOf('boom')).toBeNull();
+    expect(statusOf(null)).toBeNull();
+  });
+});
+
+describe('retryAfterOf', () => {
+  it('reads Aha\'s retry_after header', () => {
+    expect(retryAfterOf(httpError(429, { retry_after: '30' }))).toBe('30');
+  });
+
+  it('also accepts the hyphenated spelling', () => {
+    expect(retryAfterOf(httpError(429, { 'retry-after': 12 }))).toBe('12');
+  });
+
+  it('returns null when there is no header', () => {
+    expect(retryAfterOf(httpError(429))).toBeNull();
+  });
+});
+
+describe('describeAhaError', () => {
+  it('says a 403 is a permission problem, not a bad request', () => {
+    const message = describeAhaError(httpError(403), 'aha://feature/PRJ1-1');
+
+    expect(message).toContain('aha://feature/PRJ1-1');
+    expect(message).toContain('403');
+    expect(message).toMatch(/permission/i);
+    // The distinction the old raw message lost entirely.
+    expect(message).not.toBe('Request failed with status code 403');
+  });
+
+  it('admits a 404 may mean "exists but you cannot see it"', () => {
+    // Aha returns 404 for a missing record and for one the token cannot reach, so the
+    // message must not claim the record does not exist.
+    const message = describeAhaError(httpError(404), 'PRJ1-99');
+
+    expect(message).toContain('PRJ1-99');
+    expect(message).toMatch(/do not have access|cannot see/i);
+  });
+
+  it('points at the credentials for a 401', () => {
+    expect(describeAhaError(httpError(401))).toMatch(/AHA_TOKEN|configure_server/);
+  });
+
+  it('quotes retry_after and the documented limits on a 429', () => {
+    const message = describeAhaError(httpError(429, { retry_after: '30' }));
+
+    expect(message).toContain('30');
+    expect(message).toContain('300 requests per minute');
+  });
+
+  it('does not invent a retry hint when the header is absent', () => {
+    expect(describeAhaError(httpError(429))).not.toContain('retry after');
+  });
+
+  it('attributes a 5xx to Aha rather than the request', () => {
+    expect(describeAhaError(httpError(503), 'PRJ1-1')).toMatch(/on Aha's side/);
+  });
+
+  it('distinguishes not reaching Aha from being refused by it', () => {
+    const message = describeAhaError(transportError());
+
+    expect(message).toMatch(/Could not reach Aha/);
+    expect(message).toContain('ENOTFOUND');
+    expect(message).toMatch(/subdomain/);
+  });
+
+  it('passes through errors this server raises itself', () => {
+    // These already say something useful; wrapping them would only bury it.
+    const own = new Error('Aha.io API token is not configured. Set AHA_TOKEN or call configure_server.');
+
+    expect(describeAhaError(own)).toBe(own.message);
+  });
+
+  it('survives being handed something that is not an error', () => {
+    expect(describeAhaError('just a string')).toBe('just a string');
+    expect(describeAhaError(undefined)).toBe('undefined');
+  });
+
+  it('names the record generically when no subject is given', () => {
+    expect(describeAhaError(httpError(404))).toContain('the requested record');
+  });
+});
+
+describe('toMcpError', () => {
+  it('reports an inaccessible record as InvalidParams, not InternalError', () => {
+    // The old behaviour let a raw error become -32603, which reads as a server bug.
+    for (const status of [403, 404, 400]) {
+      expect(toMcpError(httpError(status), 'aha://feature/PRJ1-1').code).toBe(
+        ErrorCode.InvalidParams
+      );
+    }
+  });
+
+  it('keeps genuine server-side and unclassified failures as InternalError', () => {
+    for (const status of [500, 502, 429, 401]) {
+      expect(toMcpError(httpError(status)).code).toBe(ErrorCode.InternalError);
+    }
+    expect(toMcpError(transportError()).code).toBe(ErrorCode.InternalError);
+  });
+
+  it('carries the explanation into the error message', () => {
+    expect(toMcpError(httpError(403), 'aha://idea/PRJ1-I-1').message).toContain(
+      'aha://idea/PRJ1-I-1'
+    );
+  });
+
+  it('leaves an McpError alone rather than double-wrapping it', () => {
+    const original = new McpError(ErrorCode.InvalidParams, 'Invalid feature ID');
+
+    expect(toMcpError(original)).toBe(original);
+  });
+});


### PR DESCRIPTION
Answering "what happens when a user doesn't have access to a record", the honest answer was:

```
MCP error -32603: Request failed with status code 404
```

That names neither what was refused nor why, and `-32603` is *Internal error* — so a permissions problem reads as a bug in this server.

## What was actually there

The GraphQL client has mapped its statuses since it was written (`aha-graphql.ts:210-215`): 401 as a rejected token, 403 as a genuine permission or licensing problem. The 31 tools and 40+ resources going through `aha-js` had nothing. A `grep` for status handling across the service, tools and resources returned **one** hit — and it computed a `statusCode` it then never used.

## After

```
before  -32603  Request failed with status code 404
after   -32602  aha://feature/NOPE-99999 was not found (HTTP 404). Aha returns 404 both
                for a record that does not exist and for one this token cannot see, so it
                may exist in a workspace you do not have access to.
```

Both captured from a real client against a live account, before and after.

## Decisions worth reviewing

**404 says "or you cannot see it", deliberately.** Aha returns 404 for a missing record *and* for one the token cannot reach. The message says so rather than asserting the record does not exist, because this server genuinely cannot tell the two apart. There is a test pinning that wording, and a note in `CLAUDE.md` not to tighten it.

**Resources now distinguish the two failure kinds by code.** A reference the caller cannot use (403/404/400) is `InvalidParams` (-32602), matching the SDK's own code for an unrecognised URI; genuine server-side or unclassified failures stay `InternalError`. Previously everything was -32603, which claims a server bug for what is usually a permissions problem.

**Self-raised errors pass through untouched.** `Aha.io API token is not configured. Set AHA_TOKEN or call configure_server.` already says what to do; wrapping it would bury it. Tested.

**Nothing retries.** A 429 reports Aha's `retry_after` and the documented 300/min and 20/sec limits, but whether to wait belongs to the caller, not this layer. I'd rather add retry deliberately than smuggle it in here.

## Scope

- 25 tool catch branches, 1 in search, 4 in server config tools → `describeAhaError(error)`. Their existing prefixes already name the operation, so the mapper only explains the status.
- 50 resource rethrows → `toMcpError(error, uri.toString())`, so the message names the record.
- Removed the dead timing and status code in `listFeatures`, left over from removed tracing.

384 pass, 0 fail (19 new in `test/aha-errors.test.ts`). `tsc --noEmit` unchanged at 8 pre-existing errors, verified by stashing within the branch rather than comparing against a dirty tree.

## Heads-up on a conflict

You have uncommitted work in the main checkout — a `src/core/tool-output.ts` with `searchOutputSchema`, and top-level `title` hoisting on tool configs. That touches `tools.ts`, `search-tools.ts` and `server.ts`, which this PR also sweeps. The two will conflict. Mine only replaces the message expression inside `catch` branches, so resolution should be mechanical, but merge order matters — happy to rebase onto yours once it lands.