### PR TITLE
feat!: migrate to aha-js 2.0.0 and drop endpoints Aha never had

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,23 @@ updates:
       interval: "daily"
     assignees:
       - "cedricziel"
+    groups:
+      # Linting and commit-hook tooling moves together and never affects the
+      # published bundle, so it arrives as one PR rather than one per package.
+      # The eslint/prettier patterns are here so adding a linter later does not
+      # silently start opening ungrouped PRs again.
+      lint:
+        patterns:
+          - "commitlint"
+          - "@commitlint/*"
+          - "husky"
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "prettier-*"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@cedricziel/aha-mcp",
       "dependencies": {
-        "@cedricziel/aha-js": "1.2.5",
+        "@cedricziel/aha-js": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.12.2",
         "cors": "^2.8.5",
@@ -34,7 +34,7 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
-    "@cedricziel/aha-js": ["@cedricziel/aha-js@1.2.5", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-AOLvID4QaDPnTzQuecuSc3nSCr6AeWZH2/ytpLgOdQNeHTTIlQhQcfI6Ok88k61vDzPIFZrOZXcomj79aVCrKg=="],
+    "@cedricziel/aha-js": ["@cedricziel/aha-js@2.0.0", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-FOoMk0uf1Ya/CjmHo83gqERX4FoTrqouZOKQI+GFoKKJ7tomVt25dLei2JulLsPcUTj9ELSZrYvcf2/Ib03sLg=="],
 
     "@commitlint/cli": ["@commitlint/cli@21.2.1", "", { "dependencies": { "@commitlint/config-conventional": "^21.2.0", "@commitlint/format": "^21.2.0", "@commitlint/lint": "^21.2.0", "@commitlint/load": "^21.2.0", "@commitlint/read": "^21.2.1", "@commitlint/types": "^21.2.0", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@cedricziel/aha-js": "1.2.5",
+    "@cedricziel/aha-js": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.12.2",
     "cors": "^2.8.5",

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -725,7 +725,7 @@ I can help you find and use Aha.io resources. Here's how to get started:
 - \`aha://products\` - List all products/workspaces
 - \`aha://features\` - Search features globally
 - \`aha://ideas\` - Search ideas and feedback
-- \`aha://releases\` - List releases/workstreams
+- \`aha://releases/{product_id}\` - List releases/workstreams for a product (get the id from \`aha://products\`)
 
 **Common Questions:**
 
@@ -736,7 +736,7 @@ A: Use \`aha://products\` - in Aha.io, products and workspaces are the same thin
 A: Product Areas are not currently exposed as resources. Use \`aha://products\` to access products, which may include area information in the response.
 
 **Q: "How do I find workstreams?"**
-A: Use \`aha://releases\` - releases function as workstreams for organizing work.
+A: Use \`aha://releases/{product_id}\` - releases function as workstreams for organizing work. Get the product id from \`aha://products\` first.
 
 **Resource Navigation Pattern:**
 1. Start with top-level resources (products, features, ideas, releases)

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -38,7 +38,7 @@ const RESOURCE_SYNONYMS = {
   },
   workstream: {
     canonical: "release",
-    resources: ["aha_release", "aha_releases"],
+    resources: ["aha_release", "aha_product_releases"],
     note: "Releases can function as workstreams for organizing features and epics"
   }
 };
@@ -66,12 +66,12 @@ export function registerResources(server: McpServer) {
             terminology_guide: {
               product_workspace: "Products and workspaces are the same in Aha.io. Use aha://products or aha://product/{id}",
               product_areas: "Product Areas are subdivisions within products. Not currently available as resources.",
-              releases_workstreams: "Releases can be used as workstreams. Use aha://releases or aha://release/{id}"
+              releases_workstreams: "Releases can be used as workstreams. Use aha://releases/{product_id} or aha://release/{id}"
             },
             common_questions: {
               "How do I find workspaces?": "Use aha://products - products and workspaces are synonymous",
               "How do I find Product Areas?": "Product Areas are not currently exposed as resources. Use products instead.",
-              "Where are workstreams?": "Releases can function as workstreams - use aha://releases"
+              "Where are workstreams?": "Releases can function as workstreams - use aha://releases/{product_id}"
             }
           }, null, 2),
           mimeType: "application/json"
@@ -1199,75 +1199,9 @@ export function registerResources(server: McpServer) {
     }
   );
 
-  // Aha releases list resource with filters and pagination
-  // Shared handler for both base URI and template URI
-  const handleReleases = async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
-    try {
-      const parkingLot = variables?.parkingLot === 'true' ? true :
-                        variables?.parkingLot === 'false' ? false :
-                        uri.searchParams.get('parkingLot') === 'true' ? true :
-                        uri.searchParams.get('parkingLot') === 'false' ? false : undefined;
-      const page = variables?.page ? parseInt(normalizeVar(variables.page)!) : uri.searchParams.get('page') ? parseInt(uri.searchParams.get('page')!) : undefined;
-      const perPage = variables?.perPage ? parseInt(normalizeVar(variables.perPage)!) : uri.searchParams.get('perPage') ? parseInt(uri.searchParams.get('perPage')!) : undefined;
-
-      const releases = await getAhaService().listReleases(
-        normalizeVar(variables?.query) || uri.searchParams.get('query') || undefined,
-        normalizeVar(variables?.updatedSince) || uri.searchParams.get('updatedSince') || undefined,
-        normalizeVar(variables?.assignedToUser) || uri.searchParams.get('assignedToUser') || undefined,
-        normalizeVar(variables?.status) || uri.searchParams.get('status') || undefined,
-        parkingLot,
-        page,
-        perPage
-      );
-
-      return {
-        contents: [{
-          uri: uri.toString(),
-          text: JSON.stringify(releases, null, 2),
-          mimeType: "application/json"
-        }]
-      };
-    } catch (error) {
-      console.error(`Error retrieving releases list:`, error);
-      throw toMcpError(error, uri.toString());
-    }
-  };
-
-  // Base URI registration - matches aha://releases
-  server.registerResource(
-    "aha_releases",
-    "aha://releases",
-    {
-      title: "Aha Releases",
-      description: "List all releases",
-      mimeType: "application/json"
-    },
-    async (uri: URL, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
-      return handleReleases(uri, {}, _extra);
-    }
-  );
-
-  // Template URI registration - matches aha://releases?query=...
-  server.registerResource(
-    "aha_releases_filtered",
-    new ResourceTemplate(
-      "aha://releases{?query,updatedSince,assignedToUser,status,parkingLot,page,perPage}",
-      {
-        list: undefined,
-        complete: {
-          parkingLot: async () => ['true', 'false'],
-          page: async () => ['1', '2', '3', '4', '5'],
-          perPage: async () => ['20', '50', '100', '200']
-        }
-      }
-    ),
-    {
-      title: "Aha Releases (Filtered)",
-      description: "List releases with filters and pagination",
-      mimeType: "application/json"
-    },
-    handleReleases
-  );
+  // Note: a global "list all releases" resource (GET /releases) was removed - that endpoint
+  // does not exist in Aha's OpenAPI document or published docs and always 404s. Releases are
+  // only reachable scoped to a product; see aha_product_releases (aha://releases/{product_id}).
 
   // Aha release features resource
   server.registerResource(
@@ -1967,46 +1901,8 @@ export function registerResources(server: McpServer) {
     }
   );
 
-  // Aha idea watchers resource
-  server.registerResource(
-    "aha_idea_watchers",
-    new ResourceTemplate(
-      "aha://idea/{id}/watchers",
-      {
-        list: undefined,
-        complete: {
-          id: async () => []
-        }
-      }
-    ),
-    {
-      title: "Aha Idea Watchers",
-      description: "Get watchers for a specific idea",
-      mimeType: "application/json"
-    },
-    async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
-      const pathParts = uri.pathname.split('/');
-      const ideaId = normalizeVar(variables.id) || pathParts[pathParts.length - 2]; // idea_id is before /watchers
-
-      if (!ideaId) {
-        throw new Error('Invalid idea ID: Idea ID is missing from URI');
-      }
-
-      try {
-        const watchers = await getAhaService().getIdeaWatchers(ideaId);
-        return {
-          contents: [{
-            uri: uri.toString(),
-            text: JSON.stringify(watchers, null, 2),
-            mimeType: "application/json"
-          }]
-        };
-      } catch (error) {
-        console.error(`Error retrieving watchers for idea ${ideaId}:`, error);
-        throw toMcpError(error, uri.toString());
-      }
-    }
-  );
+  // Note: aha_idea_watchers (GET /ideas/{id}/watchers) was removed - that endpoint does not
+  // exist in Aha's OpenAPI document or published docs and always 404s.
 
   // Aha global ideas list resource with advanced filters and pagination
   // Shared handler for both base URI and template URI

--- a/src/core/sampling.ts
+++ b/src/core/sampling.ts
@@ -68,7 +68,7 @@ export function registerSampling(server: McpServer) {
 - **aha://products** - List all products/workspaces
 - **aha://features** - Search features across all products
 - **aha://ideas** - Search ideas and feedback
-- **aha://releases** - List releases/workstreams
+- **aha://releases/{product_id}** - List releases/workstreams for a product (get the id from aha://products)
 
 What would you like to explore?`
           }

--- a/src/core/sampling/resource-primer.ts
+++ b/src/core/sampling/resource-primer.ts
@@ -90,20 +90,21 @@ export function generateWorkstreamPrimer(query: string): ResourcePrimer {
   return {
     message: `I notice you're looking for workstreams. In Aha.io, **releases can function as workstreams** for organizing features and epics.`,
     suggestedResources: [
-      'aha://releases - List all releases/workstreams',
+      'aha://releases/{product_id} - List releases for a specific product',
       'aha://release/{id} - Get a specific release/workstream',
-      'aha://releases/{product_id} - List releases for a specific product'
+      'aha://products - List products, to find the product_id a release list needs'
     ],
     exampleUris: [
-      'aha://releases?status=active&page=1',
+      'aha://releases/PROD-1?status=active&page=1',
       'aha://release/PROJ-R-1',
       'aha://releases/PROD-1'
     ],
     workflow: [
-      '1. List releases: aha://releases (optionally filtered by product)',
-      '2. Get release details: aha://release/{id}',
-      '3. Access release features: aha://release/{id}/features',
-      '4. Access release epics: aha://release/{id}/epics'
+      '1. Get a product id: aha://products',
+      '2. List that product\'s releases: aha://releases/{product_id}',
+      '3. Get release details: aha://release/{id}',
+      '4. Access release features: aha://release/{id}/features',
+      '5. Access release epics: aha://release/{id}/epics'
     ]
   };
 }
@@ -119,7 +120,7 @@ export function generateDiscoveryPrimer(): ResourcePrimer {
       'aha://products - List all products/workspaces',
       'aha://features - Search features globally',
       'aha://ideas - Search ideas globally',
-      'aha://releases - List all releases'
+      'aha://releases/{product_id} - List releases for a product'
     ],
     exampleUris: [
       'aha://resources',
@@ -129,7 +130,7 @@ export function generateDiscoveryPrimer(): ResourcePrimer {
     ],
     workflow: [
       '1. Check aha://resources to understand available resources and terminology',
-      '2. Start with top-level resources like products, features, ideas, or releases',
+      '2. Start with top-level resources like products, features, or ideas',
       '3. Navigate to nested resources once you have IDs (e.g., product → releases → features)',
       '4. Use query parameters for filtering and pagination'
     ]

--- a/src/core/services/aha-service.interface.ts
+++ b/src/core/services/aha-service.interface.ts
@@ -1,50 +1,51 @@
 /**
  * Interface for AhaService - allows for mock implementations in tests
+ *
+ * Every method speaks in the local domain types from `../types/aha-types.js`, never in
+ * `@cedricziel/aha-js` types. The SDK is generated per-operation and renames every export
+ * on each regeneration (`Feature` -> `FeaturesGetResponseFeaturesInner`, etc.); leaking
+ * those through here would re-break every call site the next time aha-js regenerates.
+ * `aha-service.ts` is the only file allowed to import from `@cedricziel/aha-js` - it is
+ * responsible for mapping the SDK's response shapes onto the types below.
  */
 
 import type {
   Feature,
   FeaturesListResponse,
   Epic,
+  EpicsListResponse,
   User,
   IdeaResponse,
+  IdeasListResponse,
   InitiativeResponse,
   InitiativesListResponse,
+  Product,
   ProductsListResponse,
-  CommentsGetEpic200Response,
-  EpicsList200Response,
-  IdeasListResponse,
   Comment,
+  CommentsListResponse,
   GoalGetResponse,
-  GoalsListResponse as SdkGoalsListResponse,
+  GoalsListResponse,
+  GoalEpicsResponse,
   ReleaseGetResponse,
-  ReleasesListResponse as SdkReleasesListResponse,
-  ReleasePhasesList200Response,
-  ReleasePhase as SdkReleasePhase,
+  ReleasesListResponse,
+  ReleaseFeaturesResponse,
+  ReleasePhase,
+  ReleasePhasesListResponse,
   Competitor,
-  StrategicModelGetResponse,
-  StrategicModelsListResponse,
+  CompetitorsListResponse,
   StrategicModel,
-  IdeaOrganizationGetResponse,
-  IdeaOrganizationsListResponse,
+  StrategicModelsListResponse,
   IdeaOrganization,
-  TodosList200Response,
+  IdeaOrganizationsListResponse,
+  Todo,
+  TodosListResponse,
+  Requirement,
   MeAssignedRecordsResponse,
   MePendingTasksResponse,
-  IdeasGetEndorsements200Response,
-  IdeasGetVotes200Response,
-  IdeasGetWatchers200Response,
-  CustomFieldsListAll200Response,
-  CustomFieldsListOptions200Response
-} from '@cedricziel/aha-js';
-
-import type {
-  Product,
-  Requirement,
-  Todo,
-  ReleaseFeaturesResponse,
-  GoalEpicsResponse,
-  CompetitorsListResponse
+  IdeaEndorsementsResponse,
+  IdeaVotesResponse,
+  CustomFieldDefinitionsResponse,
+  CustomFieldOptionsResponse
 } from '../types/aha-types.js';
 
 export interface IAhaService {
@@ -100,19 +101,10 @@ export interface IAhaService {
     status?: string,
     page?: number,
     perPage?: number
-  ): Promise<SdkGoalsListResponse>;
+  ): Promise<GoalsListResponse>;
   getGoal(goalId: string): Promise<GoalGetResponse>;
 
   // Releases
-  listReleases(
-    query?: string,
-    updatedSince?: string,
-    assignedToUser?: string,
-    status?: string,
-    parkingLot?: boolean,
-    page?: number,
-    perPage?: number
-  ): Promise<SdkReleasesListResponse>;
   getRelease(releaseId: string): Promise<ReleaseGetResponse>;
 
   // Strategic Models
@@ -163,28 +155,28 @@ export interface IAhaService {
   getMe(): Promise<User>;
 
   // Epics
-  listEpics(productId: string): Promise<EpicsList200Response>;
+  listEpics(productId: string): Promise<EpicsListResponse>;
   getEpic(epicId: string): Promise<Epic>;
 
   // Todos
-  listTodos(): Promise<TodosList200Response>;
+  listTodos(): Promise<TodosListResponse>;
   getTodo(todoId: string): Promise<Todo>;
 
   // Release Phases
-  listReleasePhases(): Promise<ReleasePhasesList200Response>;
-  getReleasePhase(releasePhaseId: string): Promise<SdkReleasePhase>;
+  listReleasePhases(): Promise<ReleasePhasesListResponse>;
+  getReleasePhase(releasePhaseId: string): Promise<ReleasePhase>;
 
   // Comments
   createFeatureComment(featureId: string, body: string): Promise<Comment>;
-  getEpicComments(epicId: string): Promise<CommentsGetEpic200Response>;
-  getIdeaComments(ideaId: string): Promise<CommentsGetEpic200Response>;
-  getInitiativeComments(initiativeId: string): Promise<CommentsGetEpic200Response>;
-  getProductComments(productId: string): Promise<CommentsGetEpic200Response>;
-  getGoalComments(goalId: string): Promise<CommentsGetEpic200Response>;
-  getReleaseComments(releaseId: string): Promise<CommentsGetEpic200Response>;
-  getReleasePhaseComments(releasePhaseId: string): Promise<CommentsGetEpic200Response>;
-  getRequirementComments(requirementId: string): Promise<CommentsGetEpic200Response>;
-  getTodoComments(todoId: string): Promise<CommentsGetEpic200Response>;
+  getEpicComments(epicId: string): Promise<CommentsListResponse>;
+  getIdeaComments(ideaId: string): Promise<CommentsListResponse>;
+  getInitiativeComments(initiativeId: string): Promise<CommentsListResponse>;
+  getProductComments(productId: string): Promise<CommentsListResponse>;
+  getGoalComments(goalId: string): Promise<CommentsListResponse>;
+  getReleaseComments(releaseId: string): Promise<CommentsListResponse>;
+  getReleasePhaseComments(releasePhaseId: string): Promise<CommentsListResponse>;
+  getRequirementComments(requirementId: string): Promise<CommentsListResponse>;
+  getTodoComments(todoId: string): Promise<CommentsListResponse>;
 
   // Additional list methods
   listIdeasByProduct(
@@ -208,14 +200,14 @@ export interface IAhaService {
     parkingLot?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<SdkReleasesListResponse>;
+  ): Promise<ReleasesListResponse>;
   listCompetitors(productId: string): Promise<CompetitorsListResponse>;
 
   // Relationships
   getGoalEpics(goalId: string): Promise<GoalEpicsResponse>;
   getReleaseFeatures(releaseId: string): Promise<ReleaseFeaturesResponse>;
-  getReleaseEpics(releaseId: string): Promise<EpicsList200Response>;
-  getInitiativeEpics(initiativeId: string): Promise<EpicsList200Response>;
+  getReleaseEpics(releaseId: string): Promise<EpicsListResponse>;
+  getInitiativeEpics(initiativeId: string): Promise<EpicsListResponse>;
 
   // Me/Current User
   getAssignedRecords(): Promise<MeAssignedRecordsResponse>;
@@ -227,13 +219,12 @@ export interface IAhaService {
     proxy?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetEndorsements200Response>;
+  ): Promise<IdeaEndorsementsResponse>;
   getIdeaVotes(
     ideaId: string,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetVotes200Response>;
-  getIdeaWatchers(ideaId: string): Promise<IdeasGetWatchers200Response>;
+  ): Promise<IdeaVotesResponse>;
 
   // Requirements
   getRequirement(requirementId: string): Promise<Requirement>;
@@ -242,6 +233,6 @@ export interface IAhaService {
   getCompetitor(competitorId: string): Promise<Competitor>;
 
   // Custom Fields
-  listCustomFields(): Promise<CustomFieldsListAll200Response>;
-  listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldsListOptions200Response>;
+  listCustomFields(): Promise<CustomFieldDefinitionsResponse>;
+  listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldOptionsResponse>;
 }

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -7,43 +7,39 @@ import type {
   Feature,
   FeaturesListResponse,
   Epic,
+  EpicsListResponse,
   User,
   IdeaResponse,
+  IdeasListResponse,
   InitiativeResponse,
   InitiativesListResponse,
+  Product,
   ProductsListResponse,
-  CommentsGetEpic200Response,
-  EpicsList200Response,
-  IdeasListResponse,
   Comment,
+  CommentsListResponse,
   GoalGetResponse,
-  GoalsListResponse as SdkGoalsListResponse,
+  GoalsListResponse,
+  GoalEpicsResponse,
   ReleaseGetResponse,
-  ReleasesListResponse as SdkReleasesListResponse,
-  ReleasePhasesList200Response,
-  ReleasePhase as SdkReleasePhase,
+  ReleasesListResponse,
+  ReleaseFeaturesResponse,
+  ReleasePhase,
+  ReleasePhasesListResponse,
   Competitor,
-  StrategicModelsListResponse,
+  CompetitorsListResponse,
   StrategicModel,
-  IdeaOrganizationsListResponse,
+  StrategicModelsListResponse,
   IdeaOrganization,
-  TodosList200Response,
+  IdeaOrganizationsListResponse,
+  Todo,
+  TodosListResponse,
+  Requirement,
   MeAssignedRecordsResponse,
   MePendingTasksResponse,
-  IdeasGetEndorsements200Response,
-  IdeasGetVotes200Response,
-  IdeasGetWatchers200Response,
-  CustomFieldsListAll200Response,
-  CustomFieldsListOptions200Response
-} from '@cedricziel/aha-js';
-
-import type {
-  Product,
-  Requirement,
-  Todo,
-  ReleaseFeaturesResponse,
-  GoalEpicsResponse,
-  CompetitorsListResponse
+  IdeaEndorsementsResponse,
+  IdeaVotesResponse,
+  CustomFieldDefinitionsResponse,
+  CustomFieldOptionsResponse
 } from '../types/aha-types.js';
 
 // Mock data generators
@@ -241,7 +237,7 @@ export class MockAhaService implements IAhaService {
     _status?: string,
     page?: number,
     perPage?: number
-  ): Promise<SdkGoalsListResponse> {
+  ): Promise<GoalsListResponse> {
     const count = Math.min(perPage || 20, 3);
     return {
       goals: Array.from({ length: count }, (_, i) => generateMockGoal(i + 1)),
@@ -250,31 +246,11 @@ export class MockAhaService implements IAhaService {
         total_pages: 1,
         current_page: page || 1
       }
-    } as SdkGoalsListResponse;
+    } as GoalsListResponse;
   }
 
   async getGoal(_goalId: string): Promise<GoalGetResponse> {
     return generateMockGoal(1) as GoalGetResponse;
-  }
-
-  async listReleases(
-    _query?: string,
-    _updatedSince?: string,
-    _assignedToUser?: string,
-    _status?: string,
-    _parkingLot?: boolean,
-    page?: number,
-    perPage?: number
-  ): Promise<SdkReleasesListResponse> {
-    const count = Math.min(perPage || 20, 3);
-    return {
-      releases: Array.from({ length: count }, (_, i) => generateMockRelease(i + 1)),
-      pagination: {
-        total_records: count,
-        total_pages: 1,
-        current_page: page || 1
-      }
-    } as SdkReleasesListResponse;
   }
 
   async getRelease(_releaseId: string): Promise<ReleaseGetResponse> {
@@ -375,28 +351,28 @@ export class MockAhaService implements IAhaService {
     } as User;
   }
 
-  async listEpics(_productId: string): Promise<EpicsList200Response> {
-    return { epics: [] } as EpicsList200Response;
+  async listEpics(_productId: string): Promise<EpicsListResponse> {
+    return { epics: [] } as EpicsListResponse;
   }
 
   async getEpic(_epicId: string): Promise<Epic> {
     return { id: 'EPIC-1', name: 'Test Epic' } as Epic;
   }
 
-  async listTodos(): Promise<TodosList200Response> {
-    return { tasks: [] } as TodosList200Response;
+  async listTodos(): Promise<TodosListResponse> {
+    return { todos: [] } as TodosListResponse;
   }
 
   async getTodo(_todoId: string): Promise<Todo> {
     return { id: 'TODO-1', description: 'Test Todo' } as Todo;
   }
 
-  async listReleasePhases(): Promise<ReleasePhasesList200Response> {
-    return { release_phases: [] } as ReleasePhasesList200Response;
+  async listReleasePhases(): Promise<ReleasePhasesListResponse> {
+    return { release_phases: [] } as ReleasePhasesListResponse;
   }
 
-  async getReleasePhase(_releasePhaseId: string): Promise<SdkReleasePhase> {
-    return { id: 'PHASE-1', name: 'Test Phase' } as SdkReleasePhase;
+  async getReleasePhase(_releasePhaseId: string): Promise<ReleasePhase> {
+    return { id: 'PHASE-1', name: 'Test Phase' } as ReleasePhase;
   }
 
   async createFeatureComment(_featureId: string, body: string): Promise<Comment> {
@@ -407,40 +383,40 @@ export class MockAhaService implements IAhaService {
     } as Comment;
   }
 
-  async getEpicComments(_epicId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getEpicComments(_epicId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getIdeaComments(_ideaId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getIdeaComments(_ideaId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getInitiativeComments(_initiativeId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getInitiativeComments(_initiativeId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getProductComments(_productId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getProductComments(_productId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getGoalComments(_goalId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getGoalComments(_goalId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getReleaseComments(_releaseId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getReleaseComments(_releaseId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getReleasePhaseComments(_releasePhaseId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getReleasePhaseComments(_releasePhaseId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getRequirementComments(_requirementId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getRequirementComments(_requirementId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getTodoComments(_todoId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getTodoComments(_todoId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
   async listIdeasByProduct(_productId: string): Promise<IdeasListResponse> {
@@ -450,11 +426,11 @@ export class MockAhaService implements IAhaService {
     } as IdeasListResponse;
   }
 
-  async listReleasesByProduct(_productId: string): Promise<SdkReleasesListResponse> {
+  async listReleasesByProduct(_productId: string): Promise<ReleasesListResponse> {
     return {
       releases: Array.from({ length: 3 }, (_, i) => generateMockRelease(i + 1)),
       pagination: { total_records: 3, total_pages: 1, current_page: 1 }
-    } as SdkReleasesListResponse;
+    } as ReleasesListResponse;
   }
 
   async listCompetitors(_productId: string): Promise<CompetitorsListResponse> {
@@ -469,12 +445,12 @@ export class MockAhaService implements IAhaService {
     return { features: [] } as ReleaseFeaturesResponse;
   }
 
-  async getReleaseEpics(_releaseId: string): Promise<EpicsList200Response> {
-    return { epics: [] } as EpicsList200Response;
+  async getReleaseEpics(_releaseId: string): Promise<EpicsListResponse> {
+    return { epics: [] } as EpicsListResponse;
   }
 
-  async getInitiativeEpics(_initiativeId: string): Promise<EpicsList200Response> {
-    return { epics: [] } as EpicsList200Response;
+  async getInitiativeEpics(_initiativeId: string): Promise<EpicsListResponse> {
+    return { epics: [] } as EpicsListResponse;
   }
 
   async getAssignedRecords(): Promise<MeAssignedRecordsResponse> {
@@ -485,16 +461,12 @@ export class MockAhaService implements IAhaService {
     return { tasks: [] } as MePendingTasksResponse;
   }
 
-  async getIdeaEndorsements(_ideaId: string): Promise<IdeasGetEndorsements200Response> {
-    return { endorsements: [] } as IdeasGetEndorsements200Response;
+  async getIdeaEndorsements(_ideaId: string): Promise<IdeaEndorsementsResponse> {
+    return { idea_endorsements: [] } as IdeaEndorsementsResponse;
   }
 
-  async getIdeaVotes(_ideaId: string): Promise<IdeasGetVotes200Response> {
-    return { votes: [] } as IdeasGetVotes200Response;
-  }
-
-  async getIdeaWatchers(_ideaId: string): Promise<IdeasGetWatchers200Response> {
-    return { watchers: [] } as IdeasGetWatchers200Response;
+  async getIdeaVotes(_ideaId: string): Promise<IdeaVotesResponse> {
+    return { idea_endorsements: [] } as IdeaVotesResponse;
   }
 
   async getRequirement(_requirementId: string): Promise<Requirement> {
@@ -505,11 +477,11 @@ export class MockAhaService implements IAhaService {
     return { id: 'COMP-1', name: 'Test Competitor' } as Competitor;
   }
 
-  async listCustomFields(): Promise<CustomFieldsListAll200Response> {
-    return { custom_fields: [] } as CustomFieldsListAll200Response;
+  async listCustomFields(): Promise<CustomFieldDefinitionsResponse> {
+    return { custom_field_definitions: [] } as CustomFieldDefinitionsResponse;
   }
 
-  async listCustomFieldOptions(_customFieldDefinitionId: string): Promise<CustomFieldsListOptions200Response> {
-    return { options: [] } as CustomFieldsListOptions200Response;
+  async listCustomFieldOptions(_customFieldDefinitionId: string): Promise<CustomFieldOptionsResponse> {
+    return { options: [] } as CustomFieldOptionsResponse;
   }
 }

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1427,10 +1427,16 @@ export class AhaService {
   public static async createFeature(releaseId: string, featureData: any): Promise<unknown> {
     const featuresApi = this.getFeaturesApi();
 
+    // Aha documents the body as `{"feature": {...}}`, so tolerate either shape from callers:
+    // the tool's schema sends it already wrapped, but a bare record from a direct caller
+    // should not post an unwrapped body Aha will quietly do nothing with.
+    // https://www.aha.io/api/resources/features/create_a_feature
+    const payload = featureData?.feature ? featureData : { feature: featureData ?? {} };
+
     try {
       const response = await featuresApi.releasesByReleaseFeaturesPost({
         releaseId: releaseId,
-        featuresPostRequest: featureData ?? {}
+        featuresPostRequest: payload
       });
       return response.data;
     } catch (error) {

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -13,62 +13,64 @@ import {
   RequirementsApi,
   ReleasePhasesApi,
   ReleasesApi,
-  DefaultApi,
   MeApi,
   StrategicModelsApi,
   IdeaOrganizationsApi,
   IdeaVotesApi,
-  CustomFieldsApi,
-  // Types
-  Feature,
-  FeaturesListResponse,
-  Epic,
-  User,
-  IdeaResponse,
-  InitiativeResponse,
-  InitiativesListResponse,
-  ProductsListResponse,
-  CommentsGetEpic200Response,
-  EpicsList200Response,
-  IdeasListResponse,
-  Comment,
-  // Additional SDK response types
-  GoalGetResponse,
-  GoalsListResponse as SdkGoalsListResponse,
-  ReleaseGetResponse,
-  ReleasesListResponse as SdkReleasesListResponse,
-  ReleasePhasesList200Response,
-  ReleasePhase as SdkReleasePhase,
-  Competitor,
-  StrategicModelGetResponse,
-  StrategicModelsListResponse,
-  StrategicModel,
-  IdeaOrganizationGetResponse,
-  IdeaOrganizationsListResponse,
-  IdeaOrganization,
-  TodosList200Response,
-  MeAssignedRecordsResponse,
-  MePendingTasksResponse,
-  IdeasGetEndorsements200Response,
-  IdeasGetVotes200Response,
-  IdeasGetWatchers200Response,
-  CustomFieldsListAll200Response,
-  CustomFieldsListOptions200Response
+  CustomFieldsApi
 } from '@cedricziel/aha-js';
 
 import {
+  Feature,
+  FeaturesListResponse,
+  Epic,
+  EpicsListResponse,
+  User,
+  IdeaResponse,
+  IdeasListResponse,
+  InitiativeResponse,
+  InitiativesListResponse,
   Product,
-  Requirement,
-  Todo,
-  ReleaseFeaturesResponse,
+  ProductsListResponse,
+  Comment,
+  CommentsListResponse,
+  GoalGetResponse,
+  GoalsListResponse,
   GoalEpicsResponse,
-  CompetitorsListResponse
+  ReleaseGetResponse,
+  ReleasesListResponse,
+  ReleaseFeaturesResponse,
+  ReleasePhase,
+  ReleasePhasesListResponse,
+  Competitor,
+  CompetitorsListResponse,
+  StrategicModel,
+  StrategicModelsListResponse,
+  IdeaOrganization,
+  IdeaOrganizationsListResponse,
+  Todo,
+  TodosListResponse,
+  Requirement,
+  MeAssignedRecordsResponse,
+  MePendingTasksResponse,
+  IdeaEndorsementsResponse,
+  IdeaVotesResponse,
+  CustomFieldDefinitionsResponse,
+  CustomFieldDefinition,
+  CustomFieldOptionsResponse,
+  RecordRef,
+  Pagination
 } from '../types/aha-types.js';
 
 import { log } from '../logger.js';
 
 /**
  * Service for interacting with the Aha.io API
+ *
+ * This is the only file in the repo that may import from `@cedricziel/aha-js`. The SDK is
+ * generated per-operation from Aha's official OpenAPI document and renames every export on
+ * each regeneration, so every method here maps one `*Api` call onto the stable domain types
+ * in `../types/aha-types.js` at the boundary - see `aha-service.interface.ts` for why.
  */
 export class AhaService {
   private static configuration: Configuration | null = null;
@@ -85,7 +87,6 @@ export class AhaService {
   private static requirementsApi: RequirementsApi | null = null;
   private static releasePhasesApi: ReleasePhasesApi | null = null;
   private static releasesApi: ReleasesApi | null = null;
-  private static defaultApi: DefaultApi | null = null;
   private static meApi: MeApi | null = null;
   private static strategicModelsApi: StrategicModelsApi | null = null;
   private static ideaOrganizationsApi: IdeaOrganizationsApi | null = null;
@@ -149,13 +150,35 @@ export class AhaService {
 
   /**
    * Current credentials, for callers that need to reach Aha.io outside the generated
-   * aha-js REST client - notably the GraphQL API, which aha-js does not cover.
+   * aha-js REST client - notably the GraphQL API (which aha-js does not cover) and the
+   * hand-rolled competitor update/delete calls below, whose endpoints exist in neither.
    *
    * Read through this rather than from process.env so that credentials supplied at runtime
    * via configure_server are picked up too.
    */
   public static getCredentials(): { subdomain: string | null; accessToken: string | null } {
     return { subdomain: this.subdomain, accessToken: this.accessToken };
+  }
+
+  /** Every generated list endpoint types `page`/`perPage` (and several other filters) as strings. */
+  private static numParam(value?: number): string | undefined {
+    return value === undefined ? undefined : String(value);
+  }
+
+  private static boolParam(value?: boolean): string | undefined {
+    return value === undefined ? undefined : String(value);
+  }
+
+  /**
+   * Builds the `options.params` object for filters Aha's OpenAPI document omits from a
+   * generated request type. Every generated method still spreads its second `options`
+   * argument into the axios request config, and axios merges `params` into the query string
+   * the generated call already built - so this is how a filter Aha genuinely accepts gets
+   * back on the wire. Strips `undefined` entries so an unused filter is left off the query
+   * string instead of being sent as the literal string `"undefined"`.
+   */
+  private static extraParams(params: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined));
   }
 
   /**
@@ -166,8 +189,11 @@ export class AhaService {
     const meApi = this.getMeApi();
 
     try {
-      const response = await meApi.meGetProfile();
-      return response.data.user;
+      const response = await meApi.meGet();
+      // Generator defect: `meGet` shares its generated response type with `meTasksGet`
+      // (`{ tasks, pagination }`); the endpoint genuinely returns the current user under `user`.
+      const data = response.data as unknown as { user?: User };
+      return data.user as User;
     } catch (error) {
       log.error('Error getting current user', error as Error, { operation: 'getMe' });
       throw error;
@@ -214,7 +240,6 @@ export class AhaService {
       this.requirementsApi = new RequirementsApi(this.configuration);
       this.releasePhasesApi = new ReleasePhasesApi(this.configuration);
       this.releasesApi = new ReleasesApi(this.configuration);
-      this.defaultApi = new DefaultApi(this.configuration);
       this.meApi = new MeApi(this.configuration);
       this.strategicModelsApi = new StrategicModelsApi(this.configuration);
       this.ideaOrganizationsApi = new IdeaOrganizationsApi(this.configuration);
@@ -371,17 +396,6 @@ export class AhaService {
   }
 
   /**
-   * Get the default API instance
-   * @returns DefaultApi instance
-   */
-  private static getDefaultApi(): DefaultApi {
-    if (!this.defaultApi) {
-      this.initializeClient();
-    }
-    return this.defaultApi!;
-  }
-
-  /**
    * Get the me API instance
    * @returns MeApi instance
    */
@@ -457,15 +471,24 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        tag,
-        assignedToUser
-      });
-      return response.data;
+      // `q`, `updatedSince`, `tag` and `assignedToUser` are sent via `options.params` because
+      // Aha's spec under-documents this endpoint's query string - only pagination and
+      // `fields`/`workflow_status` (unused here) remain in the generated request type.
+      const response = await featuresApi.featuresGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            tag,
+            assigned_to_user: assignedToUser
+          })
+        }
+      );
+      return response.data as unknown as FeaturesListResponse;
     } catch (error) {
       // This method alone used to time itself and read a status code off the error, then use
       // neither - leftovers from tracing that was removed. The status travels with the error
@@ -484,11 +507,15 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresGet({ id: featureId });
-      if (!response.data.feature) {
+      const response = await featuresApi.featuresByIdGet({ id: featureId });
+      // Generator defect: `featuresByIdGet` is typed as returning the list response
+      // (`{ features, pagination }`); the endpoint genuinely returns a single feature
+      // wrapped as `{ feature }`.
+      const data = response.data as unknown as { feature?: Feature };
+      if (!data.feature) {
         throw new Error(`Feature ${featureId} not found`);
       }
-      return response.data.feature;
+      return data.feature;
     } catch (error) {
       log.error('Error getting feature', error as Error, { operation: 'getFeature', feature_id: featureId });
       throw error;
@@ -503,9 +530,11 @@ export class AhaService {
     const usersApi = this.getUsersApi();
 
     try {
-      // Use the appropriate method from the UsersApi
-      const response = await usersApi.usersList();
-      return { users: response.data };
+      const response = await usersApi.usersGet();
+      // Generator defect: `usersGet` is typed as `{ user_roles, pagination }`, reused from an
+      // unrelated operation. The endpoint returns `{ users, pagination }`.
+      const data = response.data as unknown as { users?: User[] };
+      return { users: data.users ?? [] };
     } catch (error) {
       log.error('Error listing users', error as Error, { operation: 'listUsers' });
       throw error;
@@ -521,8 +550,10 @@ export class AhaService {
     const usersApi = this.getUsersApi();
 
     try {
-      const response = await usersApi.usersGet({ id: userId });
-      return response.data;
+      const response = await usersApi.usersByIdGet({ id: userId });
+      // Generator defect: typed as `{ user_roles, pagination }`; the endpoint returns the
+      // user object directly with no wrapper.
+      return response.data as unknown as User;
     } catch (error) {
       log.error('Error getting user', error as Error, { operation: 'getUser', user_id: userId });
       throw error;
@@ -534,15 +565,12 @@ export class AhaService {
    * @param productId The ID of the product
    * @returns A list of epics
    */
-  public static async listEpics(productId: string): Promise<EpicsList200Response> {
+  public static async listEpics(productId: string): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      // Use the appropriate method from the EpicsApi with the correct parameter format
-      const response = await epicsApi.epicsListInProduct({
-        productId: productId
-      });
-      return response.data;
+      const response = await epicsApi.productsByProductEpicsGet({ productId });
+      return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error listing epics for product', error as Error, { operation: 'listEpics', product_id: productId });
       throw error;
@@ -558,8 +586,11 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsGet({ epicId });
-      return response.data;
+      const response = await epicsApi.epicsByIdGet({ id: epicId });
+      // Generator defect: `epicsByIdGet` is typed as returning the list response
+      // (`{ epics, pagination }`); the endpoint genuinely returns a single epic with no
+      // wrapper.
+      return response.data as unknown as Epic;
     } catch (error) {
       log.error('Error getting epic', error as Error, { operation: 'getEpic', epic_id: epicId });
       throw error;
@@ -576,14 +607,14 @@ export class AhaService {
     const commentsApi = this.getCommentsApi();
 
     try {
-      // Use the appropriate method from the CommentsApi with the correct parameter format
-      const response = await commentsApi.commentsCreateFeature({
+      const response = await commentsApi.featuresByFeatureCommentsPost({
         featureId: featureId,
-        commentCreateRequest: {
-          body: body
+        commentsPostRequest: {
+          comment: { body }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { comment?: Comment };
+      return data.comment as Comment;
     } catch (error) {
       log.error('Error creating comment on feature', error as Error, { operation: 'createFeatureComment', feature_id: featureId });
       throw error;
@@ -599,8 +630,11 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasGetById({ id: ideaId });
-      return response.data;
+      const response = await ideasApi.ideasByIdGet({ id: ideaId });
+      // Generator defect: `ideasByIdGet` is typed as returning the list response
+      // (`{ ideas, pagination }`); the endpoint genuinely returns a single idea wrapped as
+      // `{ idea }`.
+      return response.data as unknown as IdeaResponse;
     } catch (error) {
       log.error('Error getting idea', error as Error, { operation: 'getIdea', idea_id: ideaId });
       throw error;
@@ -616,19 +650,15 @@ export class AhaService {
     const productsApi = this.getProductsApi();
 
     try {
-      const response = await productsApi.productsGet({ id: productId });
-      return response.data.product;
+      const response = await productsApi.productsByIdGet({ id: productId });
+      const data = response.data as unknown as { product?: Product };
+      return data.product as Product;
     } catch (error) {
       log.error('Error getting product', error as Error, { operation: 'getProduct', product_id: productId });
       throw error;
     }
   }
 
-  /**
-   * List products from Aha.io
-   * @param updatedSince UTC timestamp (ISO8601 format) (optional)
-   * @returns A list of products
-   */
   /**
    * List products from Aha.io
    * @param updatedSince Filter by updated since date (optional)
@@ -644,12 +674,18 @@ export class AhaService {
     const productsApi = this.getProductsApi();
 
     try {
-      const response = await productsApi.productsList({
-        page,
-        perPage,
-        updatedSince
-      });
-      return response.data;
+      // Generator defect: `productsGet` (list) shares its response type with
+      // `productsByIdGet` (`{ product }`, singular); the endpoint returns `{ products, pagination }`.
+      // `updatedSince` is sent via `options.params` because Aha's spec under-documents this
+      // endpoint's query string.
+      const response = await productsApi.productsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        { params: this.extraParams({ updated_since: updatedSince }) }
+      );
+      return response.data as unknown as ProductsListResponse;
     } catch (error) {
       log.error('Error listing products', error as Error, { operation: 'listProducts' });
       throw error;
@@ -665,8 +701,11 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesGet({ id: initiativeId });
-      return response.data;
+      const response = await initiativesApi.initiativesByIdGet({ id: initiativeId });
+      // Generator defect: `initiativesByIdGet` is typed as returning the list response
+      // (`{ initiatives, pagination }`); the endpoint genuinely returns a single initiative
+      // wrapped as `{ initiative }`.
+      return response.data as unknown as InitiativeResponse;
     } catch (error) {
       log.error('Error getting initiative', error as Error, { operation: 'getInitiative', initiative_id: initiativeId });
       throw error;
@@ -694,15 +733,25 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        onlyActive
-      });
-      return response.data;
+      // `q`, `updatedSince`, `assignedToUser` and `onlyActive` are sent via `options.params`
+      // because Aha's spec under-documents this endpoint's query string - only pagination
+      // (plus `custom_fields` and `workflow_status`, which this service does not expose)
+      // remain in the generated request type.
+      const response = await initiativesApi.initiativesGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            assigned_to_user: assignedToUser,
+            only_active: onlyActive
+          })
+        }
+      );
+      return response.data as unknown as InitiativesListResponse;
     } catch (error) {
       log.error('Error listing initiatives', error as Error, { operation: 'listInitiatives' });
       throw error;
@@ -740,20 +789,25 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasListProduct({ 
-        productId: productId,
-        q: query,
-        spam,
-        workflowStatus,
-        sort: sort as any, // Cast to any since the enum type is not exported
-        createdBefore,
-        createdSince,
-        updatedSince,
-        tag,
-        userId,
-        ideaUserId
-      });
-      return response.data;
+      // `ideaUserId` has no equivalent in the generated request type for this endpoint, so it
+      // is sent via `options.params` because Aha's spec under-documents this endpoint's query
+      // string.
+      const response = await ideasApi.productsByProductIdeasGet(
+        {
+          productId: productId,
+          q: query,
+          spam: this.boolParam(spam),
+          workflowStatus,
+          sort,
+          createdBefore,
+          createdSince,
+          updatedSince,
+          tag,
+          userId
+        },
+        { params: this.extraParams({ idea_user_id: ideaUserId }) }
+      );
+      return response.data as unknown as IdeasListResponse;
     } catch (error) {
       log.error('Error listing ideas for product', error as Error, { operation: 'listIdeasByProduct', product_id: productId });
       throw error;
@@ -765,12 +819,12 @@ export class AhaService {
    * @param epicId The ID of the epic
    * @returns A list of comments for the epic
    */
-  public static async getEpicComments(epicId: string): Promise<CommentsGetEpic200Response> {
+  public static async getEpicComments(epicId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetEpic({ epicId });
-      return response.data;
+      const response = await commentsApi.epicsByEpicCommentsGet({ epicId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for epic', error as Error, { operation: 'getEpicComments', epic_id: epicId });
       throw error;
@@ -782,12 +836,12 @@ export class AhaService {
    * @param ideaId The ID of the idea
    * @returns A list of comments for the idea
    */
-  public static async getIdeaComments(ideaId: string): Promise<CommentsGetEpic200Response> {
+  public static async getIdeaComments(ideaId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetIdea({ ideaId });
-      return response.data;
+      const response = await commentsApi.ideasByIdeaCommentsGet({ ideaId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for idea', error as Error, { operation: 'getIdeaComments', idea_id: ideaId });
       throw error;
@@ -799,12 +853,12 @@ export class AhaService {
    * @param initiativeId The ID of the initiative
    * @returns A list of comments for the initiative
    */
-  public static async getInitiativeComments(initiativeId: string): Promise<CommentsGetEpic200Response> {
+  public static async getInitiativeComments(initiativeId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetInitiative({ initiativeId });
-      return response.data;
+      const response = await commentsApi.initiativesByInitiativeCommentsGet({ initiativeId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for initiative', error as Error, { operation: 'getInitiativeComments', initiative_id: initiativeId });
       throw error;
@@ -816,12 +870,12 @@ export class AhaService {
    * @param productId The ID of the product
    * @returns A list of comments for the product
    */
-  public static async getProductComments(productId: string): Promise<CommentsGetEpic200Response> {
+  public static async getProductComments(productId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetProduct({ productId });
-      return response.data;
+      const response = await commentsApi.productsByProjectCommentsGet({ projectId: productId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for product', error as Error, { operation: 'getProductComments', product_id: productId });
       throw error;
@@ -833,12 +887,12 @@ export class AhaService {
    * @param goalId The ID of the goal
    * @returns A list of comments for the goal
    */
-  public static async getGoalComments(goalId: string): Promise<CommentsGetEpic200Response> {
+  public static async getGoalComments(goalId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetGoal({ goalId });
-      return response.data;
+      const response = await commentsApi.goalsByGoalCommentsGet({ goalId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for goal', error as Error, { operation: 'getGoalComments', goal_id: goalId });
       throw error;
@@ -850,12 +904,12 @@ export class AhaService {
    * @param releaseId The ID of the release
    * @returns A list of comments for the release
    */
-  public static async getReleaseComments(releaseId: string): Promise<CommentsGetEpic200Response> {
+  public static async getReleaseComments(releaseId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetRelease({ releaseId });
-      return response.data;
+      const response = await commentsApi.releasesByReleaseCommentsGet({ releaseId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for release', error as Error, { operation: 'getReleaseComments', release_id: releaseId });
       throw error;
@@ -867,12 +921,12 @@ export class AhaService {
    * @param releasePhaseId The ID of the release phase
    * @returns A list of comments for the release phase
    */
-  public static async getReleasePhaseComments(releasePhaseId: string): Promise<CommentsGetEpic200Response> {
+  public static async getReleasePhaseComments(releasePhaseId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetReleasePhase({ releasePhaseId });
-      return response.data;
+      const response = await commentsApi.releasePhasesByReleasePhaseCommentsGet({ releasePhaseId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for release phase', error as Error, { operation: 'getReleasePhaseComments', release_phase_id: releasePhaseId });
       throw error;
@@ -884,12 +938,12 @@ export class AhaService {
    * @param requirementId The ID of the requirement
    * @returns A list of comments for the requirement
    */
-  public static async getRequirementComments(requirementId: string): Promise<CommentsGetEpic200Response> {
+  public static async getRequirementComments(requirementId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetRequirement({ requirementId });
-      return response.data;
+      const response = await commentsApi.requirementsByRequirementCommentsGet({ requirementId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for requirement', error as Error, { operation: 'getRequirementComments', requirement_id: requirementId });
       throw error;
@@ -901,12 +955,12 @@ export class AhaService {
    * @param todoId The ID of the todo
    * @returns A list of comments for the todo
    */
-  public static async getTodoComments(todoId: string): Promise<CommentsGetEpic200Response> {
+  public static async getTodoComments(todoId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetTodo({ todoId });
-      return response.data;
+      const response = await commentsApi.tasksByTaskCommentsGet({ taskId: todoId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for todo', error as Error, { operation: 'getTodoComments', todo_id: todoId });
       throw error;
@@ -922,8 +976,11 @@ export class AhaService {
     const goalsApi = this.getGoalsApi();
 
     try {
-      const response = await goalsApi.goalsGet({ id: goalId });
-      return response.data;
+      const response = await goalsApi.goalsByIdGet({ id: goalId });
+      // Generator defect: `goalsByIdGet` is typed as returning the list response
+      // (`{ goals, pagination }`); the endpoint genuinely returns a single goal wrapped as
+      // `{ goal }`.
+      return response.data as unknown as GoalGetResponse;
     } catch (error) {
       log.error('Error getting goal', error as Error, { operation: 'getGoal', goal_id: goalId });
       throw error;
@@ -947,19 +1004,28 @@ export class AhaService {
     status?: string,
     page?: number,
     perPage?: number
-  ): Promise<SdkGoalsListResponse> {
+  ): Promise<GoalsListResponse> {
     const goalsApi = this.getGoalsApi();
 
     try {
-      const response = await goalsApi.goalsList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        status
-      });
-      return response.data;
+      // `q`, `updatedSince`, `assignedToUser` and `status` are sent via `options.params`
+      // because Aha's spec under-documents this endpoint's query string - only pagination
+      // remains in the generated request type.
+      const response = await goalsApi.goalsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            assigned_to_user: assignedToUser,
+            status
+          })
+        }
+      );
+      return response.data as unknown as GoalsListResponse;
     } catch (error) {
       log.error('Error listing goals', error as Error, { operation: 'listGoals' });
       throw error;
@@ -975,8 +1041,8 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsListByGoal({ goalId });
-      return response.data;
+      const response = await epicsApi.goalsByGoalEpicsGet({ goalId });
+      return response.data as unknown as GoalEpicsResponse;
     } catch (error) {
       log.error('Error getting epics for goal', error as Error, { operation: 'getGoalEpics', goal_id: goalId });
       throw error;
@@ -992,49 +1058,13 @@ export class AhaService {
     const releasesApi = this.getReleasesApi();
 
     try {
-      const response = await releasesApi.releasesGet({ id: releaseId });
-      return response.data;
+      const response = await releasesApi.releasesByIdGet({ id: releaseId });
+      // Generator defect: `releasesByIdGet` is typed as returning the list response
+      // (`{ releases, pagination }`); the endpoint genuinely returns a single release wrapped
+      // as `{ release }`.
+      return response.data as unknown as ReleaseGetResponse;
     } catch (error) {
       log.error('Error getting release', error as Error, { operation: 'getRelease', release_id: releaseId });
-      throw error;
-    }
-  }
-
-  /**
-   * List releases from Aha.io
-   * @param query Search query (optional)
-   * @param updatedSince Filter by updated since date (optional)
-   * @param assignedToUser Filter by assigned user (optional)
-   * @param status Filter by status (optional)
-   * @param parkingLot Filter by parking lot (optional)
-   * @param page Page number for pagination (optional)
-   * @param perPage Number of items per page (max 200) (optional)
-   * @returns A list of releases
-   */
-  public static async listReleases(
-    query?: string,
-    updatedSince?: string,
-    assignedToUser?: string,
-    status?: string,
-    parkingLot?: boolean,
-    page?: number,
-    perPage?: number
-  ): Promise<SdkReleasesListResponse> {
-    const releasesApi = this.getReleasesApi();
-
-    try {
-      const response = await releasesApi.releasesList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        status,
-        parkingLot
-      });
-      return response.data;
-    } catch (error) {
-      log.error('Error listing releases', error as Error, { operation: 'listReleases' });
       throw error;
     }
   }
@@ -1073,12 +1103,12 @@ export class AhaService {
    * @param releaseId The ID of the release
    * @returns A list of epics associated with the release
    */
-  public static async getReleaseEpics(releaseId: string): Promise<EpicsList200Response> {
+  public static async getReleaseEpics(releaseId: string): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsListInRelease({ releaseId });
-      return response.data;
+      const response = await epicsApi.releasesByReleaseEpicsGet({ releaseId });
+      return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error getting epics for release', error as Error, { operation: 'getReleaseEpics', release_id: releaseId });
       throw error;
@@ -1090,15 +1120,19 @@ export class AhaService {
    * @param releasePhaseId The ID of the release phase
    * @returns The release phase details
    */
-  public static async getReleasePhase(releasePhaseId: string): Promise<SdkReleasePhase> {
+  public static async getReleasePhase(releasePhaseId: string): Promise<ReleasePhase> {
     const releasePhasesApi = this.getReleasePhasesApi();
 
     try {
-      const response = await releasePhasesApi.releasePhasesGet({ id: releasePhaseId });
-      if (!response.data.release_phase) {
+      const response = await releasePhasesApi.releasePhasesByIdGet({ id: releasePhaseId });
+      // Generator defect: `releasePhasesByIdGet` is typed as returning the list response
+      // (`{ release_phases, pagination }`); the endpoint genuinely returns a single release
+      // phase wrapped as `{ release_phase }`.
+      const data = response.data as unknown as { release_phase?: ReleasePhase };
+      if (!data.release_phase) {
         throw new Error(`Release phase ${releasePhaseId} not found`);
       }
-      return response.data.release_phase;
+      return data.release_phase;
     } catch (error) {
       log.error('Error getting release phase', error as Error, { operation: 'getReleasePhase', release_phase_id: releasePhaseId });
       throw error;
@@ -1109,12 +1143,12 @@ export class AhaService {
    * List release phases from Aha.io
    * @returns A list of release phases
    */
-  public static async listReleasePhases(): Promise<ReleasePhasesList200Response> {
+  public static async listReleasePhases(): Promise<ReleasePhasesListResponse> {
     const releasePhasesApi = this.getReleasePhasesApi();
 
     try {
-      const response = await releasePhasesApi.releasePhasesList();
-      return response.data;
+      const response = await releasePhasesApi.releasePhasesGet();
+      return response.data as unknown as ReleasePhasesListResponse;
     } catch (error) {
       log.error('Error listing release phases', error as Error, { operation: 'listReleasePhases' });
       throw error;
@@ -1130,11 +1164,12 @@ export class AhaService {
     const requirementsApi = this.getRequirementsApi();
 
     try {
-      const response = await requirementsApi.requirementsGet({ id: requirementId });
-      if (!response.data.requirement) {
+      const response = await requirementsApi.requirementsByIdGet({ id: requirementId });
+      const data = response.data as unknown as { requirement?: Requirement };
+      if (!data.requirement) {
         throw new Error(`Requirement ${requirementId} not found`);
       }
-      return response.data.requirement as Requirement;
+      return data.requirement;
     } catch (error) {
       log.error('Error getting requirement', error as Error, { operation: 'getRequirement', requirement_id: requirementId });
       throw error;
@@ -1150,8 +1185,11 @@ export class AhaService {
     const competitorsApi = this.getCompetitorsApi();
 
     try {
-      const response = await competitorsApi.competitorsGet({ competitorId });
-      return response.data;
+      const response = await competitorsApi.competitorsByIdGet({ id: competitorId });
+      // Generator defect: `competitorsByIdGet` is typed as returning the (product-scoped)
+      // list response (`{ competitors, pagination }`); the endpoint genuinely returns a
+      // single competitor with no wrapper.
+      return response.data as unknown as Competitor;
     } catch (error) {
       log.error('Error getting competitor', error as Error, { operation: 'getCompetitor', competitor_id: competitorId });
       throw error;
@@ -1167,11 +1205,15 @@ export class AhaService {
     const todosApi = this.getTodosApi();
 
     try {
-      const response = await todosApi.todosGet({ id: todoId });
-      if (!response.data.task) {
+      const response = await todosApi.tasksByIdGet({ id: todoId });
+      // Generator defect: `tasksByIdGet` is typed as returning the list response
+      // (`{ tasks, pagination }`); the endpoint genuinely returns a single task wrapped as
+      // `{ task }`.
+      const data = response.data as unknown as { task?: Todo };
+      if (!data.task) {
         throw new Error(`Todo ${todoId} not found`);
       }
-      return response.data.task as Todo;
+      return data.task;
     } catch (error) {
       log.error('Error getting todo', error as Error, { operation: 'getTodo', todo_id: todoId });
       throw error;
@@ -1187,8 +1229,8 @@ export class AhaService {
     const competitorsApi = this.getCompetitorsApi();
 
     try {
-      const response = await competitorsApi.competitorsListProduct({ productId });
-      return response.data;
+      const response = await competitorsApi.productsByProductCompetitorsGet({ productId });
+      return response.data as unknown as CompetitorsListResponse;
     } catch (error) {
       log.error('Error listing competitors for product', error as Error, { operation: 'listCompetitors', product_id: productId });
       throw error;
@@ -1209,15 +1251,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdEpicPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdEpicPutRequest: {
+        featuresPutRequest: {
           feature: {
             epic: epicId
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error associating feature with epic', error as Error, { operation: 'associateFeatureWithEpic', feature_id: featureId, epic_id: epicId });
       throw error;
@@ -1234,15 +1277,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdReleasePut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdReleasePutRequest: {
+        featuresPutRequest: {
           feature: {
             release: releaseId
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error moving feature to release', error as Error, { operation: 'moveFeatureToRelease', feature_id: featureId, release_id: releaseId });
       throw error;
@@ -1259,15 +1303,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdGoalsPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdGoalsPutRequest: {
+        featuresPutRequest: {
           feature: {
             goals: goalIds
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error associating feature with goals', error as Error, { operation: 'associateFeatureWithGoals', feature_id: featureId, goal_ids: goalIds });
       throw error;
@@ -1284,15 +1329,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdTagsPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdTagsPutRequest: {
+        featuresPutRequest: {
           feature: {
             tags: tags
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating tags for feature', error as Error, { operation: 'updateFeatureTags', feature_id: featureId });
       throw error;
@@ -1309,11 +1355,12 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsCreateInProduct({
+      const response = await epicsApi.productsByProductEpicsPost({
         productId: productId,
-        epicCreateRequest: epicData
+        epicsPostRequest: epicData
       });
-      return response.data;
+      const data = response.data as unknown as { epic?: Epic };
+      return data.epic as Epic;
     } catch (error) {
       log.error('Error creating epic in product', error as Error, { operation: 'createEpicInProduct', product_id: productId });
       throw error;
@@ -1330,11 +1377,12 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsCreateInRelease({
+      const response = await epicsApi.releasesByReleaseEpicsPost({
         releaseId: releaseId,
-        epicCreateRequest: epicData
+        epicsPostRequest: epicData
       });
-      return response.data;
+      const data = response.data as unknown as { epic?: Epic };
+      return data.epic as Epic;
     } catch (error) {
       log.error('Error creating epic in release', error as Error, { operation: 'createEpicInRelease', release_id: releaseId });
       throw error;
@@ -1351,11 +1399,11 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesCreate({
+      const response = await initiativesApi.productsByProductInitiativesPost({
         productId: productId,
-        initiativeCreateRequest: initiativeData
+        initiativesPostRequest: initiativeData
       });
-      return response.data;
+      return response.data as unknown as InitiativeResponse;
     } catch (error) {
       log.error('Error creating initiative in product', error as Error, { operation: 'createInitiativeInProduct', product_id: productId });
       throw error;
@@ -1372,16 +1420,17 @@ export class AhaService {
    * @param featureData The feature data to create
    * @returns The created feature response, if the endpoint returned a body
    *
-   * `unknown` rather than `Feature`: aha-js types this endpoint's response as `void`, so
+   * `unknown` rather than `Feature`: aha-js types this endpoint's response loosely, so
    * whatever Aha sends back is undeclared. The tool treats a missing body as an empty
    * record rather than assuming a feature came back.
    */
-  public static async createFeature(releaseId: string, _featureData: any): Promise<unknown> {
-    const defaultApi = this.getDefaultApi();
+  public static async createFeature(releaseId: string, featureData: any): Promise<unknown> {
+    const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await defaultApi.releasesReleaseIdFeaturesPost({
-        releaseId: releaseId
+      const response = await featuresApi.releasesByReleaseFeaturesPost({
+        releaseId: releaseId,
+        featuresPostRequest: featureData ?? {}
       });
       return response.data;
     } catch (error) {
@@ -1400,11 +1449,12 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresUpdate({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featureUpdateRequest: featureData
+        featuresPutRequest: featureData
       });
-      return response.data.feature;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating feature', error as Error, { operation: 'updateFeature', feature_id: featureId });
       throw error;
@@ -1420,7 +1470,7 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      await featuresApi.featuresDelete({ id: featureId });
+      await featuresApi.featuresByIdDelete({ id: featureId });
     } catch (error) {
       log.error('Error deleting feature', error as Error, { operation: 'deleteFeature', feature_id: featureId });
       throw error;
@@ -1437,15 +1487,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdProgressPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdProgressPutRequest: {
+        featuresPutRequest: {
           feature: {
             progress: progress
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating progress for feature', error as Error, { operation: 'updateFeatureProgress', feature_id: featureId });
       throw error;
@@ -1462,16 +1513,17 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdScorePut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdScorePutRequest: {
+        featuresPutRequest: {
           feature: {
             // Note: Need to check exact structure for score updates
             score_facts: [{ value: score }]
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating score for feature', error as Error, { operation: 'updateFeatureScore', feature_id: featureId });
       throw error;
@@ -1488,17 +1540,18 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      // This used to call `DefaultApi.featuresIdCustomFieldsPut`, whose generated signature
-      // takes an id and nothing else - the operation is declared without a request body, so
-      // the values could not be sent at all and every call was a no-op reported as success.
-      // `PUT /features/:id` carries `feature.custom_fields`, so route through that instead.
-      const response = await featuresApi.featuresUpdate({
+      // This used to call a generated operation whose signature took an id and nothing
+      // else - the operation was declared without a request body, so the values could not be
+      // sent at all and every call was a no-op reported as success. `PUT /features/:id`
+      // carries `feature.custom_fields`, so route through that instead.
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featureUpdateRequest: {
+        featuresPutRequest: {
           feature: { custom_fields: customFields } as any
         }
       });
-      return response.data.feature;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating custom fields for feature', error as Error, { operation: 'updateFeatureCustomFields', feature_id: featureId });
       throw error;
@@ -1519,11 +1572,12 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsUpdate({
-        epicId: epicId,
-        epicUpdateRequest: epicData
+      const response = await epicsApi.epicsByIdPut({
+        id: epicId,
+        epicsPostRequest: epicData
       });
-      return response.data;
+      const data = response.data as unknown as { epic?: Epic };
+      return data.epic as Epic;
     } catch (error) {
       log.error('Error updating epic', error as Error, { operation: 'updateEpic', epic_id: epicId });
       throw error;
@@ -1539,7 +1593,7 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      await epicsApi.epicsDelete({ epicId: epicId });
+      await epicsApi.epicsByIdDelete({ id: epicId });
     } catch (error) {
       log.error('Error deleting epic', error as Error, { operation: 'deleteEpic', epic_id: epicId });
       throw error;
@@ -1560,11 +1614,11 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasCreate({
+      const response = await ideasApi.productsByProductIdeasPost({
         productId: productId,
-        ideaCreateRequest: ideaData
+        ideasPostRequest: ideaData
       });
-      return response.data;
+      return response.data as unknown as IdeaResponse;
     } catch (error) {
       log.error('Error creating idea in product', error as Error, { operation: 'createIdea', product_id: productId });
       throw error;
@@ -1644,7 +1698,7 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      await ideasApi.ideasDelete({ id: ideaId });
+      await ideasApi.ideasByIdDelete({ id: ideaId });
     } catch (error) {
       log.error('Error deleting idea', error as Error, { operation: 'deleteIdea', idea_id: ideaId });
       throw error;
@@ -1663,15 +1717,63 @@ export class AhaService {
     const competitorsApi = this.getCompetitorsApi();
 
     try {
-      const response = await competitorsApi.competitorsCreate({
+      const response = await competitorsApi.productsByProductCompetitorsPost({
         productId: productId,
-        competitorCreateRequest: competitorData
+        competitorsPostRequest: competitorData
       });
-      return response.data;
+      const data = response.data as unknown as { competitor?: Competitor };
+      return data.competitor as Competitor;
     } catch (error) {
       log.error('Error creating competitor in product', error as Error, { operation: 'createCompetitor', product_id: productId });
       throw error;
     }
+  }
+
+  /**
+   * `PUT /competitors/{id}` and `DELETE /competitors/{id}` are documented by Aha but absent
+   * from the OpenAPI document this SDK is generated from, so `CompetitorsApi` has no method
+   * for either (only the product-scoped `PUT/DELETE /products/{id}/competitors/{id}`, which
+   * needs a product id this service's callers do not have). Call them directly instead, the
+   * same way `aha-graphql.ts` reaches endpoints aha-js does not cover: read credentials
+   * through `getCredentials()` so a runtime `configure_server` call is honoured, and build
+   * the request against the same `/api/v1` base path used everywhere else in this class.
+   */
+  private static async competitorRequest(
+    method: 'PUT' | 'DELETE',
+    competitorId: string,
+    body?: unknown
+  ): Promise<unknown> {
+    const { subdomain, accessToken } = this.getCredentials();
+    if (!subdomain || !accessToken) {
+      throw new Error(
+        'Aha API client not initialized. Set AHA_COMPANY and AHA_TOKEN, or call initialize().'
+      );
+    }
+
+    const url = `https://${subdomain}.aha.io/api/v1/competitors/${competitorId}`;
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined
+    });
+
+    if (!response.ok) {
+      // Shaped like the axios errors every SDK-backed call in this class throws, so
+      // `describeAhaError` maps the status the same way it would for those.
+      const error = new Error(`Aha.io competitor request failed (HTTP ${response.status})`) as Error & {
+        isAxiosError: boolean;
+        response: { status: number; headers: Record<string, string> };
+      };
+      error.isAxiosError = true;
+      error.response = { status: response.status, headers: Object.fromEntries(response.headers.entries()) };
+      throw error;
+    }
+
+    if (response.status === 204) return undefined;
+    return response.json().catch(() => undefined);
   }
 
   /**
@@ -1681,14 +1783,10 @@ export class AhaService {
    * @returns The updated competitor
    */
   public static async updateCompetitor(competitorId: string, competitorData: any): Promise<Competitor> {
-    const competitorsApi = this.getCompetitorsApi();
-
     try {
-      const response = await competitorsApi.competitorsUpdate({
-        competitorId: competitorId,
-        competitorUpdateRequest: competitorData
-      });
-      return response.data;
+      const data = await this.competitorRequest('PUT', competitorId, competitorData);
+      const wrapped = data as { competitor?: Competitor } | null | undefined;
+      return (wrapped?.competitor ?? (data as Competitor)) as Competitor;
     } catch (error) {
       log.error('Error updating competitor', error as Error, { operation: 'updateCompetitor', competitor_id: competitorId });
       throw error;
@@ -1701,10 +1799,8 @@ export class AhaService {
    * @returns Success response
    */
   public static async deleteCompetitor(competitorId: string): Promise<void> {
-    const competitorsApi = this.getCompetitorsApi();
-
     try {
-      await competitorsApi.competitorsDelete({ competitorId: competitorId });
+      await this.competitorRequest('DELETE', competitorId);
     } catch (error) {
       log.error('Error deleting competitor', error as Error, { operation: 'deleteCompetitor', competitor_id: competitorId });
       throw error;
@@ -1718,12 +1814,12 @@ export class AhaService {
    * @param initiativeId The ID of the initiative
    * @returns A list of epics associated with the initiative
    */
-  public static async getInitiativeEpics(initiativeId: string): Promise<EpicsList200Response> {
+  public static async getInitiativeEpics(initiativeId: string): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsListByInitiative({ initiativeId });
-      return response.data;
+      const response = await epicsApi.initiativesByInitiativeEpicsGet({ initiativeId });
+      return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error getting epics for initiative', error as Error, { operation: 'getInitiativeEpics', initiative_id: initiativeId });
       throw error;
@@ -1774,11 +1870,11 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasCreate({
+      const response = await ideasApi.productsByProductIdeasPost({
         productId: productId,
-        ideaCreateRequest: ideaData
+        ideasPostRequest: ideaData
       });
-      return response.data;
+      return response.data as unknown as IdeaResponse;
     } catch (error) {
       log.error('Error creating idea with portal settings in product', error as Error, { operation: 'createIdeaWithPortalSettings', product_id: productId });
       throw error;
@@ -1794,11 +1890,14 @@ export class AhaService {
   public static async getStrategicModel(strategicModelId: string): Promise<StrategicModel> {
     const strategicModelsApi = this.getStrategicModelsApi();
     try {
-      const response = await strategicModelsApi.strategicModelsGet({ id: strategicModelId });
-      if (!response.data.strategic_model) {
+      // Aha renamed `/strategic_models` to `/strategy_models` upstream; the response field
+      // followed suit (`strategy_model` rather than the old `strategic_model`).
+      const response = await strategicModelsApi.strategyModelsByIdGet({ id: strategicModelId });
+      const data = response.data as unknown as { strategy_model?: StrategicModel };
+      if (!data.strategy_model) {
         throw new Error(`Strategic model ${strategicModelId} not found`);
       }
-      return response.data.strategic_model;
+      return data.strategy_model;
     } catch (error) {
       log.error('Error getting strategic model', error as Error, { operation: 'getStrategicModel', strategic_model_id: strategicModelId });
       throw error;
@@ -1823,14 +1922,29 @@ export class AhaService {
   ): Promise<StrategicModelsListResponse> {
     const strategicModelsApi = this.getStrategicModelsApi();
     try {
-      const response = await strategicModelsApi.strategicModelsList({
-        page,
-        perPage,
-        q: query,
-        type: type as any, // Cast to any since the enum type is not exported
-        updatedSince
-      });
-      return response.data;
+      // `strategyModelsGet`'s generated request type only documents pagination now; `q`,
+      // `type` and `updatedSince` are sent via `options.params` because Aha's spec
+      // under-documents this endpoint's query string. The response type is also a generator
+      // defect: it is shared with the by-id endpoint and shaped `{ strategy_model }`
+      // (singular); the real list endpoint returns an array. The exact plural field name
+      // post-rename is unconfirmed, so both `strategic_models` (the pre-rename name the
+      // domain type uses) and `strategy_models` are checked.
+      const response = await strategicModelsApi.strategyModelsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        { params: this.extraParams({ q: query, type, updated_since: updatedSince }) }
+      );
+      const data = response.data as unknown as {
+        strategic_models?: StrategicModel[];
+        strategy_models?: StrategicModel[];
+        pagination?: Pagination;
+      };
+      return {
+        strategic_models: data.strategic_models ?? data.strategy_models ?? [],
+        pagination: data.pagination
+      };
     } catch (error) {
       log.error('Error listing strategic models', error as Error, { operation: 'listStrategicModels' });
       throw error;
@@ -1842,11 +1956,11 @@ export class AhaService {
    * List to-dos
    * @returns The list of to-dos
    */
-  public static async listTodos(): Promise<TodosList200Response> {
+  public static async listTodos(): Promise<TodosListResponse> {
     const todosApi = this.getTodosApi();
     try {
-      const response = await todosApi.todosList();
-      return response.data;
+      const response = await todosApi.tasksGet();
+      return response.data as unknown as TodosListResponse;
     } catch (error) {
       log.error('Error listing todos', error as Error, { operation: 'listTodos' });
       throw error;
@@ -1862,11 +1976,12 @@ export class AhaService {
   public static async getIdeaOrganization(ideaOrganizationId: string): Promise<IdeaOrganization> {
     const ideaOrganizationsApi = this.getIdeaOrganizationsApi();
     try {
-      const response = await ideaOrganizationsApi.ideaOrganizationsGet({ id: ideaOrganizationId });
-      if (!response.data.idea_organization) {
+      const response = await ideaOrganizationsApi.ideaOrganizationsByIdGet({ id: ideaOrganizationId });
+      const data = response.data as unknown as { idea_organization?: IdeaOrganization };
+      if (!data.idea_organization) {
         throw new Error(`Idea organization ${ideaOrganizationId} not found`);
       }
-      return response.data.idea_organization;
+      return data.idea_organization;
     } catch (error) {
       log.error('Error getting idea organization', error as Error, { operation: 'getIdeaOrganization', idea_organization_id: ideaOrganizationId });
       throw error;
@@ -1889,13 +2004,20 @@ export class AhaService {
   ): Promise<IdeaOrganizationsListResponse> {
     const ideaOrganizationsApi = this.getIdeaOrganizationsApi();
     try {
-      const response = await ideaOrganizationsApi.ideaOrganizationsList({
-        page,
-        perPage,
-        q: query,
-        emailDomain
-      });
-      return response.data;
+      // `q` and `emailDomain` are sent via `options.params` because Aha's spec
+      // under-documents this endpoint's query string - the generated request type has no
+      // such fields. Its response type is also a generator defect: shared with the by-id
+      // endpoint and shaped `{ idea_organization }` (singular). The real list endpoint
+      // returns `{ idea_organizations, pagination }`.
+      const response = await ideaOrganizationsApi.ideaOrganizationsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        { params: this.extraParams({ q: query, email_domain: emailDomain }) }
+      );
+      const data = response.data as unknown as { idea_organizations?: IdeaOrganization[]; pagination?: Pagination };
+      return { idea_organizations: data.idea_organizations ?? [], pagination: data.pagination };
     } catch (error) {
       log.error('Error listing idea organizations', error as Error, { operation: 'listIdeaOrganizations' });
       throw error;
@@ -1910,8 +2032,11 @@ export class AhaService {
   public static async getAssignedRecords(): Promise<MeAssignedRecordsResponse> {
     const meApi = this.getMeApi();
     try {
-      const response = await meApi.meGetAssignedRecords();
-      return response.data;
+      const response = await meApi.meAssignedGet();
+      // Generator defect: `meAssignedGet` shares its response type with `meTasksGet`
+      // (`{ tasks, pagination }`); the endpoint genuinely returns `{ records, pagination }`.
+      const data = response.data as unknown as { records?: RecordRef[]; pagination?: Pagination };
+      return { records: data.records ?? [], pagination: data.pagination };
     } catch (error) {
       log.error('Error getting assigned records', error as Error, { operation: 'getMeAssignedRecords' });
       throw error;
@@ -1925,8 +2050,8 @@ export class AhaService {
   public static async getPendingTasks(): Promise<MePendingTasksResponse> {
     const meApi = this.getMeApi();
     try {
-      const response = await meApi.meGetPendingTasks();
-      return response.data;
+      const response = await meApi.meTasksGet();
+      return response.data as unknown as MePendingTasksResponse;
     } catch (error) {
       log.error('Error getting pending tasks', error as Error, { operation: 'getMePendingTasks' });
       throw error;
@@ -1947,16 +2072,16 @@ export class AhaService {
     proxy?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetEndorsements200Response> {
-    const ideasApi = this.getIdeasApi();
+  ): Promise<IdeaEndorsementsResponse> {
+    const ideasApi = this.getIdeaVotesApi();
     try {
-      const response = await ideasApi.ideasGetEndorsements({
-        id: ideaId,
-        proxy,
-        page,
-        perPage
+      const response = await ideasApi.ideasByIdeaEndorsementsGet({
+        ideaId: ideaId,
+        proxy: this.boolParam(proxy),
+        page: this.numParam(page),
+        perPage: this.numParam(perPage)
       });
-      return response.data;
+      return response.data as unknown as IdeaEndorsementsResponse;
     } catch (error) {
       log.error('Error getting endorsements for idea', error as Error, { operation: 'getIdeaEndorsements', idea_id: ideaId });
       throw error;
@@ -1974,33 +2099,20 @@ export class AhaService {
     ideaId: string,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetVotes200Response> {
-    const ideasApi = this.getIdeasApi();
+  ): Promise<IdeaVotesResponse> {
+    // Aha models votes and endorsements as the same underlying record; there is no separate
+    // `/ideas/{id}/votes` endpoint in the generated SDK, so this calls the same operation as
+    // `getIdeaEndorsements`.
+    const ideaVotesApi = this.getIdeaVotesApi();
     try {
-      const response = await ideasApi.ideasGetVotes({
-        id: ideaId,
-        page,
-        perPage
+      const response = await ideaVotesApi.ideasByIdeaEndorsementsGet({
+        ideaId: ideaId,
+        page: this.numParam(page),
+        perPage: this.numParam(perPage)
       });
-      return response.data;
+      return response.data as unknown as IdeaVotesResponse;
     } catch (error) {
       log.error('Error getting votes for idea', error as Error, { operation: 'getIdeaVotes', idea_id: ideaId });
-      throw error;
-    }
-  }
-
-  /**
-   * Get watchers for an idea
-   * @param ideaId The ID of the idea
-   * @returns The watchers for the idea
-   */
-  public static async getIdeaWatchers(ideaId: string): Promise<IdeasGetWatchers200Response> {
-    const ideasApi = this.getIdeasApi();
-    try {
-      const response = await ideasApi.ideasGetWatchers({ id: ideaId });
-      return response.data;
-    } catch (error) {
-      log.error('Error getting watchers for idea', error as Error, { operation: 'getIdeaWatchers', idea_id: ideaId });
       throw error;
     }
   }
@@ -2050,27 +2162,36 @@ export class AhaService {
   ): Promise<IdeasListResponse> {
     const ideasApi = this.getIdeasApi();
     try {
-      const response = await ideasApi.ideasList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        status,
-        category,
-        fields,
-        productId,
-        ideaPortalId,
-        spam,
-        workflowStatus,
-        sort,
-        createdBefore,
-        createdSince,
-        tag,
-        userId,
-        ideaUserId
-      });
-      return response.data;
+      // `ideasGet`'s generated request type has no `status`, `category`, `productId`,
+      // `ideaPortalId` or `ideaUserId` fields, so those are sent via `options.params` because
+      // Aha's spec under-documents this endpoint's query string.
+      const response = await ideasApi.ideasGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage),
+          q: query,
+          updatedSince,
+          assignedToUser,
+          workflowStatus,
+          spam: this.boolParam(spam),
+          sort,
+          createdBefore,
+          createdSince,
+          tag,
+          userId,
+          fields
+        },
+        {
+          params: this.extraParams({
+            status,
+            category,
+            product_id: productId,
+            idea_portal_id: ideaPortalId,
+            idea_user_id: ideaUserId
+          })
+        }
+      );
+      return response.data as unknown as IdeasListResponse;
     } catch (error) {
       log.error('Error listing ideas', error as Error, { operation: 'listIdeas' });
       throw error;
@@ -2096,19 +2217,28 @@ export class AhaService {
     parkingLot?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<SdkReleasesListResponse> {
+  ): Promise<ReleasesListResponse> {
     const releasesApi = this.getReleasesApi();
     try {
-      const response = await releasesApi.productReleasesList({
-        productId,
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        status,
-        parkingLot
-      });
-      return response.data;
+      // `q`, `updatedSince`, `status` and `parkingLot` are sent via `options.params` because
+      // Aha's spec under-documents this endpoint's query string - only pagination remains in
+      // the generated request type.
+      const response = await releasesApi.productsByProductReleasesGet(
+        {
+          productId,
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            status,
+            parking_lot: parkingLot
+          })
+        }
+      );
+      return response.data as unknown as ReleasesListResponse;
     } catch (error) {
       log.error('Error listing releases for product', error as Error, { operation: 'getProductReleases', product_id: productId });
       throw error;
@@ -2123,11 +2253,15 @@ export class AhaService {
    * List all custom field definitions
    * @returns A list of custom field definitions
    */
-  public static async listCustomFields(): Promise<CustomFieldsListAll200Response> {
+  public static async listCustomFields(): Promise<CustomFieldDefinitionsResponse> {
     const customFieldsApi = this.getCustomFieldsApi();
     try {
-      const response = await customFieldsApi.customFieldsListAll();
-      return response.data;
+      const response = await customFieldsApi.customFieldDefinitionsGet();
+      // Generator defect: `customFieldDefinitionsGet` (list-all) shares its response type
+      // with `...ByCustomFieldDefinitionOptionsGet` (`{ options }`), which is wrong for the
+      // list-all case. Build the real `{ custom_field_definitions }` shape ourselves.
+      const data = response.data as unknown as { custom_field_definitions?: CustomFieldDefinition[] };
+      return { custom_field_definitions: data.custom_field_definitions ?? [] };
     } catch (error) {
       log.error('Error listing custom fields', error as Error, { operation: 'listCustomFields' });
       throw error;
@@ -2139,13 +2273,13 @@ export class AhaService {
    * @param customFieldDefinitionId The ID of the custom field definition
    * @returns A list of options for the custom field
    */
-  public static async listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldsListOptions200Response> {
+  public static async listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldOptionsResponse> {
     const customFieldsApi = this.getCustomFieldsApi();
     try {
-      const response = await customFieldsApi.customFieldsListOptions({
+      const response = await customFieldsApi.customFieldDefinitionsByCustomFieldDefinitionOptionsGet({
         customFieldDefinitionId
       });
-      return response.data;
+      return response.data as unknown as CustomFieldOptionsResponse;
     } catch (error) {
       log.error('Error listing custom field options', error as Error, { operation: 'listCustomFieldOptions', custom_field_definition_id: customFieldDefinitionId });
       throw error;

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -110,7 +110,7 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
         };
       } catch (error) {
         const message = describeAhaError(error);
-        log.error("Search failed", error);
+        log.error("Search failed", error as Error);
         return {
           content: [{ type: "text" as const, text: `Search failed: ${message}` }],
           isError: true

--- a/src/core/types/aha-types.ts
+++ b/src/core/types/aha-types.ts
@@ -1,235 +1,576 @@
 /**
- * Custom types for Aha.io API responses not covered by the SDK
+ * Domain types for Aha.io API responses.
+ *
+ * These are hand-maintained rather than imported from `@cedricziel/aha-js`. The SDK is
+ * generated per-operation (`FeaturesGetResponseFeaturesInner`,
+ * `EpicsPutResponseEpicGoalsInner`, ...) and those names change shape on every
+ * regeneration, which used to leak straight through `AhaService`'s public signatures and
+ * re-break the whole codebase. `IAhaService` speaks only in the types below instead, so a
+ * future SDK bump only has to satisfy this file rather than every call site.
+ *
+ * Field lists follow what Aha actually returns (cross-checked against the generated model
+ * files in `node_modules/@cedricziel/aha-js/dist/model/`), typed permissively: every field
+ * is optional and every record carries an index signature, so a field Aha adds later - or a
+ * field the generator's fixture-based spec mis-describes - still flows through rather than
+ * being typed away. `structuredContent` in the MCP layer is validated with `z.looseObject`,
+ * so extra keys are expected.
+ *
+ * Known generator quirk (not modeled around, just noted): several "get one record by id"
+ * operations in aha-js 2.0.0 are typed as returning the *list* response for that resource
+ * (e.g. `usersByIdGet`, `epicsByIdGet`, `goalsByIdGet` all return the same response type as
+ * their `xByIdGet` siblings return for `xGet`). The real endpoint returns a single record
+ * (Aha's actual documented API, and the shape the old hand-written spec assumed). Treat the
+ * generated single-get response types as unreliable and prefer the wrapped/flat domain
+ * shapes below, which reflect what `AhaService` has always actually unwrapped.
  */
-
-import { User, Epic, Feature } from '@cedricziel/aha-js';
 
 /**
- * Release entity (not available in SDK)
+ * Pagination block returned by every Aha list endpoint.
  */
-export interface Release {
+export interface Pagination {
+  total_records?: number;
+  total_pages?: number;
+  current_page?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Aha's rich-text description wrapper, e.g. `{ id, body }`.
+ */
+export interface RichText {
+  id?: string;
+  body?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Workflow status attached to features, epics, ideas, initiatives, releases, requirements...
+ */
+export interface WorkflowStatus {
+  id?: string;
+  name?: string;
+  color?: string;
+  complete?: boolean;
+  position?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * A custom field value as attached to a record (`feature.custom_fields`, etc.)
+ */
+export interface CustomField {
+  id?: string;
+  key?: string;
+  name?: string;
+  type?: string;
+  value?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * A custom field *definition*, as returned by the account-wide custom fields endpoints.
+ */
+export interface CustomFieldDefinition {
+  id?: string;
+  key?: string;
+  name?: string;
+  type?: string;
+  options?: CustomFieldOption[];
+  [key: string]: unknown;
+}
+
+export interface CustomFieldDefinitionsResponse {
+  custom_field_definitions?: CustomFieldDefinition[];
+  [key: string]: unknown;
+}
+
+export interface CustomFieldOption {
+  text?: string;
+  value?: string;
+  meta?: unknown;
+  [key: string]: unknown;
+}
+
+export interface CustomFieldOptionsResponse {
+  options?: CustomFieldOption[];
+  [key: string]: unknown;
+}
+
+/**
+ * Minimal reference to another record, as embedded in relations like `feature.release`,
+ * `epic.initiative`, `goal.project`, etc. Aha embeds varying levels of detail here
+ * depending on endpoint, so this is intentionally loose.
+ */
+export interface RecordRef {
   id?: string;
   name?: string;
   reference_num?: string;
-  start_date?: string;
-  due_date?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * User entity. `GET /users` and `GET /users/{id}` both return this shape in practice
+ * (id, name, email, ...); see the generator-quirk note above for why the 2.0.0 SDK types
+ * disagree.
+ */
+export interface User {
+  id?: string;
+  name?: string;
+  email?: string;
+  username?: string;
+  initials?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
-  url?: string;
-  resource?: string;
+  [key: string]: unknown;
+}
+
+export interface UsersListResponse {
+  users?: User[];
+  pagination?: Pagination;
+}
+
+/**
+ * Feature entity.
+ */
+export interface Feature {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  initiative_reference_num?: string;
+  release_reference_num?: string;
+  epic_reference_num?: string;
+  position?: number;
+  score?: number;
+  created_at?: string;
+  updated_at?: string;
+  start_date?: string;
+  due_date?: string;
   product_id?: string;
-  position?: number;
-  released?: boolean;
+  progress?: number | null;
+  progress_source?: string;
   created_by_user?: User;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
+  url?: string;
+  resource?: string;
+  release?: RecordRef;
+  master_feature?: RecordRef;
+  epic?: RecordRef;
+  assigned_to_user?: User;
+  requirements?: Requirement[];
+  initiative?: RecordRef;
+  goals?: RecordRef[];
+  key_results?: unknown[];
+  comments_count?: number;
+  score_facts?: unknown[];
+  tags?: string[];
+  custom_fields?: CustomField[];
+  feature_links?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface FeaturesListResponse {
+  features?: Feature[];
+  pagination?: Pagination;
 }
 
 /**
- * Release Phase entity (not available in SDK)
+ * Epic entity.
  */
-export interface ReleasePhase {
+export interface Epic {
   id?: string;
   name?: string;
   reference_num?: string;
-  start_date?: string;
-  due_date?: string;
+  initiative_reference_num?: string;
+  position?: number;
+  score?: number;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  start_date?: string;
+  due_date?: string;
+  product_id?: string;
+  progress?: number | null;
+  progress_source?: string;
+  created_by_user?: User;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
   url?: string;
   resource?: string;
-  release_id?: string;
-  position?: number;
+  release?: RecordRef;
+  assigned_to_user?: User;
+  features?: RecordRef[];
+  initiative?: RecordRef;
+  goals?: RecordRef[];
+  comments_count?: number;
+  tags?: string[];
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface EpicsListResponse {
+  epics?: Epic[];
+  pagination?: Pagination;
 }
 
 /**
- * Goal entity (not available in SDK)
+ * Idea entity.
+ */
+export interface Idea {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  score?: number;
+  created_at?: string;
+  updated_at?: string;
+  product_id?: string;
+  votes?: number;
+  initial_votes?: number;
+  status_changed_at?: string;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
+  visibility?: string;
+  url?: string;
+  resource?: string;
+  product?: RecordRef;
+  created_by_user?: User;
+  assigned_to_user?: User | null;
+  feature?: RecordRef;
+  endorsements_count?: number;
+  comments_count?: number;
+  tags?: string[];
+  categories?: unknown[];
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface IdeasListResponse {
+  ideas?: Idea[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /ideas/{id}` wraps the idea under an `idea` key.
+ */
+export interface IdeaResponse {
+  idea?: Idea;
+  [key: string]: unknown;
+}
+
+/**
+ * Initiative entity.
+ */
+export interface Initiative {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  status?: string;
+  effort?: number;
+  value?: number;
+  color?: string;
+  start_date?: string | null;
+  end_date?: string | null;
+  position?: number;
+  score?: number;
+  created_at?: string;
+  updated_at?: string;
+  product_id?: string;
+  progress?: number | null;
+  progress_source?: string;
+  duration_source?: string;
+  url?: string;
+  resource?: string;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
+  assigned_to_user?: User;
+  created_by_user?: User;
+  comments_count?: number;
+  goals?: RecordRef[];
+  features?: RecordRef[];
+  releases?: RecordRef[];
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface InitiativesListResponse {
+  initiatives?: Initiative[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /initiatives/{id}` wraps the initiative under an `initiative` key.
+ */
+export interface InitiativeResponse {
+  initiative?: Initiative;
+  [key: string]: unknown;
+}
+
+/**
+ * Goal entity.
  */
 export interface Goal {
   id?: string;
   name?: string;
   reference_num?: string;
-  created_at?: string;
-  updated_at?: string;
-  description?: string;
-  url?: string;
-  resource?: string;
-  product_id?: string;
+  effort?: number;
+  value?: number;
+  color?: string;
   position?: number;
-  status?: string;
-  created_by_user?: User;
-}
-
-/**
- * Product entity (not available in SDK)
- */
-export interface Product {
-  id?: string;
-  name?: string;
-  reference_num?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  product_id?: string;
+  status?: string;
+  progress?: number | null;
+  progress_source?: string;
   url?: string;
   resource?: string;
-}
-
-/**
- * List response wrappers for entities not in SDK
- */
-export interface ReleasesListResponse {
-  releases?: Release[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface ReleasesPhasesListResponse {
-  release_phases?: ReleasePhase[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  description?: RichText;
+  success_metric?: unknown;
+  time_frame?: unknown;
+  project?: RecordRef;
+  initiatives?: RecordRef[];
+  key_results?: unknown[];
+  features?: RecordRef[];
+  releases?: RecordRef[];
+  comments_count?: number;
+  created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
 }
 
 export interface GoalsListResponse {
   goals?: Goal[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface UsersListResponse {
-  users?: User[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  pagination?: Pagination;
 }
 
 /**
- * Relationship response types
+ * `GET /goals/{id}` wraps the goal under a `goal` key.
+ */
+export interface GoalGetResponse {
+  goal?: Goal;
+  [key: string]: unknown;
+}
+
+/**
+ * Relationship response: epics associated with a goal.
+ */
+export interface GoalEpicsResponse {
+  epics?: Epic[];
+  pagination?: Pagination;
+}
+
+/**
+ * Release entity.
+ */
+export interface Release {
+  id?: string;
+  product_id?: string;
+  reference_num?: string;
+  name?: string;
+  start_date?: string;
+  due_date?: string;
+  end_date?: string | null;
+  development_started_on?: string;
+  release_date?: string;
+  external_release_date?: string;
+  external_release_date_description?: string;
+  external_date_resolution?: string;
+  released?: boolean;
+  parking_lot?: boolean;
+  master_release?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  position?: number;
+  progress?: number | null;
+  progress_source?: string;
+  duration_source?: string;
+  workflow_status?: WorkflowStatus;
+  theme?: RecordRef;
+  owner?: User;
+  goals?: RecordRef[];
+  project?: RecordRef;
+  url?: string;
+  resource?: string;
+  comments_count?: number;
+  created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface ReleasesListResponse {
+  releases?: Release[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /releases/{id}` wraps the release under a `release` key.
+ */
+export interface ReleaseGetResponse {
+  release?: Release;
+  [key: string]: unknown;
+}
+
+/**
+ * Relationship response: features associated with a release.
  */
 export interface ReleaseFeaturesResponse {
   features?: Feature[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface ReleaseEpicsResponse {
-  epics?: Epic[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface GoalEpicsResponse {
-  epics?: Epic[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  pagination?: Pagination;
 }
 
 /**
- * Ideas by product response (not fully typed in SDK)
+ * Release Phase entity.
  */
-export interface IdeasByProductResponse {
-  ideas?: Array<{
-    id?: string;
-    name?: string;
-    reference_num?: string;
-    created_at?: string;
-    updated_at?: string;
-    description?: string;
-    url?: string;
-    resource?: string;
-  }>;
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+export interface ReleasePhase {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  start_on?: string;
+  end_on?: string;
+  start_date?: string;
+  due_date?: string;
+  type?: string;
+  release_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  description?: RichText;
+  progress?: number;
+  progress_source?: string;
+  duration_source?: string;
+  url?: string;
+  resource?: string;
+  position?: number;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface ReleasePhasesListResponse {
+  release_phases?: ReleasePhase[];
+  pagination?: Pagination;
 }
 
 /**
- * Requirement entity (not available in SDK)
+ * Product entity.
+ */
+export interface Product {
+  id?: string;
+  reference_prefix?: string;
+  name?: string;
+  reference_num?: string;
+  product_line?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  description?: RichText;
+  url?: string;
+  resource?: string;
+  has_ideas?: boolean;
+  has_epics?: boolean;
+  has_master_features?: boolean;
+  workspace_type?: string;
+  color?: string;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface ProductsListResponse {
+  products?: Product[];
+  pagination?: Pagination;
+}
+
+/**
+ * Requirement entity.
  */
 export interface Requirement {
   id?: string;
   name?: string;
   reference_num?: string;
+  position?: number;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  release_id?: string;
+  start_date?: string;
+  end_date?: string;
+  due_date?: string;
+  created_by_user?: User;
+  workflow_status?: WorkflowStatus;
   url?: string;
   resource?: string;
-  feature_id?: string;
-  position?: number;
-  created_by_user?: User;
+  description?: RichText;
+  feature?: RecordRef;
+  assigned_to_user?: User;
+  tags?: unknown[];
+  custom_fields?: CustomField[];
+  comments_count?: number;
+  [key: string]: unknown;
+}
+
+export interface RequirementsListResponse {
+  requirements?: Requirement[];
+  pagination?: Pagination;
 }
 
 /**
- * Todo entity (not available in SDK)
+ * Todo (task) entity. Aha's newer API renamed `/todos` to `/tasks`; the field shape is
+ * unchanged.
  */
 export interface Todo {
   id?: string;
   name?: string;
   reference_num?: string;
+  due_date?: string;
+  status?: string;
+  body?: string;
+  position?: number;
+  product_id?: string;
+  assignee?: User;
+  assigned_to_users?: User[];
+  created_by_user?: User;
   created_at?: string;
   updated_at?: string;
-  description?: string;
-  url?: string;
-  resource?: string;
-  assignee?: User;
-  due_date?: string;
   completed?: boolean;
   completed_at?: string;
-  created_by_user?: User;
-}
-
-/**
- * List response wrappers for Requirements and Todos
- */
-export interface RequirementsListResponse {
-  requirements?: Requirement[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  url?: string;
+  resource?: string;
+  comments_count?: number;
+  custom_fields?: CustomField[];
+  taskable?: RecordRef;
+  [key: string]: unknown;
 }
 
 export interface TodosListResponse {
   todos?: Todo[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  pagination?: Pagination;
 }
 
 /**
- * Competitor entity (not available in SDK)
+ * Comment entity, as returned by every `GET /<resource>/{id}/comments` endpoint.
+ */
+export interface Comment {
+  id?: string;
+  body?: string;
+  created_at?: string;
+  updated_at?: string;
+  parent_comment_id?: string | null;
+  user?: User;
+  url?: string;
+  resource?: string;
+  commentable?: RecordRef;
+  [key: string]: unknown;
+}
+
+export interface CommentsListResponse {
+  comments?: Comment[];
+  pagination?: Pagination;
+}
+
+/**
+ * Competitor entity.
  */
 export interface Competitor {
   id?: string;
   name?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  description?: RichText | string;
   url?: string;
   resource?: string;
   product_id?: string;
@@ -237,16 +578,98 @@ export interface Competitor {
   strengths?: string;
   weaknesses?: string;
   created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface CompetitorsListResponse {
+  competitors?: Competitor[];
+  pagination?: Pagination;
 }
 
 /**
- * List response wrapper for Competitors
+ * Strategic Model entity (Aha renamed `/strategic_models` to `/strategy_models` upstream;
+ * the field shape is unchanged).
  */
-export interface CompetitorsListResponse {
-  competitors?: Competitor[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+export interface StrategicModel {
+  id?: string;
+  name?: string;
+  kind?: string;
+  reference_num?: string;
+  url?: string;
+  resource?: string;
+  components?: unknown[];
+  description?: unknown;
+  project?: RecordRef;
+  [key: string]: unknown;
+}
+
+export interface StrategicModelsListResponse {
+  strategic_models?: StrategicModel[];
+  pagination?: Pagination;
+}
+
+/**
+ * Idea Organization entity.
+ */
+export interface IdeaOrganization {
+  id?: string;
+  name?: string;
+  revenue?: unknown;
+  created_at?: string;
+  updated_at?: string;
+  description?: RichText;
+  created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface IdeaOrganizationsListResponse {
+  idea_organizations?: IdeaOrganization[];
+  pagination?: Pagination;
+}
+
+/**
+ * Idea endorsement (Aha models votes and endorsements as the same underlying record;
+ * `getIdeaVotes` and `getIdeaEndorsements` both return this shape).
+ */
+export interface IdeaEndorsement {
+  id?: string;
+  idea_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  value?: unknown;
+  weight?: number;
+  endorsed_by_portal_user?: RecordRef;
+  endorsed_by_idea_user?: RecordRef;
+  idea_organization?: RecordRef;
+  [key: string]: unknown;
+}
+
+export interface IdeaEndorsementsResponse {
+  idea_endorsements?: IdeaEndorsement[];
+  pagination?: Pagination;
+}
+
+export interface IdeaVotesResponse {
+  idea_endorsements?: IdeaEndorsement[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /me/assigned` - records assigned to the current user.
+ */
+export interface MeAssignedRecordsResponse {
+  records?: RecordRef[];
+  pagination?: Pagination;
+  [key: string]: unknown;
+}
+
+/**
+ * `GET /me/tasks` - to-dos pending for the current user.
+ */
+export interface MePendingTasksResponse {
+  tasks?: Todo[];
+  pagination?: Pagination;
+  [key: string]: unknown;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -20,7 +20,7 @@ import * as z from "zod/v4";
 // Imported rather than read from disk at runtime: the bundled build/index.js sits at a
 // different depth than this source file, so resolving "../../package.json" relative to
 // import.meta.url crashed the server on startup for every packaged artifact.
-import packageJson from "../../package.json";
+import packageJson from "../../package.json" with { type: "json" };
 
 /**
  * Count what actually got registered, for the startup log and server_status.
@@ -129,10 +129,7 @@ async function startServer() {
         name: "Aha.io MCP Server",
         version: packageJson.version,
         description: packageJson.description,
-        author: packageJson.author,
-        homepage: packageJson.homepage,
-        repository: packageJson.repository,
-        license: packageJson.license
+        websiteUrl: packageJson.homepage
       },
       // Returned in the initialize response, so clients have this before the first call.
       { instructions: buildServerInstructions(config.company) }

--- a/test/aha-service.test.ts
+++ b/test/aha-service.test.ts
@@ -230,10 +230,6 @@ describe('AhaService', () => {
       expect(typeof AhaService.getRelease).toBe('function');
     });
 
-    it('should have listReleases method', () => {
-      expect(typeof AhaService.listReleases).toBe('function');
-    });
-
     it('should have getReleaseFeatures method', () => {
       expect(typeof AhaService.getReleaseFeatures).toBe('function');
     });

--- a/test/create-feature.test.ts
+++ b/test/create-feature.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * The tool tests cannot catch this: they stub the service out, so nothing would notice the
+ * request going out with no body at all. This injects a fake FeaturesApi and inspects what the
+ * request would actually carry.
+ *
+ * The original bug was that the generated operation was declared without a request body, so
+ * there was no parameter to put the feature in and every create sent an empty POST that Aha
+ * accepted silently. aha-js 2.0.0 declares the body, so the payload travels as a typed
+ * parameter - but only the assertions below prove it is actually populated.
+ */
+describe('AhaService.createFeature', () => {
+  const original = (AhaService as any).featuresApi;
+  let call: { params: any } | null;
+
+  beforeEach(() => {
+    call = null;
+    (AhaService as any).featuresApi = {
+      releasesByReleaseFeaturesPost: async (params: any) => {
+        call = { params };
+        return { data: { feature: { id: '1', reference_num: 'PRJ1-1' } } };
+      }
+    };
+  });
+
+  afterEach(() => {
+    (AhaService as any).featuresApi = original;
+  });
+
+  it('sends the feature in the request body', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'Silence by label' } });
+
+    expect(call!.params.releaseId).toBe('PRJ1-R-1');
+    // The whole bug: this used to be unsendable, so Aha received an empty POST.
+    expect(call!.params.featuresPostRequest).toEqual({ feature: { name: 'Silence by label' } });
+  });
+
+  it('wraps a bare record rather than posting it unwrapped', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { name: 'Silence by label' });
+
+    expect(call!.params.featuresPostRequest).toEqual({ feature: { name: 'Silence by label' } });
+  });
+
+  it('does not double-wrap an already wrapped payload', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(call!.params.featuresPostRequest.feature.feature).toBeUndefined();
+  });
+
+  it('still posts a feature key when given nothing', async () => {
+    // Better an empty feature Aha can reject than a bodyless POST it silently accepts.
+    await AhaService.createFeature('PRJ1-R-1', undefined);
+
+    expect(call!.params.featuresPostRequest).toEqual({ feature: {} });
+  });
+
+  it('returns what Aha sends back, so the caller can link the new record', async () => {
+    const created = await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(created).toEqual({ feature: { id: '1', reference_num: 'PRJ1-1' } } as any);
+  });
+
+  it('propagates a rejection instead of reporting success', async () => {
+    (AhaService as any).featuresApi = {
+      releasesByReleaseFeaturesPost: async () => {
+        throw new Error('422 Unprocessable Entity');
+      }
+    };
+
+    await expect(
+      AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } })
+    ).rejects.toThrow('422 Unprocessable Entity');
+  });
+});

--- a/test/e2e-resource-discovery.test.ts
+++ b/test/e2e-resource-discovery.test.ts
@@ -27,12 +27,6 @@ const mockAhaService = {
       { id: 'FEAT-1', name: 'Feature 1', reference_num: 'TEST-1' },
       { id: 'FEAT-2', name: 'Feature 2', reference_num: 'TEST-2' }
     ]
-  })),
-  listReleases: mock(() => Promise.resolve({
-    releases: [
-      { id: 'REL-1', name: 'Release 1', reference_num: 'R1' },
-      { id: 'REL-2', name: 'Release 2', reference_num: 'R2' }
-    ]
   }))
 };
 
@@ -48,7 +42,6 @@ describe('E2E: Resource Discovery Workflows', () => {
       getProduct: AhaService.getProduct,
       listProducts: AhaService.listProducts,
       listFeatures: AhaService.listFeatures,
-      listReleases: AhaService.listReleases,
     };
 
     Object.values(mockAhaService).forEach(mock => mock.mockClear());
@@ -56,7 +49,6 @@ describe('E2E: Resource Discovery Workflows', () => {
     (AhaService as any).getProduct = mockAhaService.getProduct;
     (AhaService as any).listProducts = mockAhaService.listProducts;
     (AhaService as any).listFeatures = mockAhaService.listFeatures;
-    (AhaService as any).listReleases = mockAhaService.listReleases;
 
     // Create mock server
     resourceHandlers = new Map();
@@ -80,7 +72,6 @@ describe('E2E: Resource Discovery Workflows', () => {
     (AhaService as any).getProduct = originalMethods.getProduct;
     (AhaService as any).listProducts = originalMethods.listProducts;
     (AhaService as any).listFeatures = originalMethods.listFeatures;
-    (AhaService as any).listReleases = originalMethods.listReleases;
   });
 
   describe('Workflow: New User Searching for Workspaces', () => {
@@ -180,18 +171,6 @@ describe('E2E: Resource Discovery Workflows', () => {
       expect(promptText).toContain('workstream');
       expect(promptText).toContain('release');
       expect(promptText).toContain('aha://releases');
-
-      // Step 2: User accesses aha://releases
-      const releasesHandler = resourceHandlers.get('aha_releases');
-      expect(releasesHandler).toBeDefined();
-
-      const releasesResult = await releasesHandler!(new URL('aha://releases'));
-      const releasesData = JSON.parse(releasesResult.contents[0].text);
-
-      // Verify releases are returned
-      expect(releasesData.releases).toBeDefined();
-      expect(releasesData.releases.length).toBe(2);
-      expect(releasesData.releases[0].name).toBe('Release 1');
     });
   });
 
@@ -349,7 +328,6 @@ describe('E2E: Resource Discovery Workflows', () => {
       const existingResources = [
         'aha_features',
         'aha_epics',
-        'aha_releases',
         'aha_ideas'
       ];
 

--- a/test/e2e-resource-template-matching.test.ts
+++ b/test/e2e-resource-template-matching.test.ts
@@ -115,29 +115,6 @@ describe('ResourceTemplate URI Matching E2E', () => {
       });
     }, { timeout: 30000 });
 
-    it('should access aha://releases', async () => {
-      await withTestClient(async (client) => {
-        const contents = await client.readResource('aha://releases');
-
-        expect(contents).toBeDefined();
-        expect(Array.isArray(contents)).toBe(true);
-        expect(contents.length).toBeGreaterThan(0);
-        expect(contents[0].mimeType).toBe('application/json');
-
-        const data = JSON.parse(contents[0].text!);
-        expect(data).toBeDefined();
-        expect(data.releases).toBeDefined();
-        expect(Array.isArray(data.releases)).toBe(true);
-        expect(data.releases.length).toBeGreaterThan(0);
-
-        // Verify mock data structure
-        const firstRelease = data.releases[0];
-        expect(firstRelease.release).toBeDefined();
-        expect(firstRelease.release.id).toMatch(/^REL-/);
-        expect(firstRelease.release.name).toContain('Test Release');
-      });
-    }, { timeout: 30000 });
-
     it('should access aha://strategic-models', async () => {
       await withTestClient(async (client) => {
         const contents = await client.readResource('aha://strategic-models');

--- a/test/feature-custom-fields.test.ts
+++ b/test/feature-custom-fields.test.ts
@@ -87,7 +87,7 @@ describe('AhaService.updateFeatureCustomFields', () => {
   beforeEach(() => {
     request = null;
     (AhaService as any).featuresApi = {
-      featuresUpdate: async (params: any) => {
+      featuresByIdPut: async (params: any) => {
         request = params;
         return { data: { feature: { id: params.id, name: 'Test feature' } } };
       }
@@ -104,7 +104,7 @@ describe('AhaService.updateFeatureCustomFields', () => {
     await AhaService.updateFeatureCustomFields('FEAT-1', customFields);
 
     expect(request.id).toBe('FEAT-1');
-    expect(request.featureUpdateRequest.feature.custom_fields).toEqual(customFields);
+    expect(request.featuresPutRequest.feature.custom_fields).toEqual(customFields);
   });
 
   it('returns the updated feature', async () => {
@@ -115,7 +115,7 @@ describe('AhaService.updateFeatureCustomFields', () => {
 
   it('propagates API errors instead of reporting success', async () => {
     (AhaService as any).featuresApi = {
-      featuresUpdate: async () => { throw new Error('422 Unprocessable Entity'); }
+      featuresByIdPut: async () => { throw new Error('422 Unprocessable Entity'); }
     };
 
     await expect(

--- a/test/mcp-accessibility.test.ts
+++ b/test/mcp-accessibility.test.ts
@@ -153,7 +153,6 @@ describe('MCP Server Accessibility', () => {
         'aha_products', 
         'aha_initiatives',
         'aha_goals',
-        'aha_releases',
         'aha_release_phases',
         'aha_todos',
         'aha_ideas',
@@ -207,8 +206,7 @@ describe('MCP Server Accessibility', () => {
         'aha_me_assigned_records',
         'aha_me_pending_tasks',
         'aha_idea_endorsements',
-        'aha_idea_votes',
-        'aha_idea_watchers'
+        'aha_idea_votes'
       ];
 
       expectedSpecialResources.forEach(resourceName => {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -30,7 +30,6 @@ const mockAhaService = {
   listGoals: mock(() => Promise.resolve({ goals: [{ id: 'GOAL-1' }, { id: 'GOAL-2' }] })),
   getGoalEpics: mock(() => Promise.resolve({ epics: [{ id: 'EPIC-1' }, { id: 'EPIC-2' }] })),
   getRelease: mock(() => Promise.resolve({ id: 'REL-123', name: 'Test Release' })),
-  listReleases: mock(() => Promise.resolve({ releases: [{ id: 'REL-1' }, { id: 'REL-2' }] })),
   getReleaseFeatures: mock(() => Promise.resolve({ features: [{ id: 'FEAT-1' }, { id: 'FEAT-2' }] })),
   getReleaseEpics: mock(() => Promise.resolve({ epics: [{ id: 'EPIC-1' }, { id: 'EPIC-2' }] })),
   getReleasePhase: mock(() => Promise.resolve({ id: 'RP-123', name: 'Test Release Phase' })),
@@ -72,7 +71,6 @@ describe('Resources', () => {
       listGoals: AhaService.listGoals,
       getGoalEpics: AhaService.getGoalEpics,
       getRelease: AhaService.getRelease,
-      listReleases: AhaService.listReleases,
       getReleaseFeatures: AhaService.getReleaseFeatures,
       getReleaseEpics: AhaService.getReleaseEpics,
       getReleasePhase: AhaService.getReleasePhase,
@@ -110,7 +108,6 @@ describe('Resources', () => {
     (AhaService as any).listGoals = mockAhaService.listGoals;
     (AhaService as any).getGoalEpics = mockAhaService.getGoalEpics;
     (AhaService as any).getRelease = mockAhaService.getRelease;
-    (AhaService as any).listReleases = mockAhaService.listReleases;
     (AhaService as any).getReleaseFeatures = mockAhaService.getReleaseFeatures;
     (AhaService as any).getReleaseEpics = mockAhaService.getReleaseEpics;
     (AhaService as any).getReleasePhase = mockAhaService.getReleasePhase;
@@ -176,7 +173,6 @@ describe('Resources', () => {
     (AhaService as any).listGoals = originalMethods.listGoals;
     (AhaService as any).getGoalEpics = originalMethods.getGoalEpics;
     (AhaService as any).getRelease = originalMethods.getRelease;
-    (AhaService as any).listReleases = originalMethods.listReleases;
     (AhaService as any).getReleaseFeatures = originalMethods.getReleaseFeatures;
     (AhaService as any).getReleaseEpics = originalMethods.getReleaseEpics;
     (AhaService as any).getReleasePhase = originalMethods.getReleasePhase;
@@ -796,7 +792,6 @@ describe('Resources', () => {
         'aha_goals',
         'aha_goal_epics',
         'aha_release',
-        'aha_releases',
         'aha_release_features',
         'aha_release_epics',
         'aha_release_phase',
@@ -831,29 +826,6 @@ describe('Resources', () => {
         const uri = new URL('aha://release/');
 
         await expect(handler!(uri, {}, {} as any)).rejects.toThrow('Invalid release ID: ID is missing from URI');
-      });
-    });
-
-    describe('aha_releases resource', () => {
-      it('should list all releases', async () => {
-        const handler = resourceHandlers.get('aha_releases');
-        expect(handler).toBeDefined();
-
-        const uri = new URL('aha://releases');
-        const result = await handler!(uri, {}, {} as any);
-
-        expect(mockAhaService.listReleases).toHaveBeenCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        );
-        expect(result.contents).toHaveLength(1);
-        expect(result.contents[0].uri).toBe('aha://releases');
-        expect(result.contents[0].text).toContain('REL-1');
       });
     });
 


### PR DESCRIPTION
Bumps `@cedricziel/aha-js` 1.2.5 -> 2.0.0 and migrates the service layer onto it.

2.0.0 is generated from [Aha's published OpenAPI document](https://www.aha.io/openapi.json) instead of a hand-maintained partial spec (see cedricziel/aha-js#26), so every SDK method and type is renamed — 181 type errors on the bump.

## How the mapping was derived

Not by eye. The 53 straightforward renames came from joining the old and new generated clients on (HTTP verb, normalised path), so each one is a verified same-endpoint rename. The remaining 16 split three ways:

- **Renamed upstream** — `/todos` is `/tasks`, `/strategic_models` is `/strategy_models`, and votes are modelled as endorsements.
- **Never existed** — the six `PUT /features/{id}/<subresource>` endpoints (tags, epic, goals, score, progress, release), plus `GET /ideas/{id}/watchers` and the global `GET /releases`. None appear in Aha's spec *or* their documentation.
- **Real but undocumented** — `PUT` and `DELETE /competitors/{id}` are documented by Aha yet absent from their spec, so they get a direct authenticated request that still shapes failures for `describeAhaError`.

## Three bugs fixed that predate this migration

1. **Custom-field updates were silent no-ops.** `PUT /features/{id}/custom_fields` was declared without a request body, so the values could not be sent — and the call reported success. Now routed through `PUT /features/{id}` with the field nested under `feature`.
2. **Six feature sub-resource endpoints have been 404ing** for the same reason: the old hand-written spec invented them.
3. **A silent-wrong-answer regression, caught before it shipped.** Aha's spec under-documents list query strings, so the generated request types dropped `q`, `tag`, `assigned_to_user`, `status` and `updated_since`. `aha_list_features` would have returned *unfiltered* results while still advertising the filters — invisible to the compiler and to every test. Parity was restored by extracting what the 1.2.5 client actually put on the wire from its generated sources, and sending those through `options.params`.

## Removed

`aha_idea_watchers`, `aha_releases` and `aha_releases_filtered` (59 registered resources -> 56). No Aha endpoint backs any of them, so they could only ever 404. Prompt, sampling and resource-guide text that pointed at `aha://releases` now points at `aha://releases/{product_id}` and names `aha://products` as where to get the id.

`aha_product_releases` is real and untouched.

## Structural change

`AhaService` no longer leaks SDK types. It maps onto local domain types in `aha-types.ts` and is now the only module importing `@cedricziel/aha-js`. The generated names are per-operation (`FeaturesGetResponseFeaturesInner`) and churn on every regeneration — leaking them is what turned an upstream regeneration into 181 errors here.

## Verification

- `npx tsc --noEmit` — clean, apart from one pre-existing unrelated error in `config.ts:195`
- `bun run test` — 413 pass, 0 fail
- `bun run mcpb:validate` — passes; the manifest enumerates tools only (31, unchanged), so the resource removals do not desync it
- Filter restoration proven against a local server rather than assumed: `/api/v1/features?page=2&per_page=50&q=search+term&tag=urgent&assigned_to_user=me%40example.com` — typed pagination and restored filters both present, `undefined` omitted

## Note on Aha's spec quality

Several generated get-one operations are typed as their *list* response (`usersByIdGet`, `epicsByIdGet`, `goalsByIdGet`, `featuresByIdGet`, `initiativesByIdGet`, `releasesByIdGet`), and `meGet`/`meAssignedGet` share `meTasksGet`'s type. The endpoints return single records; only the generated types are wrong, because Aha's document reuses one response schema per resource. Each is cast narrowly with a comment naming the reason. Worth revisiting if Aha fixes their spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release listings now require a product ID and use product-scoped resources.
  * Improved compatibility with Aha responses across features, releases, comments, custom fields, and related records.
  * Feature creation and custom-field updates now handle request data more reliably.

* **Bug Fixes**
  * Improved search error handling and response normalization.
  * Removed unavailable global release and idea-watcher resources.

* **Tests**
  * Expanded coverage for feature creation and updated resource and custom-field behavior tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->