### PR TITLE
feat!: bring the tool surface up to the 2026-07-28 tools spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,62 @@ missing. Conventions used here:
 - `idempotentHint` is false for the `create_*` tools (a repeated call creates another record)
   and true for updates and associations.
 
+Tools carry a display title in **both** spec locations: top-level `title` (the current
+field) and `annotations.title` (what pre-2025-06-18 clients read, and what the spec gives
+precedence over `name`). They must stay identical; the e2e suite asserts it.
+
+#### Tool output: `outputSchema` and `structuredContent`
+
+Every tool declares an `outputSchema` and returns `structuredContent`, with the serialised
+JSON repeated in a text block for clients that ignore structured results. Schemas live in
+`src/core/tool-output.ts`. Two rules there are load-bearing:
+
+- **Anything wrapping an Aha record uses `z.looseObject`.** A raw Zod shape converts to
+  `additionalProperties: false`, and the SDK *client* rejects a result carrying keys the
+  schema does not list - which would break every record-returning tool on the first field
+  Aha adds. Payloads the server builds itself (deletions, search, the server/config tools)
+  are closed objects.
+- **Only describe fields Aha reliably returns, permissively typed.** The server validates
+  its own `structuredContent` and turns a mismatch into a protocol error, so a wrong guess
+  about a field's type fails the call rather than degrading. Undescribed fields still reach
+  the client verbatim.
+
+`structuredContent` is always the record itself, never Aha's wrapper: `unwrapRecord()`
+flattens the `{ idea: ... }` / `{ initiative: ... }` responses so one contract covers every
+record type. A response with no body becomes `{}` - every record field is optional, whereas
+a missing `structuredContent` fails output validation and sinks the call.
+
+Tools that touch a single record also return a `resource_link` to its `aha://` URI via
+`recordLinks()`, so a client can re-read current state instead of trusting the point-in-time
+copy. No identifier, no link: a link to an unreadable URI is worse than none.
+
+#### Tool errors
+
+Failures return `isError: true` with a plain-text message, never a success-shaped result
+whose body says `success: false` - clients render the latter as a successful call. Output
+validation is skipped for `isError` results at both ends, which is what lets a tool with an
+`outputSchema` report a failure at all.
+
+#### Tool rate limiting
+
+`src/core/rate-limit.ts` wraps `server.registerTool` so every tool spends a token from a
+process-wide bucket first; refusals come back as `isError` results naming the seconds to
+wait. It is installed in `startServer()` **before** any registration - tools registered
+earlier would not be covered. The bucket is deliberately global rather than per-session:
+what it protects is Aha's API, which all sessions share. Default 120/minute, set
+`MCP_TOOL_RATE_LIMIT_PER_MINUTE` to change it or `0` to disable.
+
+#### Schema dialects
+
+Input and output schemas are advertised as draft-07, because `toJsonSchemaCompat` in the
+SDK converts Zod with a hardcoded `draft-7` target and never passes `target` for tools. The
+spec permits an explicit dialect and only *recommends* 2020-12, so this conforms; it changes
+when the SDK lets the target through, not before. Zero-argument tools use
+`z.strictObject({}).optional()` and emit no `$schema`, so they default to 2020-12 - and,
+unlike the raw `{}` shape they replaced, they accept a `tools/call` with `arguments` omitted
+entirely, which the spec allows. An e2e test pins the dialects so an SDK upgrade surfaces
+here rather than in a client.
+
 ### Resources
 
 - Use unique URIs for resource identification (e.g., `aha://idea/{id}`)
@@ -265,7 +321,7 @@ missing. Conventions used here:
 
 - Validate all inputs rigorously using Zod schemas
 - Implement proper authentication via environment variables
-- Rate limit API requests to external services
+- Rate limit tool invocations (`src/core/rate-limit.ts`), which the tools spec requires
 - Sanitize user inputs before API calls
 - Handle errors without exposing internal implementation details
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The Aha.io integration can be configured using multiple methods, with the follow
 - `MCP_PORT`: Port number for HTTP-based modes (default: 3001)
 - `MCP_HOST`: Host address for HTTP-based modes (default: 0.0.0.0)
 - `MCP_AUTH_TOKEN`: Authentication token for HTTP-based modes (optional)
+- `MCP_TOOL_RATE_LIMIT_PER_MINUTE`: Tool calls allowed per minute (default: 120, `0` disables)
 
 #### Transport Modes
 
@@ -706,6 +707,7 @@ The Docker image supports all the same environment variables as the npm package:
 | `MCP_PORT` | Port for streamable-http mode | `3001` |
 | `MCP_HOST` | Host for streamable-http mode | `0.0.0.0` |
 | `MCP_AUTH_TOKEN` | Bearer token for the streamable-http transport | - |
+| `MCP_TOOL_RATE_LIMIT_PER_MINUTE` | Tool calls allowed per minute (`0` disables) | `120` |
 | `MCP_CONFIG_DIR` | Configuration directory | `/home/mcp/.config` |
 
 ### Health Checks

