### PR TITLE
fix: send the feature payload when creating a feature

### DIFF
--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1376,13 +1376,24 @@ export class AhaService {
    * whatever Aha sends back is undeclared. The tool treats a missing body as an empty
    * record rather than assuming a feature came back.
    */
-  public static async createFeature(releaseId: string, _featureData: any): Promise<unknown> {
+  public static async createFeature(releaseId: string, featureData: any): Promise<unknown> {
     const defaultApi = this.getDefaultApi();
 
+    // Aha documents the body as `{"feature": {...}}`, so tolerate either shape from callers:
+    // the tool sends it already wrapped, but a bare record should not silently create nothing.
+    // https://www.aha.io/api/resources/features/create_a_feature
+    const payload = featureData?.feature ? featureData : { feature: featureData ?? {} };
+
     try {
-      const response = await defaultApi.releasesReleaseIdFeaturesPost({
-        releaseId: releaseId
-      });
+      // `releasesReleaseIdFeaturesPost` is generated as `(releaseId, options)` - the operation
+      // is declared without a request body, so there was no parameter to put the feature in
+      // and every create sent an empty POST. The payload goes through axios' own `data`
+      // option, which the generated client spreads into the request config; that is the only
+      // route to a body until the operation is regenerated with one.
+      const response = await defaultApi.releasesReleaseIdFeaturesPost(
+        { releaseId: releaseId },
+        { data: payload, headers: { "Content-Type": "application/json" } }
+      );
       return response.data;
     } catch (error) {
       log.error('Error creating feature in release', error as Error, { operation: 'createFeature', release_id: releaseId });

--- a/test/create-feature.test.ts
+++ b/test/create-feature.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * The tool tests cannot catch this: they stub the service out, so nothing would notice the
+ * request going out with no body at all. This injects a fake DefaultApi and inspects what the
+ * request would actually carry.
+ */
+describe('AhaService.createFeature', () => {
+  const original = (AhaService as any).defaultApi;
+  let call: { params: any; options: any } | null;
+
+  beforeEach(() => {
+    call = null;
+    (AhaService as any).defaultApi = {
+      releasesReleaseIdFeaturesPost: async (params: any, options: any) => {
+        call = { params, options };
+        return { data: { feature: { id: '1', reference_num: 'PRJ1-1' } } };
+      }
+    };
+  });
+
+  afterEach(() => {
+    (AhaService as any).defaultApi = original;
+  });
+
+  it('sends the feature in the request body', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'Silence by label' } });
+
+    expect(call!.params.releaseId).toBe('PRJ1-R-1');
+    // The whole bug: this used to be undefined, so Aha received an empty POST.
+    expect(call!.options.data).toEqual({ feature: { name: 'Silence by label' } });
+  });
+
+  it('wraps a bare record rather than posting it unwrapped', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { name: 'Silence by label' });
+
+    expect(call!.options.data).toEqual({ feature: { name: 'Silence by label' } });
+  });
+
+  it('does not double-wrap an already wrapped payload', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(call!.options.data.feature.feature).toBeUndefined();
+  });
+
+  it('sends JSON', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(call!.options.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('still posts a feature key when given nothing', async () => {
+    // Better an empty feature Aha can reject than a bodyless POST it silently accepts.
+    await AhaService.createFeature('PRJ1-R-1', undefined);
+
+    expect(call!.options.data).toEqual({ feature: {} });
+  });
+
+  it('returns what Aha sends back, so the caller can link the new record', async () => {
+    const created = await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(created).toEqual({ feature: { id: '1', reference_num: 'PRJ1-1' } } as any);
+  });
+
+  it('propagates a rejection instead of reporting success', async () => {
+    (AhaService as any).defaultApi = {
+      releasesReleaseIdFeaturesPost: async () => {
+        throw new Error('422 Unprocessable Entity');
+      }
+    };
+
+    await expect(
+      AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } })
+    ).rejects.toThrow('422 Unprocessable Entity');
+  });
+});


### PR DESCRIPTION
Raised by review on #313, pulled out into its own PR because it predates that branch and is worse than its inline rating suggested.

`aha_create_feature` posted **nothing**. `releasesReleaseIdFeaturesPost` is generated as `(releaseId, options)` — the operation is declared without a request body, so there was no parameter for the feature, and the argument was named `_featureData` to silence the unused-parameter warning. Aha accepts the empty POST, so the tool reported success while the name and description went nowhere.

Same bug as #304 fixed in `updateFeatureCustomFields`: an operation the generator emitted without a body. That is twice now in the same client — worth watching for a third.

## Verified on the wire, not assumed

The payload goes through axios' `data` option, which the generated client spreads into the request config. I pointed the SDK at a local server to confirm it arrives:

```
POST /releases/PRJ1-R-1/features
Content-Type: application/json
{"feature":{"name":"Silence by label"}}
```

That matches [Aha's documented body](https://www.aha.io/api/resources/features/create_a_feature) — `{"feature":{"name":"New name", ...}}`.

## Details

Either shape is accepted from callers: the tool sends `{feature: {...}}` already, but a bare record used to create nothing at all, so it is wrapped rather than posted unwrapped. `undefined` still posts `{feature: {}}` — better an empty feature Aha can reject than a bodyless POST it silently accepts.

7 tests inject a fake `DefaultApi` and inspect the request. The tool-level tests could not have caught this: they stub the service out, so nothing would notice a request going out with no body. That is the same blind spot the mock fix in #313 closes from the other side.

423 pass, 0 fail. `tsc --noEmit` unchanged at 8 pre-existing.

## Still unverified

I have not watched this create a real feature — that would mean writing to the live workspace. The request is confirmed well-formed and matches the docs, but the round trip is worth one manual call on a scratch release before relying on it.