--- a/src/core/rate-limit.ts
+++ b/src/core/rate-limit.ts
@@ -1,0 +1,147 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { log } from "./logger.js";
+
+/**
+ * Tool invocation rate limiting, which the tools specification requires of servers.
+ *
+ * The bucket is process-wide rather than per-session: what it protects is Aha's API, which
+ * every session shares, and a per-session budget would let N sessions multiply the load on
+ * it. Local-only tools (`server_status`, `get_server_config`) draw from the same bucket -
+ * a burst of those is still a burst, and separate budgets would mean a caller could not
+ * predict what it is allowed to do next.
+ *
+ * Refusals come back as tool execution errors with `isError`, not JSON-RPC errors: the spec
+ * reserves protocol errors for requests a model cannot fix, and "wait and retry" is exactly
+ * the kind of feedback a model can act on.
+ */
+
+/** Requests per minute allowed by default. Override with MCP_TOOL_RATE_LIMIT_PER_MINUTE. */
+export const DEFAULT_RATE_LIMIT_PER_MINUTE = 120;
+
+export interface TokenBucketOptions {
+  /** Sustained rate, in invocations per minute. */
+  perMinute: number;
+  /** Injectable clock, in milliseconds. Defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * A token bucket: `perMinute` tokens of burst capacity, refilling continuously at
+ * `perMinute / 60` per second. Capacity equal to the rate keeps the knob to one number -
+ * "120 a minute" also means "at most 120 back to back".
+ */
+export class TokenBucket {
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private readonly now: () => number;
+  private tokens: number;
+  private lastRefill: number;
+
+  constructor(options: TokenBucketOptions) {
+    this.capacity = Math.max(1, options.perMinute);
+    this.refillPerMs = this.capacity / 60_000;
+    this.now = options.now ?? (() => Date.now());
+    this.tokens = this.capacity;
+    this.lastRefill = this.now();
+  }
+
+  /**
+   * Take a token if one is available.
+   *
+   * @returns `null` when the call may proceed, or the whole seconds to wait when it may not.
+   */
+  public take(): number | null {
+    const now = this.now();
+    this.tokens = Math.min(this.capacity, this.tokens + (now - this.lastRefill) * this.refillPerMs);
+    this.lastRefill = now;
+
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return null;
+    }
+
+    // Round up, so a caller that honours the number always finds a token waiting.
+    return Math.max(1, Math.ceil((1 - this.tokens) / this.refillPerMs / 1000));
+  }
+}
+
+/**
+ * Read the configured limit. `0` disables rate limiting, which exists for tests and for
+ * operators running the server against a private account where the only client is
+ * themselves.
+ */
+export function configuredRateLimit(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.MCP_TOOL_RATE_LIMIT_PER_MINUTE;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_RATE_LIMIT_PER_MINUTE;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    log.warn('Ignoring invalid MCP_TOOL_RATE_LIMIT_PER_MINUTE', {
+      value: raw,
+      using: DEFAULT_RATE_LIMIT_PER_MINUTE
+    });
+    return DEFAULT_RATE_LIMIT_PER_MINUTE;
+  }
+
+  return Math.floor(parsed);
+}
+
+/**
+ * Wrap `server.registerTool` so every tool registered afterwards spends a token before its
+ * handler runs.
+ *
+ * Patching the registrar rather than each handler is what keeps this enforceable: tools are
+ * registered from three different modules, and a limiter that has to be remembered at 31
+ * call sites is one that will be forgotten at the 32nd.
+ *
+ * Call before registering any tools. Returns the bucket, or null when disabled.
+ */
+export function installToolRateLimit(
+  server: McpServer,
+  options: { perMinute?: number; now?: () => number } = {}
+): TokenBucket | null {
+  const perMinute = options.perMinute ?? configuredRateLimit();
+  if (perMinute === 0) {
+    log.info('Tool rate limiting disabled', { reason: 'MCP_TOOL_RATE_LIMIT_PER_MINUTE=0' });
+    return null;
+  }
+
+  const bucket = new TokenBucket({ perMinute, now: options.now });
+  const originalRegisterTool = server.registerTool.bind(server);
+
+  (server as unknown as Record<string, unknown>).registerTool = (
+    name: string,
+    config: unknown,
+    handler: unknown
+  ) => {
+    // Task handlers are objects rather than callbacks; nothing here registers one, and
+    // wrapping something we do not understand would be worse than leaving it alone.
+    if (typeof handler !== 'function') {
+      return (originalRegisterTool as (...args: unknown[]) => unknown)(name, config, handler);
+    }
+
+    const guarded = async (...args: unknown[]) => {
+      const retryAfterSeconds = bucket.take();
+      if (retryAfterSeconds !== null) {
+        log.warn('Tool call refused by rate limit', { tool: name, retry_after_seconds: retryAfterSeconds });
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Rate limit reached: this server allows ${perMinute} tool calls per minute. ` +
+                `Retry ${name} in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`
+            }
+          ],
+          isError: true
+        };
+      }
+
+      return (handler as (...args: unknown[]) => unknown)(...args);
+    };
+
+    return (originalRegisterTool as (...args: unknown[]) => unknown)(name, config, guarded);
+  };
+
+  log.info('Tool rate limiting enabled', { per_minute: perMinute });
+  return bucket;
+}

--- a/src/core/rate-limit.ts
+++ b/src/core/rate-limit.ts
@@ -52,7 +52,11 @@ export class TokenBucket {
    */
   public take(): number | null {
     const now = this.now();
-    this.tokens = Math.min(this.capacity, this.tokens + (now - this.lastRefill) * this.refillPerMs);
+    // Clamped: `Date.now()` can move backward across an NTP correction, and a negative
+    // elapsed time would subtract tokens rather than add them, locking callers out until the
+    // bucket recovered.
+    const elapsed = Math.max(0, now - this.lastRefill);
+    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.refillPerMs);
     this.lastRefill = now;
 
     if (this.tokens >= 1) {
@@ -75,15 +79,19 @@ export function configuredRateLimit(env: Record<string, string | undefined> = pr
   if (raw === undefined || raw.trim() === '') return DEFAULT_RATE_LIMIT_PER_MINUTE;
 
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) {
+  // Integers only. Flooring a fractional value used to turn `0.5` into `0`, and `0` is the
+  // documented way to disable rate limiting entirely - so a typo silently removed the limit
+  // while skipping the warning below.
+  if (!Number.isInteger(parsed) || parsed < 0) {
     log.warn('Ignoring invalid MCP_TOOL_RATE_LIMIT_PER_MINUTE', {
       value: raw,
+      reason: Number.isFinite(parsed) ? 'expected a non-negative whole number' : 'not a number',
       using: DEFAULT_RATE_LIMIT_PER_MINUTE
     });
     return DEFAULT_RATE_LIMIT_PER_MINUTE;
   }
 
-  return Math.floor(parsed);
+  return parsed;
 }
 
 /**

--- a/src/core/services/aha-errors.ts
+++ b/src/core/services/aha-errors.ts
@@ -1,4 +1,5 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { log } from "../logger.js";
 
 /**
  * Turning Aha's REST failures into something a caller can act on.
@@ -49,6 +50,24 @@ function isTransportFailure(error: unknown): boolean {
 
 function fallbackMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * A local system error - `EACCES` writing the config file, and the like.
+ *
+ * These are the one class whose message is worth withholding: a syscall error carries the
+ * filesystem path it failed on, which a remote client over streamable-http has no business
+ * seeing and cannot act on anyway. Everything else reaching `fallbackMessage` is authored in
+ * this codebase and says something useful, so it is passed through - a blanket redaction
+ * would make `configure_server` undebuggable.
+ */
+function systemErrorCode(error: unknown): string | null {
+  const candidate = error as { code?: unknown; syscall?: unknown } | null;
+  if (!candidate || typeof candidate !== "object") return null;
+
+  const { code, syscall } = candidate;
+  const looksLikeSyscall = typeof code === "string" && /^E[A-Z]+$/.test(code) && typeof syscall === "string";
+  return looksLikeSyscall ? code : null;
 }
 
 /**
@@ -117,6 +136,19 @@ export function describeAhaError(error: unknown, subject?: string): string {
     return (
       `Could not reach Aha.io: ${fallbackMessage(error)}. Check network access and that the ` +
       "configured company subdomain is right."
+    );
+  }
+
+  const systemCode = systemErrorCode(error);
+  if (systemCode) {
+    // Logged rather than returned, so the detail survives for whoever runs the server.
+    log.error("Local system error while serving a request", error as Error, {
+      operation: "describeAhaError",
+      system_error_code: systemCode
+    });
+    return (
+      `The server hit a local system error (${systemCode}) while handling this. The detail is ` +
+      "in the server log."
     );
   }
 

--- a/src/core/services/aha-service.interface.ts
+++ b/src/core/services/aha-service.interface.ts
@@ -71,7 +71,7 @@ export interface IAhaService {
   getFeature(featureId: string): Promise<Feature>;
   updateFeature(featureId: string, featureData: any): Promise<Feature>;
   deleteFeature(featureId: string): Promise<void>;
-  createFeature(releaseId: string, featureData: any): Promise<void>;
+  createFeature(releaseId: string, featureData: any): Promise<unknown>;
 
   // Products
   listProducts(

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -183,9 +183,12 @@ export class MockAhaService implements IAhaService {
   }
 
   async createFeature(_releaseId: string, featureData: any): Promise<unknown> {
-    // The real endpoint is not typed to return a body, so echo the request back the way a
-    // create would: enough for a caller to see structuredContent arrive.
-    return { id: 'MOCK-FEATURE-1', reference_num: 'MOCK-1', ...featureData };
+    // Shaped as `{ feature: { ... } }`, which is what Aha returns and what the create path
+    // unwraps. Spreading `featureData` at the root instead put its own `feature` key there,
+    // so `unwrapRecord` descended into it and the identifiers were lost - leaving
+    // structuredContent without an id and recordLinks with nothing to link to.
+    const inner = featureData?.feature ?? featureData ?? {};
+    return { feature: { id: 'MOCK-FEATURE-1', reference_num: 'MOCK-1', ...inner } };
   }
 
   async listProducts(

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -182,8 +182,10 @@ export class MockAhaService implements IAhaService {
     // Mock delete - no-op
   }
 
-  async createFeature(_releaseId: string, _featureData: any): Promise<void> {
-    // Mock create - no-op
+  async createFeature(_releaseId: string, featureData: any): Promise<unknown> {
+    // The real endpoint is not typed to return a body, so echo the request back the way a
+    // create would: enough for a caller to see structuredContent arrive.
+    return { id: 'MOCK-FEATURE-1', reference_num: 'MOCK-1', ...featureData };
   }
 
   async listProducts(

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1370,9 +1370,13 @@ export class AhaService {
    * Create a feature within a specific release
    * @param releaseId The ID of the release
    * @param featureData The feature data to create
-   * @returns The created feature response
+   * @returns The created feature response, if the endpoint returned a body
+   *
+   * `unknown` rather than `Feature`: aha-js types this endpoint's response as `void`, so
+   * whatever Aha sends back is undeclared. The tool treats a missing body as an empty
+   * record rather than assuming a feature came back.
    */
-  public static async createFeature(releaseId: string, _featureData: any): Promise<void> {
+  public static async createFeature(releaseId: string, _featureData: any): Promise<unknown> {
     const defaultApi = this.getDefaultApi();
 
     try {

--- a/src/core/tool-output.ts
+++ b/src/core/tool-output.ts
@@ -1,0 +1,243 @@
+import * as z from "zod/v4";
+
+/**
+ * Output schemas for the tools, paired with the `structuredContent` every tool returns
+ * alongside its human-readable text block.
+ *
+ * Two constraints shaped these, both learned the hard way:
+ *
+ * 1. **Everything that wraps an Aha record must be a `looseObject`.** A raw Zod shape
+ *    converts to JSON Schema with `additionalProperties: false`, and the SDK client
+ *    validates `structuredContent` against the advertised schema and *throws* on keys the
+ *    schema does not list. Aha records carry far more fields than are described here, so a
+ *    closed schema would break every one of those tools at call time.
+ * 2. **Only type fields Aha reliably returns, and type them permissively.** The server
+ *    validates its own `structuredContent` before sending it and turns a mismatch into a
+ *    protocol error, so an optimistic guess about a field's type does not degrade - it
+ *    fails the call outright. Anything not enumerated here still reaches the client
+ *    verbatim; it just is not described.
+ *
+ * Payloads this server builds itself (deletions, search, the server/config tools) are
+ * closed objects, because their shape is known rather than inherited from an API response.
+ */
+
+/**
+ * Widen an Aha record for `structuredContent`, which the SDK types as an index-signature
+ * object. TypeScript does not give an `interface` an implicit index signature, so every
+ * record needs one widening step; doing it here keeps the call sites free of casts and
+ * makes the reason greppable.
+ */
+export function structured<T extends object>(record: T): Record<string, unknown> {
+  return record as Record<string, unknown>;
+}
+
+/**
+ * Aha wraps some responses in a single key - `{ idea: { ... } }` for the idea creators,
+ * `{ initiative: { ... } }` for initiatives - and returns others bare. Unwrapping here means
+ * `structuredContent` is always the record itself, so one contract covers every tool
+ * instead of the caller needing to know which record types arrive wrapped.
+ *
+ * A missing body becomes `{}` rather than undefined: every field of the record schemas is
+ * optional, whereas an absent structuredContent fails output validation outright.
+ */
+export function unwrapRecord(payload: unknown, key: string): Record<string, unknown> {
+  if (payload && typeof payload === "object") {
+    const inner = (payload as Record<string, unknown>)[key];
+    if (inner && typeof inner === "object" && !Array.isArray(inner)) {
+      return inner as Record<string, unknown>;
+    }
+    return payload as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Record types with a single-record resource template in resources.ts. */
+type LinkableRecordType = "feature" | "epic" | "idea" | "initiative" | "competitor";
+
+function identifier(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number") return String(value);
+  return undefined;
+}
+
+/**
+ * A `resource_link` back to the record a tool just touched, so a client can re-read its
+ * full current state - or subscribe to it - instead of relying on the point-in-time copy in
+ * the result. Returns an array so call sites can spread it: there is nothing worth linking
+ * to when the response carried no identifier, and a link to an unreadable URI is worse than
+ * no link.
+ */
+export function recordLinks(
+  recordType: LinkableRecordType,
+  record: Record<string, unknown>,
+  fallbackId?: string
+) {
+  const id = identifier(record.reference_num) ?? identifier(record.id) ?? fallbackId;
+  if (!id) return [];
+
+  return [
+    {
+      type: "resource_link" as const,
+      uri: `aha://${recordType}/${id}`,
+      name: identifier(record.name) ?? `${recordType} ${id}`,
+      description: `The ${recordType} this call touched. Read it for the record's current full state.`,
+      mimeType: "application/json"
+    }
+  ];
+}
+
+/** Fields common to every Aha record returned by a tool. */
+const recordIdentity = {
+  id: z
+    .union([z.string(), z.number()])
+    .optional()
+    .describe("Internal Aha.io id. Numeric for some record types, a string for others."),
+  reference_num: z
+    .string()
+    .optional()
+    .describe("Human-facing identifier, e.g. PRJ1-123. Prefer this over `id` when talking to people."),
+  name: z.string().optional().describe("Record name"),
+  url: z.string().optional().describe("Absolute URL of the record's web page in Aha.io"),
+  resource: z.string().optional().describe("Absolute URL of the record's REST API endpoint"),
+  created_at: z.string().optional().describe("ISO 8601 creation timestamp"),
+  updated_at: z.string().optional().describe("ISO 8601 last-modified timestamp")
+};
+
+/** Progress and score arrive as numbers, or null when unset. */
+const progressField = z.number().nullish().describe("Completion percentage, 0-100");
+const scoreField = z.number().nullish().describe("Aha.io score");
+
+export const featureOutputSchema = z.looseObject({
+  ...recordIdentity,
+  progress: progressField,
+  score: scoreField
+});
+
+export const epicOutputSchema = z.looseObject({
+  ...recordIdentity,
+  progress: progressField
+});
+
+export const initiativeOutputSchema = z.looseObject({
+  ...recordIdentity,
+  progress: progressField
+});
+
+export const ideaOutputSchema = z.looseObject({
+  ...recordIdentity,
+  score: scoreField
+});
+
+export const competitorOutputSchema = z.looseObject({
+  ...recordIdentity
+});
+
+export const commentOutputSchema = z.looseObject({
+  id: z.union([z.string(), z.number()]).optional().describe("Comment id"),
+  created_at: z.string().optional().describe("ISO 8601 creation timestamp"),
+  updated_at: z.string().optional().describe("ISO 8601 last-modified timestamp")
+});
+
+/**
+ * Aha's DELETE endpoints answer with an empty body, so there is no record to hand back -
+ * only a restatement of what went away, which the caller can use to confirm the right
+ * record was targeted.
+ */
+export const deletionOutputSchema = z.object({
+  deleted: z.literal(true).describe("Always true; failures come back with isError instead"),
+  record_type: z
+    .enum(["feature", "epic", "idea", "competitor"])
+    .describe("Type of record that was deleted"),
+  id: z.string().describe("Id or reference number the deletion was requested for")
+});
+
+/** Built by `aha_search` from the GraphQL response, so every field is known. */
+export const searchOutputSchema = z.object({
+  query: z.string().describe("The search term that was run"),
+  workspace_id: z.string().nullable().describe("Workspace the search was scoped to, or null for all"),
+  record_types: z
+    .union([z.array(z.string()), z.literal("all")])
+    .describe('Record types searched, or "all"'),
+  total_count: z.number().describe("Number of matching records"),
+  total_count_is_capped: z
+    .boolean()
+    .describe("True when Aha.io stopped counting at 10000, so total_count is a floor, not a total"),
+  page: z.number().describe("1-based page number these results came from"),
+  total_pages: z.number().describe("Number of pages available"),
+  is_last_page: z.boolean().describe("True when there is no further page to fetch"),
+  results: z
+    .array(
+      z.object({
+        name: z.string().nullable().describe("Record name"),
+        type: z.string().describe("Aha.io record type, e.g. Feature or Idea"),
+        id: z.string().nullable().describe("Record id or reference number"),
+        workspace_id: z.string().nullable().describe("Workspace (Aha project) the record lives in"),
+        url: z.string().describe("Absolute URL of the record's web page in Aha.io"),
+        updated_at: z.string().describe("ISO 8601 last-modified timestamp")
+      })
+    )
+    .describe("Matching records, most relevant first")
+});
+
+/**
+ * The server/config tools report on this process rather than on Aha, but they are still
+ * loose: `checks` and the config summary grow fields over time, and none of them is worth
+ * a failed tool call.
+ */
+export const healthCheckOutputSchema = z.looseObject({
+  status: z.string().describe("healthy, degraded or unhealthy"),
+  timestamp: z.string().describe("ISO 8601 time the check ran"),
+  uptime: z.number().describe("Milliseconds since the server started"),
+  version: z.string().describe("Server version"),
+  checks: z.looseObject({}).describe("Per-subsystem results, each with a status and message")
+});
+
+export const serverStatusOutputSchema = z.looseObject({
+  status: z.string().describe("Lifecycle state of the server"),
+  version: z.string().describe("Server version"),
+  uptime: z.number().describe("Milliseconds since the server started"),
+  environment: z.string().describe("NODE_ENV the server is running under")
+});
+
+const configSummarySchema = z.looseObject({
+  company: z.string().describe('Configured company subdomain, or "not configured"'),
+  tokenConfigured: z.boolean().describe("Whether an Aha.io API token is present"),
+  mode: z.string().describe("Transport mode"),
+  isComplete: z.boolean().describe("Whether the configuration is usable against Aha.io")
+});
+
+export const configureServerOutputSchema = z.object({
+  success: z.literal(true).describe("Always true; failures come back with isError instead"),
+  message: z.string().describe("What changed"),
+  config: configSummarySchema.describe("Configuration after the update, with the token redacted"),
+  note: z.string().describe("Caveats that apply to the update")
+});
+
+export const serverConfigOutputSchema = z.looseObject({
+  ...configSummarySchema.shape,
+  validation: z
+    .looseObject({
+      isValid: z.boolean().describe("Whether the configuration passes validation"),
+      errors: z.array(z.string()).describe("Validation failures, empty when valid")
+    })
+    .describe("Result of validating the stored configuration"),
+  environmentOverrides: z
+    .looseObject({})
+    .describe("Which settings an environment variable is currently overriding")
+});
+
+export const testConfigurationOutputSchema = z.object({
+  success: z.literal(true).describe("Always true; failures come back with isError instead"),
+  message: z.string().describe("Outcome of the connection test"),
+  connection: z.object({
+    status: z.string().describe("Connection state"),
+    user: z
+      .looseObject({
+        name: z.string().describe("Display name of the authenticated user"),
+        email: z.string().describe("Email of the authenticated user"),
+        id: z.string().describe("Aha.io user id")
+      })
+      .describe("The user the token authenticates as"),
+    company: z.string().describe("Company subdomain that was reached")
+  })
+});

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -2,6 +2,17 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import * as services from "./services/index.js";
 import { registerSearchTools } from "./tools/search-tools.js";
+import {
+  commentOutputSchema,
+  competitorOutputSchema,
+  deletionOutputSchema,
+  epicOutputSchema,
+  featureOutputSchema,
+  ideaOutputSchema,
+  initiativeOutputSchema,
+  recordLinks,
+  unwrapRecord
+} from "./tool-output.js";
 import { log } from "./logger.js";
 import { describeAhaError } from "./services/aha-errors.js";
 
@@ -16,11 +27,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_feature_comment",
     {
+      title: "Create feature comment",
       description: "Create a comment on a feature in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         body: z.string().describe("Comment body")
       },
+      outputSchema: commentOutputSchema,
       annotations: {
         title: "Create feature comment",
         readOnlyHint: false,
@@ -32,14 +45,16 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; body: string }) => {
       try {
         const comment = await services.AhaService.createFeatureComment(params.featureId, params.body);
+        const record = unwrapRecord(comment, "comment");
 
         return {
           content: [
             {
               type: "text",
-              text: `Comment created successfully:\n\n${JSON.stringify(comment, null, 2)}`
+              text: `Comment created successfully:\n\n${JSON.stringify(record, null, 2)}`
             }
-          ]
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -63,11 +78,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_associate_feature_with_epic",
     {
+      title: "Associate feature with epic",
       description: "Associate a feature with an epic in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         epicId: z.string().describe("ID or name of the epic")
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Associate feature with epic",
         readOnlyHint: false,
@@ -79,14 +96,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; epicId: string }) => {
       try {
         const feature = await services.AhaService.associateFeatureWithEpic(params.featureId, params.epicId);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully associated with epic ${params.epicId}:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} successfully associated with epic ${params.epicId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -106,11 +126,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_move_feature_to_release",
     {
+      title: "Move feature to release",
       description: "Move a feature to a different release in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         releaseId: z.string().describe("ID or key of the target release")
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Move feature to release",
         readOnlyHint: false,
@@ -122,14 +144,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; releaseId: string }) => {
       try {
         const feature = await services.AhaService.moveFeatureToRelease(params.featureId, params.releaseId);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully moved to release ${params.releaseId}:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} successfully moved to release ${params.releaseId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -149,11 +174,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_associate_feature_with_goals",
     {
+      title: "Set feature goals",
       description: "Associate a feature with multiple goals in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         goalIds: z.array(z.number()).describe("Array of goal IDs to associate with the feature")
       },
+      outputSchema: featureOutputSchema,
       // destructive: PUT /features/:id/goals replaces the goal set, so goals left out are unlinked.
       annotations: {
         title: "Set feature goals",
@@ -166,14 +193,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; goalIds: number[] }) => {
       try {
         const feature = await services.AhaService.associateFeatureWithGoals(params.featureId, params.goalIds);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully associated with goals ${params.goalIds.join(', ')}:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} successfully associated with goals ${params.goalIds.join(', ')}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -193,11 +223,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_feature_tags",
     {
+      title: "Set feature tags",
       description: "Update tags for a feature in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         tags: z.array(z.string()).describe("Array of tag strings to associate with the feature")
       },
+      outputSchema: featureOutputSchema,
       // destructive: PUT /features/:id/tags replaces the tag set, so tags left out are removed.
       annotations: {
         title: "Set feature tags",
@@ -210,14 +242,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; tags: string[] }) => {
       try {
         const feature = await services.AhaService.updateFeatureTags(params.featureId, params.tags);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} tags successfully updated to [${params.tags.join(', ')}]:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} tags successfully updated to [${params.tags.join(', ')}]:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -237,6 +272,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_epic_in_product",
     {
+      title: "Create epic in product",
       description: "Create an epic within a specific product in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -247,6 +283,7 @@ export function registerTools(server: McpServer) {
           }).describe("Epic data object")
         }).describe("Epic creation data")
       },
+      outputSchema: epicOutputSchema,
       annotations: {
         title: "Create epic in product",
         readOnlyHint: false,
@@ -258,14 +295,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; epicData: any }) => {
       try {
         const epic = await services.AhaService.createEpicInProduct(params.productId, params.epicData);
+        const record = unwrapRecord(epic, "epic");
 
         return {
           content: [
             {
               type: "text",
-              text: `Epic successfully created in product ${params.productId}:\n\n${JSON.stringify(epic, null, 2)}`
-            }
-          ]
+              text: `Epic successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("epic", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -285,6 +325,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_epic_in_release",
     {
+      title: "Create epic in release",
       description: "Create an epic within a specific release in Aha.io",
       inputSchema: {
         releaseId: z.string().describe("ID of the release"),
@@ -295,6 +336,7 @@ export function registerTools(server: McpServer) {
           }).describe("Epic data object")
         }).describe("Epic creation data")
       },
+      outputSchema: epicOutputSchema,
       annotations: {
         title: "Create epic in release",
         readOnlyHint: false,
@@ -306,14 +348,17 @@ export function registerTools(server: McpServer) {
     async (params: { releaseId: string; epicData: any }) => {
       try {
         const epic = await services.AhaService.createEpicInRelease(params.releaseId, params.epicData);
+        const record = unwrapRecord(epic, "epic");
 
         return {
           content: [
             {
               type: "text",
-              text: `Epic successfully created in release ${params.releaseId}:\n\n${JSON.stringify(epic, null, 2)}`
-            }
-          ]
+              text: `Epic successfully created in release ${params.releaseId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("epic", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -333,6 +378,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_initiative_in_product",
     {
+      title: "Create initiative in product",
       description: "Create an initiative within a specific product in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -343,6 +389,7 @@ export function registerTools(server: McpServer) {
           }).describe("Initiative data object")
         }).describe("Initiative creation data")
       },
+      outputSchema: initiativeOutputSchema,
       annotations: {
         title: "Create initiative in product",
         readOnlyHint: false,
@@ -354,14 +401,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; initiativeData: any }) => {
       try {
         const initiative = await services.AhaService.createInitiativeInProduct(params.productId, params.initiativeData);
+        const record = unwrapRecord(initiative, "initiative");
 
         return {
           content: [
             {
               type: "text",
-              text: `Initiative successfully created in product ${params.productId}:\n\n${JSON.stringify(initiative, null, 2)}`
-            }
-          ]
+              text: `Initiative successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("initiative", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -385,6 +435,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_feature",
     {
+      title: "Create feature",
       description: "Create a feature within a specific release in Aha.io",
       inputSchema: {
         releaseId: z.string().describe("ID of the release"),
@@ -395,6 +446,7 @@ export function registerTools(server: McpServer) {
           }).describe("Feature data object")
         }).describe("Feature creation data")
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Create feature",
         readOnlyHint: false,
@@ -406,14 +458,21 @@ export function registerTools(server: McpServer) {
     async (params: { releaseId: string; featureData: any }) => {
       try {
         const feature = await services.AhaService.createFeature(params.releaseId, params.featureData);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature successfully created in release ${params.releaseId}:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature successfully created in release ${params.releaseId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record)
+          ],
+          // Unlike the other writers, this endpoint is not typed to return a body. An empty
+          // record still validates - every field of featureOutputSchema is optional - where a
+          // missing structuredContent would fail output validation and sink the call. With no
+          // identifier to link to, recordLinks yields nothing rather than a broken URI.
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -433,6 +492,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_feature",
     {
+      title: "Update feature",
       description: "Update a feature in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
@@ -443,6 +503,7 @@ export function registerTools(server: McpServer) {
           }).describe("Feature data object")
         }).describe("Feature update data")
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Update feature",
         readOnlyHint: false,
@@ -454,14 +515,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; featureData: any }) => {
       try {
         const feature = await services.AhaService.updateFeature(params.featureId, params.featureData);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully updated:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} successfully updated:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -481,10 +545,12 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_delete_feature",
     {
+      title: "Delete feature",
       description: "Delete a feature in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature")
       },
+      outputSchema: deletionOutputSchema,
       annotations: {
         title: "Delete feature",
         readOnlyHint: false,
@@ -503,7 +569,8 @@ export function registerTools(server: McpServer) {
               type: "text",
               text: `Feature ${params.featureId} successfully deleted`
             }
-          ]
+          ],
+          structuredContent: { deleted: true as const, record_type: "feature" as const, id: params.featureId }
         };
       } catch (error) {
         return {
@@ -523,11 +590,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_feature_progress",
     {
+      title: "Update feature progress",
       description: "Update a feature's progress in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         progress: z.number().min(0).max(100).describe("Progress percentage (0-100)")
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Update feature progress",
         readOnlyHint: false,
@@ -539,14 +608,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; progress: number }) => {
       try {
         const feature = await services.AhaService.updateFeatureProgress(params.featureId, params.progress);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} progress updated to ${params.progress}%:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} progress updated to ${params.progress}%:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -566,11 +638,13 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_feature_score",
     {
+      title: "Update feature score",
       description: "Update a feature's score in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         score: z.number().describe("Score value")
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Update feature score",
         readOnlyHint: false,
@@ -582,14 +656,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; score: number }) => {
       try {
         const feature = await services.AhaService.updateFeatureScore(params.featureId, params.score);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} score updated to ${params.score}:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} score updated to ${params.score}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -609,6 +686,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_feature_custom_fields",
     {
+      title: "Update feature custom fields",
       description: "Update a feature's custom fields in Aha.io",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
@@ -618,6 +696,7 @@ export function registerTools(server: McpServer) {
           "Custom fields as a key/value object, keyed by the custom field's API key"
         )
       },
+      outputSchema: featureOutputSchema,
       annotations: {
         title: "Update feature custom fields",
         readOnlyHint: false,
@@ -629,14 +708,17 @@ export function registerTools(server: McpServer) {
     async (params: { featureId: string; customFields: Record<string, any> }) => {
       try {
         const feature = await services.AhaService.updateFeatureCustomFields(params.featureId, params.customFields);
+        const record = unwrapRecord(feature, "feature");
 
         return {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} custom fields updated:\n\n${JSON.stringify(feature, null, 2)}`
-            }
-          ]
+              text: `Feature ${params.featureId} custom fields updated:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("feature", record, params.featureId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -660,6 +742,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_epic",
     {
+      title: "Update epic",
       description: "Update an epic in Aha.io",
       inputSchema: {
         epicId: z.string().describe("ID of the epic"),
@@ -670,6 +753,7 @@ export function registerTools(server: McpServer) {
           }).describe("Epic data object")
         }).describe("Epic update data")
       },
+      outputSchema: epicOutputSchema,
       annotations: {
         title: "Update epic",
         readOnlyHint: false,
@@ -681,14 +765,17 @@ export function registerTools(server: McpServer) {
     async (params: { epicId: string; epicData: any }) => {
       try {
         const epic = await services.AhaService.updateEpic(params.epicId, params.epicData);
+        const record = unwrapRecord(epic, "epic");
 
         return {
           content: [
             {
               type: "text",
-              text: `Epic ${params.epicId} successfully updated:\n\n${JSON.stringify(epic, null, 2)}`
-            }
-          ]
+              text: `Epic ${params.epicId} successfully updated:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("epic", record, params.epicId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -708,10 +795,12 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_delete_epic",
     {
+      title: "Delete epic",
       description: "Delete an epic in Aha.io",
       inputSchema: {
         epicId: z.string().describe("ID of the epic")
       },
+      outputSchema: deletionOutputSchema,
       annotations: {
         title: "Delete epic",
         readOnlyHint: false,
@@ -730,7 +819,8 @@ export function registerTools(server: McpServer) {
               type: "text",
               text: `Epic ${params.epicId} successfully deleted`
             }
-          ]
+          ],
+          structuredContent: { deleted: true as const, record_type: "epic" as const, id: params.epicId }
         };
       } catch (error) {
         return {
@@ -754,6 +844,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_idea",
     {
+      title: "Create idea",
       description: "Create an idea in a product in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -765,6 +856,7 @@ export function registerTools(server: McpServer) {
           }).describe("Idea data object")
         }).describe("Idea creation data")
       },
+      outputSchema: ideaOutputSchema,
       annotations: {
         title: "Create idea",
         readOnlyHint: false,
@@ -776,14 +868,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdea(params.productId, params.ideaData);
+        const record = unwrapRecord(idea, "idea");
 
         return {
           content: [
             {
               type: "text",
-              text: `Idea successfully created in product ${params.productId}:\n\n${JSON.stringify(idea, null, 2)}`
-            }
-          ]
+              text: `Idea successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("idea", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -803,6 +898,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_idea_with_category",
     {
+      title: "Create idea with category",
       description: "Create an idea with a category in a product in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -815,6 +911,7 @@ export function registerTools(server: McpServer) {
           }).describe("Idea data object")
         }).describe("Idea creation data with category")
       },
+      outputSchema: ideaOutputSchema,
       annotations: {
         title: "Create idea with category",
         readOnlyHint: false,
@@ -826,14 +923,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdeaWithCategory(params.productId, params.ideaData);
+        const record = unwrapRecord(idea, "idea");
 
         return {
           content: [
             {
               type: "text",
-              text: `Idea with category successfully created in product ${params.productId}:\n\n${JSON.stringify(idea, null, 2)}`
-            }
-          ]
+              text: `Idea with category successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("idea", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -853,6 +953,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_idea_with_score",
     {
+      title: "Create idea with score",
       description: "Create an idea with a score in a product in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -865,6 +966,7 @@ export function registerTools(server: McpServer) {
           }).describe("Idea data object")
         }).describe("Idea creation data with score")
       },
+      outputSchema: ideaOutputSchema,
       annotations: {
         title: "Create idea with score",
         readOnlyHint: false,
@@ -876,14 +978,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdeaWithScore(params.productId, params.ideaData);
+        const record = unwrapRecord(idea, "idea");
 
         return {
           content: [
             {
               type: "text",
-              text: `Idea with score successfully created in product ${params.productId}:\n\n${JSON.stringify(idea, null, 2)}`
-            }
-          ]
+              text: `Idea with score successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("idea", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -903,10 +1008,12 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_delete_idea",
     {
+      title: "Delete idea",
       description: "Delete an idea in Aha.io",
       inputSchema: {
         ideaId: z.string().describe("ID of the idea")
       },
+      outputSchema: deletionOutputSchema,
       annotations: {
         title: "Delete idea",
         readOnlyHint: false,
@@ -925,7 +1032,8 @@ export function registerTools(server: McpServer) {
               type: "text",
               text: `Idea ${params.ideaId} successfully deleted`
             }
-          ]
+          ],
+          structuredContent: { deleted: true as const, record_type: "idea" as const, id: params.ideaId }
         };
       } catch (error) {
         return {
@@ -949,6 +1057,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_competitor",
     {
+      title: "Create competitor",
       description: "Create a competitor in a product in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -960,6 +1069,7 @@ export function registerTools(server: McpServer) {
           }).describe("Competitor data object")
         }).describe("Competitor creation data")
       },
+      outputSchema: competitorOutputSchema,
       annotations: {
         title: "Create competitor",
         readOnlyHint: false,
@@ -971,14 +1081,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; competitorData: any }) => {
       try {
         const competitor = await services.AhaService.createCompetitor(params.productId, params.competitorData);
+        const record = unwrapRecord(competitor, "competitor");
 
         return {
           content: [
             {
               type: "text",
-              text: `Competitor successfully created in product ${params.productId}:\n\n${JSON.stringify(competitor, null, 2)}`
-            }
-          ]
+              text: `Competitor successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("competitor", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -998,6 +1111,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_update_competitor",
     {
+      title: "Update competitor",
       description: "Update a competitor in Aha.io",
       inputSchema: {
         competitorId: z.string().describe("ID of the competitor"),
@@ -1009,6 +1123,7 @@ export function registerTools(server: McpServer) {
           }).describe("Competitor data object")
         }).describe("Competitor update data")
       },
+      outputSchema: competitorOutputSchema,
       annotations: {
         title: "Update competitor",
         readOnlyHint: false,
@@ -1020,14 +1135,17 @@ export function registerTools(server: McpServer) {
     async (params: { competitorId: string; competitorData: any }) => {
       try {
         const competitor = await services.AhaService.updateCompetitor(params.competitorId, params.competitorData);
+        const record = unwrapRecord(competitor, "competitor");
 
         return {
           content: [
             {
               type: "text",
-              text: `Competitor ${params.competitorId} successfully updated:\n\n${JSON.stringify(competitor, null, 2)}`
-            }
-          ]
+              text: `Competitor ${params.competitorId} successfully updated:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("competitor", record, params.competitorId)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -1047,10 +1165,12 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_delete_competitor",
     {
+      title: "Delete competitor",
       description: "Delete a competitor in Aha.io",
       inputSchema: {
         competitorId: z.string().describe("ID of the competitor")
       },
+      outputSchema: deletionOutputSchema,
       annotations: {
         title: "Delete competitor",
         readOnlyHint: false,
@@ -1069,7 +1189,8 @@ export function registerTools(server: McpServer) {
               type: "text",
               text: `Competitor ${params.competitorId} successfully deleted`
             }
-          ]
+          ],
+          structuredContent: { deleted: true as const, record_type: "competitor" as const, id: params.competitorId }
         };
       } catch (error) {
         return {
@@ -1097,6 +1218,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_idea_by_portal_user",
     {
+      title: "Create idea as portal user",
       description: "Create an idea by a portal user in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -1113,6 +1235,7 @@ export function registerTools(server: McpServer) {
           }).describe("Idea data object")
         }).describe("Idea creation data by portal user")
       },
+      outputSchema: ideaOutputSchema,
       annotations: {
         title: "Create idea as portal user",
         readOnlyHint: false,
@@ -1124,14 +1247,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdeaByPortalUser(params.productId, params.ideaData);
+        const record = unwrapRecord(idea, "idea");
 
         return {
           content: [
             {
               type: "text",
-              text: `Idea by portal user successfully created in product ${params.productId}:\n\n${JSON.stringify(idea, null, 2)}`
-            }
-          ]
+              text: `Idea by portal user successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("idea", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {
@@ -1151,6 +1277,7 @@ export function registerTools(server: McpServer) {
   server.registerTool(
     "aha_create_idea_with_portal_settings",
     {
+      title: "Create idea with portal settings",
       description: "Create an idea with enhanced portal settings in Aha.io",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
@@ -1165,6 +1292,7 @@ export function registerTools(server: McpServer) {
           }).describe("Idea data object")
         }).describe("Idea creation data with portal settings")
       },
+      outputSchema: ideaOutputSchema,
       annotations: {
         title: "Create idea with portal settings",
         readOnlyHint: false,
@@ -1176,14 +1304,17 @@ export function registerTools(server: McpServer) {
     async (params: { productId: string; ideaData: any }) => {
       try {
         const idea = await services.AhaService.createIdeaWithPortalSettings(params.productId, params.ideaData);
+        const record = unwrapRecord(idea, "idea");
 
         return {
           content: [
             {
               type: "text",
-              text: `Idea with portal settings successfully created in product ${params.productId}:\n\n${JSON.stringify(idea, null, 2)}`
-            }
-          ]
+              text: `Idea with portal settings successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+            },
+            ...recordLinks("idea", record)
+          ],
+          structuredContent: record
         };
       } catch (error) {
         return {

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -7,6 +7,7 @@ import {
   MIN_PER_PAGE,
   SEARCHABLE_TYPES
 } from "../services/aha-graphql.js";
+import { searchOutputSchema } from "../tool-output.js";
 import { log } from "../logger.js";
 import { describeAhaError } from "../services/aha-errors.js";
 
@@ -21,6 +22,7 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
   server.registerTool(
     "aha_search",
     {
+      title: "Search Aha.io",
       description: "Search across Aha.io records - ideas, features, epics, initiatives, goals, key results, " +
           "requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so " +
           "results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and " +
@@ -58,6 +60,7 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
               `anything below ${MIN_PER_PAGE} to ${MIN_PER_PAGE}.`
           )
       },
+      outputSchema: searchOutputSchema,
       annotations: {
         title: "Search Aha.io",
         readOnlyHint: true,
@@ -74,35 +77,36 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
           per: perPage
         });
 
+        const payload = {
+          query,
+          workspace_id: workspaceId ?? null,
+          record_types: recordTypes ?? ("all" as const),
+          total_count: result.totalCount,
+          // Aha stops counting at 10000; say so rather than implying an exact total.
+          total_count_is_capped: result.totalCountIsCapped,
+          page: result.currentPage,
+          total_pages: result.totalPages,
+          is_last_page: result.isLastPage,
+          results: result.results.map(hit => ({
+            name: hit.name,
+            type: hit.searchableType,
+            id: hit.searchableId,
+            workspace_id: hit.projectId,
+            url: hit.url,
+            updated_at: hit.updatedAt
+          }))
+        };
+
         return {
+          // The same payload twice: structuredContent is what a client should read, the
+          // text block is the spec's backwards-compatible copy for clients that ignore it.
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify(
-                {
-                  query,
-                  workspace_id: workspaceId ?? null,
-                  record_types: recordTypes ?? "all",
-                  total_count: result.totalCount,
-                  // Aha stops counting at 10000; say so rather than implying an exact total.
-                  total_count_is_capped: result.totalCountIsCapped,
-                  page: result.currentPage,
-                  total_pages: result.totalPages,
-                  is_last_page: result.isLastPage,
-                  results: result.results.map(hit => ({
-                    name: hit.name,
-                    type: hit.searchableType,
-                    id: hit.searchableId,
-                    workspace_id: hit.projectId,
-                    url: hit.url,
-                    updated_at: hit.updatedAt
-                  }))
-                },
-                null,
-                2
-              )
+              text: JSON.stringify(payload, null, 2)
             }
-          ]
+          ],
+          structuredContent: payload
         };
       } catch (error) {
         const message = describeAhaError(error);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6,6 +6,14 @@ import { registerSampling } from "../core/sampling.js";
 import { buildServerInstructions } from "../core/instructions.js";
 import * as services from "../core/services/index.js";
 import { ConfigService } from "../core/config.js";
+import { installToolRateLimit } from "../core/rate-limit.js";
+import {
+  configureServerOutputSchema,
+  healthCheckOutputSchema,
+  serverConfigOutputSchema,
+  serverStatusOutputSchema,
+  testConfigurationOutputSchema
+} from "../core/tool-output.js";
 import { log } from "../core/logger.js";
 import { describeAhaError } from "../core/services/aha-errors.js";
 import * as z from "zod/v4";
@@ -130,12 +138,21 @@ async function startServer() {
       { instructions: buildServerInstructions(config.company) }
     );
 
+    // Before any registerTool call: the limiter works by wrapping the registrar, so tools
+    // registered ahead of this line would not be covered.
+    installToolRateLimit(server);
+
     // Add health check tool
     server.registerTool(
       "server_health_check",
       {
+        title: "Check server health",
         description: "Get server health status and diagnostics",
-        inputSchema: {},
+        // strictObject({}).optional(): a raw `{}` shape made `arguments` mandatory, so
+        // `tools/call` with no arguments at all - which the spec allows - failed input
+        // validation. Strict still rejects arguments this tool would ignore.
+        inputSchema: z.strictObject({}).optional(),
+        outputSchema: healthCheckOutputSchema,
         // openWorld: the check calls Aha's /me endpoint when credentials are present.
         annotations: {
           title: "Check server health",
@@ -145,11 +162,16 @@ async function startServer() {
       },
       async () => {
         const healthCheck = await performHealthCheck();
+        // Dates are serialised for structuredContent rather than handed over as Date
+        // objects: output validation runs on the value before it is serialised, so a Date
+        // where the schema says string would fail the call.
+        const payload = { ...healthCheck, timestamp: healthCheck.timestamp.toISOString() };
         return {
           content: [{
             type: "text",
-            text: JSON.stringify(healthCheck, null, 2)
-          }]
+            text: JSON.stringify(payload, null, 2)
+          }],
+          structuredContent: payload
         };
       }
     );
@@ -158,8 +180,13 @@ async function startServer() {
     server.registerTool(
       "server_status",
       {
+        title: "Get server status",
         description: "Get detailed server status and configuration",
-        inputSchema: {},
+        // strictObject({}).optional(): a raw `{}` shape made `arguments` mandatory, so
+        // `tools/call` with no arguments at all - which the spec allows - failed input
+        // validation. Strict still rejects arguments this tool would ignore.
+        inputSchema: z.strictObject({}).optional(),
+        outputSchema: serverStatusOutputSchema,
         annotations: {
           title: "Get server status",
           readOnlyHint: true,
@@ -168,26 +195,36 @@ async function startServer() {
       },
       async () => {
         updateServerStatus(serverStatus.status);
+        const payload = {
+          ...serverStatus,
+          // Same reason as server_health_check: ISO strings, not Date objects.
+          startTime: serverStatus.startTime.toISOString(),
+          lastHealthCheck: serverStatus.lastHealthCheck?.toISOString() ?? null,
+          ahaConnection: {
+            ...serverStatus.ahaConnection,
+            lastChecked: serverStatus.ahaConnection.lastChecked?.toISOString() ?? null
+          },
+          systemInfo: {
+            nodeVersion: process.version,
+            platform: process.platform,
+            arch: process.arch,
+            pid: process.pid,
+            workingDirectory: process.cwd(),
+            memoryUsage: {
+              heapUsed: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
+              heapTotal: Math.round(process.memoryUsage().heapTotal / 1024 / 1024),
+              external: Math.round(process.memoryUsage().external / 1024 / 1024),
+              rss: Math.round(process.memoryUsage().rss / 1024 / 1024)
+            }
+          }
+        };
+
         return {
           content: [{
             type: "text",
-            text: JSON.stringify({
-              ...serverStatus,
-              systemInfo: {
-                nodeVersion: process.version,
-                platform: process.platform,
-                arch: process.arch,
-                pid: process.pid,
-                workingDirectory: process.cwd(),
-                memoryUsage: {
-                  heapUsed: Math.round(process.memoryUsage().heapUsed / 1024 / 1024),
-                  heapTotal: Math.round(process.memoryUsage().heapTotal / 1024 / 1024),
-                  external: Math.round(process.memoryUsage().external / 1024 / 1024),
-                  rss: Math.round(process.memoryUsage().rss / 1024 / 1024)
-                }
-              }
-            }, null, 2)
-          }]
+            text: JSON.stringify(payload, null, 2)
+          }],
+          structuredContent: payload
         };
       }
     );
@@ -196,6 +233,7 @@ async function startServer() {
     server.registerTool(
       "configure_server",
       {
+        title: "Configure server",
         description: "Configure server settings (company, token, mode)",
         inputSchema: {
           company: z.string().optional().describe("Aha.io company subdomain"),
@@ -206,6 +244,7 @@ async function startServer() {
           port: z.number().optional().describe("Port number for the streamable-http transport"),
           host: z.string().optional().describe("Host address for the streamable-http transport")
         },
+        outputSchema: configureServerOutputSchema,
         // non-destructive: only the fields supplied are merged into ~/.aha-mcp-config.json.
         annotations: {
           title: "Configure server",
@@ -232,26 +271,30 @@ async function startServer() {
             services.AhaService.initialize(newConfig.token || undefined, newConfig.company || undefined);
           }
 
+          const payload = {
+            success: true as const,
+            message: "Configuration updated successfully",
+            config: ConfigService.getConfigSummary() as Record<string, unknown>,
+            note: "Server restart may be required for transport mode changes"
+          };
+
           return {
             content: [{
               type: "text",
-              text: JSON.stringify({
-                success: true,
-                message: "Configuration updated successfully",
-                config: ConfigService.getConfigSummary(),
-                note: "Server restart may be required for transport mode changes"
-              }, null, 2)
-            }]
+              text: JSON.stringify(payload, null, 2)
+            }],
+            structuredContent: payload
           };
         } catch (error) {
+          // A rejected configuration is a tool execution error: isError lets the client show
+          // it as a failure and gives the model something to correct, which a success-shaped
+          // result carrying `success: false` does not.
           return {
             content: [{
               type: "text",
-              text: JSON.stringify({
-                success: false,
-                error: describeAhaError(error)
-              }, null, 2)
-            }]
+              text: `Configuration update failed: ${describeAhaError(error)}`
+            }],
+            isError: true
           };
         }
       }
@@ -260,8 +303,13 @@ async function startServer() {
     server.registerTool(
       "get_server_config",
       {
+        title: "Get server configuration",
         description: "Get current server configuration",
-        inputSchema: {},
+        // strictObject({}).optional(): a raw `{}` shape made `arguments` mandatory, so
+        // `tools/call` with no arguments at all - which the spec allows - failed input
+        // validation. Strict still rejects arguments this tool would ignore.
+        inputSchema: z.strictObject({}).optional(),
+        outputSchema: serverConfigOutputSchema,
         annotations: {
           title: "Get server configuration",
           readOnlyHint: true,
@@ -271,22 +319,25 @@ async function startServer() {
       async () => {
         const configSummary = ConfigService.getConfigSummary();
         const currentConfig = ConfigService.getConfig();
-        
+
+        const payload = {
+          ...(configSummary as Record<string, unknown>),
+          validation: ConfigService.validateConfig(currentConfig),
+          environmentOverrides: {
+            company: !!process.env.AHA_COMPANY,
+            token: !!process.env.AHA_TOKEN,
+            mode: !!process.env.MCP_TRANSPORT_MODE,
+            port: !!process.env.MCP_PORT,
+            host: !!process.env.MCP_HOST
+          }
+        };
+
         return {
           content: [{
             type: "text",
-            text: JSON.stringify({
-              ...configSummary,
-              validation: ConfigService.validateConfig(currentConfig),
-              environmentOverrides: {
-                company: !!process.env.AHA_COMPANY,
-                token: !!process.env.AHA_TOKEN,
-                mode: !!process.env.MCP_TRANSPORT_MODE,
-                port: !!process.env.MCP_PORT,
-                host: !!process.env.MCP_HOST
-              }
-            }, null, 2)
-          }]
+            text: JSON.stringify(payload, null, 2)
+          }],
+          structuredContent: payload
         };
       }
     );
@@ -294,8 +345,13 @@ async function startServer() {
     server.registerTool(
       "test_configuration",
       {
+        title: "Test Aha.io configuration",
         description: "Test current Aha.io configuration",
-        inputSchema: {},
+        // strictObject({}).optional(): a raw `{}` shape made `arguments` mandatory, so
+        // `tools/call` with no arguments at all - which the spec allows - failed input
+        // validation. Strict still rejects arguments this tool would ignore.
+        inputSchema: z.strictObject({}).optional(),
+        outputSchema: testConfigurationOutputSchema,
         annotations: {
           title: "Test Aha.io configuration",
           readOnlyHint: true,
@@ -305,52 +361,54 @@ async function startServer() {
       async () => {
         try {
           const config = ConfigService.getConfig();
-          
+
+          // Both failure paths below carry isError. They used to return a success-shaped
+          // result whose body said `success: false`, which clients render as a successful
+          // call and the spec reserves for results the model should treat as fact.
           if (!ConfigService.isConfigComplete(config)) {
             return {
               content: [{
                 type: "text",
-                text: JSON.stringify({
-                  success: false,
-                  error: "Configuration is incomplete. Company and token are required.",
-                  config: ConfigService.getConfigSummary()
-                }, null, 2)
-              }]
+                text: "Configuration is incomplete. Company and token are required.\n\n" +
+                  JSON.stringify(ConfigService.getConfigSummary(), null, 2)
+              }],
+              isError: true
             };
           }
 
           // Test connection by trying to get current user
           const user = await services.AhaService.getMe();
-          
+
+          const payload = {
+            success: true as const,
+            message: "Configuration test successful",
+            connection: {
+              status: "connected",
+              user: {
+                name: user.name || 'Unknown',
+                email: user.email || 'Unknown',
+                id: user.id || 'Unknown'
+              },
+              company: config.company ?? 'not configured'
+            }
+          };
+
           return {
             content: [{
               type: "text",
-              text: JSON.stringify({
-                success: true,
-                message: "Configuration test successful",
-                connection: {
-                  status: "connected",
-                  user: {
-                    name: user.name || 'Unknown',
-                    email: user.email || 'Unknown',
-                    id: user.id || 'Unknown'
-                  },
-                  company: config.company
-                }
-              }, null, 2)
-            }]
+              text: JSON.stringify(payload, null, 2)
+            }],
+            structuredContent: payload
           };
         } catch (error) {
           const errorMessage = describeAhaError(error);
           return {
             content: [{
               type: "text",
-              text: JSON.stringify({
-                success: false,
-                error: errorMessage,
-                suggestion: "Check your company subdomain and API token"
-              }, null, 2)
-            }]
+              text: `Configuration test failed: ${errorMessage}\n\n` +
+                "Check your company subdomain and API token."
+            }],
+            isError: true
           };
         }
       }

--- a/test/aha-errors.test.ts
+++ b/test/aha-errors.test.ts
@@ -138,3 +138,40 @@ describe('toMcpError', () => {
     expect(toMcpError(original)).toBe(original);
   });
 });
+
+describe('local system errors', () => {
+  /** What Node throws when the config file cannot be written. */
+  const systemError = () =>
+    Object.assign(new Error("EACCES: permission denied, open '/Users/someone/.aha-mcp-config.json'"), {
+      code: 'EACCES',
+      syscall: 'open',
+      path: '/Users/someone/.aha-mcp-config.json'
+    });
+
+  it('withholds the path but names the code', () => {
+    const message = describeAhaError(systemError());
+
+    expect(message).toContain('EACCES');
+    // A remote client over streamable-http has no business seeing a local path.
+    expect(message).not.toContain('/Users/someone');
+    expect(message).toMatch(/server log/);
+  });
+
+  it('still passes through messages this codebase authors', () => {
+    // Deliberately narrow: blanket redaction would make configure_server undebuggable.
+    const authored = new Error('Company subdomain is required.');
+
+    expect(describeAhaError(authored)).toBe('Company subdomain is required.');
+  });
+
+  it('does not mistake an axios transport failure for a local one', () => {
+    // Those carry a code too, but the hostname is worth telling the caller about.
+    const dns = Object.assign(new Error('getaddrinfo ENOTFOUND nope.aha.io'), {
+      isAxiosError: true,
+      code: 'ENOTFOUND',
+      syscall: 'getaddrinfo'
+    });
+
+    expect(describeAhaError(dns)).toMatch(/Could not reach Aha/);
+  });
+});

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -202,6 +202,56 @@ describe('E2E Streamable HTTP Transport', () => {
       }, { mode: 'streamable-http', timeout: 15000 });
     }, 20000);
 
+    it('should give every tool a display title in both spec locations', async () => {
+      await withTestClient(async (client) => {
+        const tools = await client.listTools();
+
+        // Tool.title is the current spec field; annotations.title is what pre-2025-06-18
+        // clients read, and the spec gives it precedence over `name` when `title` is
+        // absent. Both are populated so no client falls back to the underscored name -
+        // this asserts they stay in step rather than drifting apart.
+        const untitled = tools.filter(t => !t.title).map(t => t.name);
+        expect(untitled).toEqual([]);
+
+        for (const tool of tools) {
+          expect(tool.title).toBe(tool.annotations!.title);
+        }
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+
+    it('should declare a JSON Schema dialect the spec permits', async () => {
+      await withTestClient(async (client) => {
+        const tools = await client.listTools();
+
+        // The SDK converts Zod with a hardcoded draft-07 target, which the spec allows as an
+        // explicit dialect even though it recommends 2020-12. Pinned so an SDK upgrade that
+        // changes the target shows up here rather than in a client.
+        const dialects = new Set(
+          tools.map(t => (t.inputSchema as any).$schema ?? '2020-12 (no $schema, per spec default)')
+        );
+        for (const dialect of dialects) {
+          expect(['http://json-schema.org/draft-07/schema#', '2020-12 (no $schema, per spec default)'])
+            .toContain(dialect);
+        }
+
+        for (const tool of tools) {
+          // MUST be a valid schema object with an object root.
+          expect((tool.inputSchema as any).type).toBe('object');
+        }
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+
+    it('should accept a call on a no-argument tool with arguments omitted', async () => {
+      await withTestClient(async (client) => {
+        // `arguments` is optional in CallToolRequest, so leaving it out must not read as a
+        // malformed request.
+        const result: any = await client.callToolWithoutArguments('server_status');
+
+        expect(result.isError).toBeFalsy();
+        expect(result.structuredContent?.version).toBeDefined();
+      }, { mode: 'streamable-http', timeout: 15000 });
+    }, 20000);
+
     it('should call a tool via HTTP', async () => {
       await withTestClient(async (client) => {
         // Use a simple tool that doesn't require complex setup

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import * as z from 'zod/v4';
+import {
+  DEFAULT_RATE_LIMIT_PER_MINUTE,
+  TokenBucket,
+  configuredRateLimit,
+  installToolRateLimit
+} from '../src/core/rate-limit.js';
+
+describe('TokenBucket', () => {
+  it('allows a full burst, then refuses', () => {
+    const bucket = new TokenBucket({ perMinute: 3, now: () => 0 });
+
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).not.toBeNull();
+  });
+
+  it('reports a wait long enough that a token is there afterwards', () => {
+    let now = 0;
+    const bucket = new TokenBucket({ perMinute: 60, now: () => now });
+
+    expect(bucket.take()).toBeNull();
+    // Drain the remaining 59 tokens without advancing the clock.
+    for (let i = 0; i < 59; i++) bucket.take();
+
+    const wait = bucket.take();
+    expect(wait).not.toBeNull();
+
+    now += wait! * 1000;
+    expect(bucket.take()).toBeNull();
+  });
+
+  it('refills continuously rather than in windows', () => {
+    let now = 0;
+    const bucket = new TokenBucket({ perMinute: 60, now: () => now });
+    for (let i = 0; i < 60; i++) bucket.take();
+    expect(bucket.take()).not.toBeNull();
+
+    // 60/minute is one a second, so a second buys exactly one call, not a fresh window.
+    now += 1000;
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).not.toBeNull();
+  });
+
+  it('never refills beyond its capacity', () => {
+    let now = 0;
+    const bucket = new TokenBucket({ perMinute: 2, now: () => now });
+    now += 60 * 60 * 1000;
+
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).not.toBeNull();
+  });
+});
+
+describe('configuredRateLimit', () => {
+  it('defaults when unset', () => {
+    expect(configuredRateLimit({})).toBe(DEFAULT_RATE_LIMIT_PER_MINUTE);
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '' })).toBe(DEFAULT_RATE_LIMIT_PER_MINUTE);
+  });
+
+  it('reads an explicit limit, including 0 for disabled', () => {
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '30' })).toBe(30);
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '0' })).toBe(0);
+  });
+
+  it('falls back to the default on nonsense rather than refusing to start', () => {
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: 'lots' })).toBe(DEFAULT_RATE_LIMIT_PER_MINUTE);
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '-5' })).toBe(DEFAULT_RATE_LIMIT_PER_MINUTE);
+  });
+});
+
+describe('installToolRateLimit', () => {
+  const connect = async (perMinute: number, now?: () => number) => {
+    const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+    const bucket = installToolRateLimit(server, { perMinute, now });
+
+    let calls = 0;
+    server.registerTool(
+      'counted',
+      {
+        title: 'Counted',
+        description: 'Counts invocations that got past the limiter',
+        inputSchema: { value: z.string().optional() },
+        annotations: { title: 'Counted', readOnlyHint: true, openWorldHint: false }
+      },
+      async () => {
+        calls += 1;
+        return { content: [{ type: 'text' as const, text: `call ${calls}` }] };
+      }
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    return { client, bucket, calls: () => calls };
+  };
+
+  it('refuses over-budget calls as tool errors, not protocol errors', async () => {
+    const { client, calls } = await connect(2, () => 0);
+
+    expect((await client.callTool({ name: 'counted', arguments: {} })).isError).toBeFalsy();
+    expect((await client.callTool({ name: 'counted', arguments: {} })).isError).toBeFalsy();
+
+    const refused: any = await client.callTool({ name: 'counted', arguments: {} });
+    expect(refused.isError).toBe(true);
+    expect(refused.content[0].text).toContain('Rate limit reached');
+    // Actionable for a model: it says how long to wait.
+    expect(refused.content[0].text).toMatch(/Retry counted in \d+ seconds?/);
+
+    // The handler never ran for the refused call.
+    expect(calls()).toBe(2);
+  });
+
+  it('lets calls through again once the bucket refills', async () => {
+    let now = 0;
+    const { client } = await connect(60, () => now);
+    for (let i = 0; i < 60; i++) await client.callTool({ name: 'counted', arguments: {} });
+
+    expect((await client.callTool({ name: 'counted', arguments: {} })).isError).toBe(true);
+
+    now += 2000;
+    expect((await client.callTool({ name: 'counted', arguments: {} })).isError).toBeFalsy();
+  });
+
+  it('does not install a bucket when the limit is 0', async () => {
+    const { client, bucket } = await connect(0, () => 0);
+    expect(bucket).toBeNull();
+
+    for (let i = 0; i < 5; i++) {
+      expect((await client.callTool({ name: 'counted', arguments: {} })).isError).toBeFalsy();
+    }
+  });
+
+  it('leaves arguments and results untouched for calls it allows', async () => {
+    const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+    installToolRateLimit(server, { perMinute: 10, now: () => 0 });
+
+    server.registerTool(
+      'echo',
+      {
+        title: 'Echo',
+        description: 'Echoes its argument',
+        inputSchema: { value: z.string() },
+        outputSchema: z.looseObject({ value: z.string() }),
+        annotations: { title: 'Echo', readOnlyHint: true, openWorldHint: false }
+      },
+      async ({ value }) => ({
+        content: [{ type: 'text' as const, text: value }],
+        structuredContent: { value }
+      })
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const result: any = await client.callTool({ name: 'echo', arguments: { value: 'through' } });
+    expect(result.content[0].text).toBe('through');
+    expect(result.structuredContent).toEqual({ value: 'through' });
+  });
+});

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -165,3 +165,35 @@ describe('installToolRateLimit', () => {
     expect(result.structuredContent).toEqual({ value: 'through' });
   });
 });
+
+describe('robustness of the limiter against its inputs', () => {
+  it('does not drain the bucket when the clock moves backward', () => {
+    // An NTP correction mid-run used to make elapsed time negative, subtracting tokens.
+    let now = 1_000_000;
+    const bucket = new TokenBucket({ perMinute: 60, now: () => now });
+
+    expect(bucket.take()).toBeNull();
+    now -= 30_000; // clock corrected backwards
+    expect(bucket.take()).toBeNull();
+    expect(bucket.take()).toBeNull();
+  });
+
+  it('rejects a fractional limit instead of flooring it to "disabled"', () => {
+    // 0.5 used to floor to 0, and 0 is the documented way to switch rate limiting off - so a
+    // typo silently removed the limit, skipping the warning too.
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '0.5' })).toBe(
+      DEFAULT_RATE_LIMIT_PER_MINUTE
+    );
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '119.9' })).toBe(
+      DEFAULT_RATE_LIMIT_PER_MINUTE
+    );
+  });
+
+  it('still honours an explicit 0 as "disabled"', () => {
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '0' })).toBe(0);
+  });
+
+  it('still accepts a whole number', () => {
+    expect(configuredRateLimit({ MCP_TOOL_RATE_LIMIT_PER_MINUTE: '42' })).toBe(42);
+  });
+});

--- a/test/tool-structured-output.test.ts
+++ b/test/tool-structured-output.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerTools } from '../src/core/tools.js';
+import { registerSearchTools } from '../src/core/tools/search-tools.js';
+import { AhaService } from '../src/core/services/aha-service.js';
+import type { AhaGraphQLClient } from '../src/core/services/aha-graphql.js';
+
+/**
+ * These go through a real MCP client rather than calling handlers directly, because the
+ * client is what validates `structuredContent` against the advertised `outputSchema` and
+ * throws when they disagree. A call that returns at all is therefore the conformance
+ * assertion; the expects below are about content.
+ */
+async function connected(register: (server: McpServer) => void) {
+  const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+  register(server);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+// A record with the fields the output schemas describe, plus the ones they do not: the
+// extras are the point, since a closed schema would reject them at call time.
+const FEATURE = {
+  id: '6971110726488350000',
+  reference_num: 'PRJ1-123',
+  name: 'Structured output',
+  url: 'https://test.aha.io/features/PRJ1-123',
+  resource: 'https://test.aha.io/api/v1/features/PRJ1-123',
+  created_at: '2026-08-01T10:00:00.000Z',
+  updated_at: '2026-08-02T10:00:00.000Z',
+  progress: 40,
+  score: 12,
+  workflow_status: { id: '1', name: 'In development', complete: false },
+  description: { id: '2', body: '<p>nested object, undescribed by the schema</p>' },
+  custom_fields: [{ key: 'team', value: 'platform' }]
+};
+
+describe('Tool structured output', () => {
+  const patched: string[] = [];
+
+  const patch = (method: keyof typeof AhaService, impl: (...args: any[]) => Promise<any>) => {
+    patched.push(method as string);
+    (AhaService as any)[`__original_${method}`] = (AhaService as any)[method];
+    (AhaService as any)[method] = impl;
+  };
+
+  afterEach(() => {
+    for (const method of patched) {
+      (AhaService as any)[method] = (AhaService as any)[`__original_${method}`];
+      delete (AhaService as any)[`__original_${method}`];
+    }
+    patched.length = 0;
+  });
+
+  it('advertises an output schema on every tool', async () => {
+    const client = await connected(registerTools);
+    const tools = (await client.listTools()).tools;
+
+    const without = tools.filter(t => !t.outputSchema).map(t => t.name);
+    expect(without).toEqual([]);
+  });
+
+  it('leaves record schemas open so undescribed Aha fields survive the round trip', async () => {
+    const client = await connected(registerTools);
+    const tools = (await client.listTools()).tools;
+    const schema = tools.find(t => t.name === 'aha_update_feature')!.outputSchema as any;
+
+    // additionalProperties: false here would make every record-returning tool fail on the
+    // first field Aha adds that the schema does not list.
+    expect(schema.additionalProperties).not.toBe(false);
+    expect(Object.keys(schema.properties)).toContain('reference_num');
+  });
+
+  it('returns the record as structuredContent, and the same JSON in the text block', async () => {
+    patch('updateFeature', async () => FEATURE);
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_update_feature',
+      arguments: { featureId: 'PRJ1-123', featureData: { feature: { name: 'Structured output' } } }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual(FEATURE);
+    // The text block stays the backwards-compatible copy for clients that ignore
+    // structuredContent, so it must carry the same record.
+    expect(result.content[0].text).toContain(JSON.stringify(FEATURE, null, 2));
+  });
+
+  it('describes deletions rather than returning an empty body', async () => {
+    patch('deleteFeature', async () => undefined);
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_delete_feature',
+      arguments: { featureId: 'PRJ1-123' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({
+      deleted: true,
+      record_type: 'feature',
+      id: 'PRJ1-123'
+    });
+  });
+
+  it('omits structuredContent on failures and flags them with isError', async () => {
+    patch('updateFeature', async () => {
+      throw new Error('Request failed with status code 404');
+    });
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_update_feature',
+      arguments: { featureId: 'NOPE-1', featureData: { feature: { name: 'x' } } }
+    });
+
+    // Output validation is skipped for error results, which is what lets a tool with an
+    // output schema report a failure at all.
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content[0].text).toContain('404');
+  });
+
+  it('survives a create endpoint that answers with no body', async () => {
+    patch('createFeature', async () => undefined);
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_create_feature',
+      arguments: { releaseId: 'PRJ1-R-1', featureData: { feature: { name: 'no body back' } } }
+    });
+
+    // An absent structuredContent would be a protocol error, so the tool sends {}.
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({});
+  });
+
+  it('links the record it touched, so the client can re-read it as a resource', async () => {
+    patch('updateFeature', async () => FEATURE);
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_update_feature',
+      arguments: { featureId: 'PRJ1-123', featureData: { feature: { name: 'Structured output' } } }
+    });
+
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    expect(link).toBeDefined();
+    // reference_num over id: it is the identifier people recognise, and the resource
+    // template accepts either.
+    expect(link.uri).toBe('aha://feature/PRJ1-123');
+    expect(link.name).toBe('Structured output');
+  });
+
+  it('falls back to the requested id when the response carries no identifier', async () => {
+    patch('updateFeatureProgress', async () => ({ progress: 60 }));
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_update_feature_progress',
+      arguments: { featureId: 'PRJ1-123', progress: 60 }
+    });
+
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    expect(link.uri).toBe('aha://feature/PRJ1-123');
+  });
+
+  it('emits no link when there is no identifier to link to', async () => {
+    patch('createFeature', async () => undefined);
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_create_feature',
+      arguments: { releaseId: 'PRJ1-R-1', featureData: { feature: { name: 'no body back' } } }
+    });
+
+    // A resource_link to aha://feature/undefined would be worse than none at all.
+    expect(result.content.some((c: any) => c.type === 'resource_link')).toBe(false);
+  });
+
+  it('unwraps the responses Aha nests under a single key', async () => {
+    const idea = { id: '123', reference_num: 'PRJ1-I-4', name: 'Wrapped idea', score: 3 };
+    patch('createIdea', async () => ({ idea }));
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_create_idea',
+      arguments: { productId: 'PRJ1', ideaData: { idea: { name: 'Wrapped idea' } } }
+    });
+
+    // Aha answers idea creation with { idea: {...} }. structuredContent is the record
+    // itself, so one contract holds whether or not a record type arrives wrapped.
+    expect(result.structuredContent).toEqual(idea);
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    expect(link.uri).toBe('aha://idea/PRJ1-I-4');
+  });
+
+  it('returns the search envelope as structured content', async () => {
+    const fakeClient = {
+      searchDocuments: async () => ({
+        totalCount: 2,
+        totalCountIsCapped: false,
+        currentPage: 1,
+        totalPages: 1,
+        isLastPage: true,
+        results: [
+          {
+            name: 'Login flow',
+            searchableType: 'Feature',
+            searchableId: 'PRJ1-1',
+            projectId: '123',
+            url: 'https://test.aha.io/features/PRJ1-1',
+            updatedAt: '2026-08-01T10:00:00.000Z'
+          },
+          {
+            // A hit with the nullable fields actually null, which the schema allows.
+            name: null,
+            searchableType: 'Idea',
+            searchableId: null,
+            projectId: null,
+            url: 'https://test.aha.io/ideas/PRJ1-I-1',
+            updatedAt: '2026-08-02T10:00:00.000Z'
+          }
+        ]
+      })
+    } as unknown as AhaGraphQLClient;
+
+    const client = await connected(server => registerSearchTools(server, fakeClient));
+    const result: any = await client.callTool({
+      name: 'aha_search',
+      arguments: { query: 'login' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent.total_count).toBe(2);
+    expect(result.structuredContent.total_count_is_capped).toBe(false);
+    expect(result.structuredContent.record_types).toBe('all');
+    expect(result.structuredContent.workspace_id).toBeNull();
+    expect(result.structuredContent.results).toHaveLength(2);
+    expect(result.structuredContent.results[0].url).toBe('https://test.aha.io/features/PRJ1-1');
+  });
+});

--- a/test/utils/mcp-client-helper.ts
+++ b/test/utils/mcp-client-helper.ts
@@ -428,6 +428,17 @@ export class TestMCPClient {
   }
 
   /**
+   * Call a tool without an `arguments` member at all, which CallToolRequest permits for
+   * tools that take no parameters. `callTool` above always sends one, so it cannot cover
+   * this case.
+   */
+  async callToolWithoutArguments(name: string): Promise<any> {
+    this.ensureConnected();
+
+    return this.client!.callTool({ name });
+  }
+
+  /**
    * Check if client is connected
    */
   isConnected(): boolean {


### PR DESCRIPTION
Closes the gaps between the tool surface and the [2026-07-28 tools spec](https://modelcontextprotocol.io/specification/2026-07-28/server/tools), one at a time. 31 tools, verified against the built server over stdio.

## What was missing

**`outputSchema` / `structuredContent` — zero coverage.** Every tool returned a prose prefix plus `JSON.stringify(record)`. All 31 now declare a schema and return structured content, keeping the serialised JSON in a text block for clients that ignore it. Schemas live in `src/core/tool-output.ts`, where two rules are load-bearing:

- Anything wrapping an Aha record is a `z.looseObject`. A raw Zod shape converts to `additionalProperties: false`, and the SDK **client** rejects a result carrying keys the schema does not list — which would have broken every record-returning tool on the first field Aha adds. Payloads the server builds itself (deletions, search, server/config tools) are closed objects.
- Only fields Aha reliably returns are described, permissively typed. The server validates its own `structuredContent` and turns a mismatch into a protocol error, so an optimistic guess fails the call rather than degrading.

`structuredContent` is always the record itself — `unwrapRecord()` flattens the `{ idea: … }` / `{ initiative: … }` responses so one contract covers every record type.

**No top-level `Tool.title`.** All 31 had only `annotations.title`. Both are now populated (the latter is what pre-2025-06-18 clients read), and an e2e test asserts they stay identical.

**No `resource_link` results.** 20 single-record tools now link to the record's `aha://…` URI — `reference_num` preferred, falling back to the requested id — so a client can re-read live state instead of trusting the point-in-time copy. No identifier means no link, rather than a link to an unreadable URI.

**No rate limiting**, which the spec requires of servers. `src/core/rate-limit.ts` wraps `server.registerTool` rather than each handler, so a future tool cannot forget it; the bucket is process-wide because what it protects is Aha's API, which every session shares. Refusals are `isError` results naming the seconds to wait. Default 120/minute via `MCP_TOOL_RATE_LIMIT_PER_MINUTE`, `0` disables.

**Failures reported as successes.** `test_configuration` and `configure_server` returned `success: false` in a success-shaped result, which clients render as a successful call. Both now set `isError`.

**Zero-argument tools rejected spec-legal calls.** `inputSchema: {}` made `arguments` mandatory, so a `tools/call` omitting it — which `CallToolRequest` allows — failed input validation. The four now use `z.strictObject({}).optional()`.

## Deliberately not changed

The draft-07 `$schema` on input schemas comes from the SDK: `toJsonSchemaCompat` hardcodes a `draft-7` target and never passes `target` for tools. The spec permits an explicit dialect and only *recommends* 2020-12, so this conforms — overriding `tools/list` to rewrite schemas would be fragile for a RECOMMENDED-level item. Instead the dialect is documented (the spec's actual SHOULD) and pinned by an e2e test, so an SDK upgrade surfaces here rather than in a client.

Everything else new in this revision is unreachable on `@modelcontextprotocol/sdk@1.30.0`, whose `LATEST_PROTOCOL_VERSION` is `2025-11-25`: `resultType`, `InputRequiredResult`/MRTR elicitation from `tools/call`, `subscriptions/listen`-gated `list_changed`, `tools/list` caching, `x-mcp-header`, and tool `icons` (in `ToolSchema` but not exposed by `registerTool`).

## Incidental fixes

`AhaService.createFeature` was typed `Promise<void>` while returning a body; retyped `unknown` with the interface and mock aligned. Note the separate pre-existing bug it exposed, left for its own PR: `aha_create_feature` ignores `featureData` entirely, because `releasesReleaseIdFeaturesPost` in aha-js takes no request body.

## Verification

- 390 tests pass, up from 365. New: `test/tool-structured-output.test.ts` (structured results, unwrapping, links, error paths — routed through a real MCP client, so the client's own schema validation is the conformance assertion) and `test/rate-limit.test.ts`.
- `bunx tsc --noEmit` shows no new errors against the 8 pre-existing ones.
- `bun run build` then `node build/index.js --help` still starts; `bun run mcpb:validate` passes and `manifest.json` still matches the registered tools exactly, so no regeneration was needed.

## Breaking

The title carries `!` for the response-shape changes: the two config tools' failure results, the unwrapped idea/initiative records (in both `structuredContent` and the text block), zero-argument tools now rejecting stray arguments that were previously ignored, and any tool being refusable once the rate limit is reached. Drop the `!` when squashing if you read those as non-breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured output for records, searches, deletions, health checks, and configuration tools.
  - Added resource links and clearer record identifiers in responses.
  - Added configurable tool-call rate limiting, defaulting to 120 calls per minute, with retry guidance.
  - Added support for Streamable HTTP transport and improved tool display titles.

- **Bug Fixes**
  - Configuration failures now return proper error responses.
  - Tools can be called without arguments when appropriate.

- **Documentation**
  - Documented rate-limit configuration and expanded tool behavior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->