### PR TITLE
feat!: render tool results as summaries and links instead of duplicated JSON

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,23 @@ updates:
       interval: "daily"
     assignees:
       - "cedricziel"
+    groups:
+      # Linting and commit-hook tooling moves together and never affects the
+      # published bundle, so it arrives as one PR rather than one per package.
+      # The eslint/prettier patterns are here so adding a linter later does not
+      # silently start opening ungrouped PRs again.
+      lint:
+        patterns:
+          - "commitlint"
+          - "@commitlint/*"
+          - "husky"
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "prettier-*"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   modelcontextprotocol/typescript-sdk#1083. Delete it once that lands, not before -
   without it, resource URIs carrying query parameters do not match.
 - `manifest.json`'s tool list must match what the server actually registers. Regenerate it
-  from a running server rather than editing by hand, and keep prompts as
+  with `bun run manifest:sync`, which spawns the real server and copies `tools/list`
+  verbatim, rather than editing by hand - `bun run manifest:check` fails without writing,
+  for CI. Changing a tool's description in `src/core/tools.ts` and forgetting this leaves
+  the desktop extension advertising the old behaviour. Keep prompts as
   `prompts_generated: true` - the schema requires a `text` field on any statically declared
   prompt, which the server generates at runtime instead.
 
@@ -190,7 +193,7 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
 - **Authentication**: Runtime configuration with environment variables and config file support
 
 Tool, resource and prompt counts are also mirrored in `manifest.json` for the desktop
-extension - regenerate that list from a running server rather than editing it by hand.
+extension - regenerate that list with `bun run manifest:sync` rather than editing it by hand.
 
 ### Transport Layer
 
@@ -260,8 +263,7 @@ precedence over `name`). They must stay identical; the e2e suite asserts it.
 
 #### Tool output: `outputSchema` and `structuredContent`
 
-Every tool declares an `outputSchema` and returns `structuredContent`, with the serialised
-JSON repeated in a text block for clients that ignore structured results. Schemas live in
+Every tool declares an `outputSchema` and returns `structuredContent`. Schemas live in
 `src/core/tool-output.ts`. Two rules there are load-bearing:
 
 - **Anything wrapping an Aha record uses `z.looseObject`.** A raw Zod shape converts to
@@ -281,7 +283,32 @@ a missing `structuredContent` fails output validation and sinks the call.
 
 Tools that touch a single record also return a `resource_link` to its `aha://` URI via
 `recordLinks()`, so a client can re-read current state instead of trusting the point-in-time
-copy. No identifier, no link: a link to an unreadable URI is worse than none.
+copy. No identifier, no link: a link to an unreadable URI is worse than none. Each link sets
+`title` as well as `name` - hosts display `title` in preference - plus
+`annotations.audience`, `priority: 1` and, when Aha's `updated_at` is plainly Zulu ISO 8601,
+`lastModified`. The timestamp guard is deliberate: the SDK types that annotation as
+`z.iso.datetime()`, which rejects a numeric offset, and a rejected annotation fails the whole
+call where an omitted one costs only a hint.
+
+`aha_search` deliberately emits **no** `resource_link`s. `recordLinks()` can only build URIs
+for the five types with a single-record template in `resources.ts`, while search returns a
+dozen or more - so linking would cover some hits and silently skip others in the same result
+set, for no reason a client could see. Its hits already carry an absolute `url`, and `perPage`
+goes to 200, so the alternative was up to 200 content blocks of partial coverage. Reconsider
+only if the missing record types gain resource templates.
+
+**The text block is a one-line summary, not a copy of the record.** `recordSummary()` builds
+`Updated feature PRJ1-123 "Name" - https://...`; `aha_search` renders its hits as a markdown
+link list. This block used to be the payload re-serialised with `JSON.stringify(x, null, 2)`,
+which duplicated `structuredContent` verbatim - double the tokens, and nothing a client could
+present as anything but a blob. The record still travels in `structuredContent` and the
+`resource_link` is the durable pointer, so the text block's job is to say what happened in a
+form a person and a model can both read. Building the search links server-side also keeps the
+model from re-emitting - and mangling - URLs it only ever needed to pass through.
+
+Tool descriptions state what comes back ("Returns the updated feature and a link to it").
+Host-side rendering is decided by a model reading tool contracts, so a description that names
+its output is the cheapest lever this server has over how a result is presented.
 
 #### Tool errors
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@cedricziel/aha-mcp",
       "dependencies": {
-        "@cedricziel/aha-js": "1.2.5",
+        "@cedricziel/aha-js": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.12.2",
         "cors": "^2.8.5",
@@ -34,7 +34,7 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
-    "@cedricziel/aha-js": ["@cedricziel/aha-js@1.2.5", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-AOLvID4QaDPnTzQuecuSc3nSCr6AeWZH2/ytpLgOdQNeHTTIlQhQcfI6Ok88k61vDzPIFZrOZXcomj79aVCrKg=="],
+    "@cedricziel/aha-js": ["@cedricziel/aha-js@2.0.0", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-FOoMk0uf1Ya/CjmHo83gqERX4FoTrqouZOKQI+GFoKKJ7tomVt25dLei2JulLsPcUTj9ELSZrYvcf2/Ib03sLg=="],
 
     "@commitlint/cli": ["@commitlint/cli@21.2.1", "", { "dependencies": { "@commitlint/config-conventional": "^21.2.0", "@commitlint/format": "^21.2.0", "@commitlint/lint": "^21.2.0", "@commitlint/load": "^21.2.0", "@commitlint/read": "^21.2.1", "@commitlint/types": "^21.2.0", "tinyexec": "^1.0.0", "yargs": "^18.0.0" }, "bin": { "commitlint": "cli.js" } }, "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg=="],
 

--- a/manifest.json
+++ b/manifest.json
@@ -52,107 +52,107 @@
   "tools": [
     {
       "name": "aha_associate_feature_with_epic",
-      "description": "Associate a feature with an epic in Aha.io"
+      "description": "Associate a feature with an epic in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_associate_feature_with_goals",
-      "description": "Associate a feature with multiple goals in Aha.io"
+      "description": "Associate a feature with multiple goals in Aha.io. Replaces the feature's whole goal set, so goals left out are unlinked. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_create_competitor",
-      "description": "Create a competitor in a product in Aha.io"
+      "description": "Create a competitor in a product in Aha.io. Returns the created competitor and a link to it."
     },
     {
       "name": "aha_create_epic_in_product",
-      "description": "Create an epic within a specific product in Aha.io"
+      "description": "Create an epic within a specific product in Aha.io. Returns the created epic and a link to it."
     },
     {
       "name": "aha_create_epic_in_release",
-      "description": "Create an epic within a specific release in Aha.io"
+      "description": "Create an epic within a specific release in Aha.io. Returns the created epic and a link to it."
     },
     {
       "name": "aha_create_feature",
-      "description": "Create a feature within a specific release in Aha.io"
+      "description": "Create a feature within a specific release in Aha.io. Returns the created feature and a link to it."
     },
     {
       "name": "aha_create_feature_comment",
-      "description": "Create a comment on a feature in Aha.io"
+      "description": "Create a comment on a feature in Aha.io. Returns the created comment."
     },
     {
       "name": "aha_create_idea",
-      "description": "Create an idea in a product in Aha.io"
+      "description": "Create an idea in a product in Aha.io. Returns the created idea and a link to it."
     },
     {
       "name": "aha_create_idea_by_portal_user",
-      "description": "Create an idea by a portal user in Aha.io"
+      "description": "Create an idea in a product in Aha.io, attributed to an ideas-portal user rather than to the API token's owner. Returns the created idea and a link to it."
     },
     {
       "name": "aha_create_idea_with_category",
-      "description": "Create an idea with a category in a product in Aha.io"
+      "description": "Create an idea with a category in a product in Aha.io. Returns the created idea and a link to it."
     },
     {
       "name": "aha_create_idea_with_portal_settings",
-      "description": "Create an idea with enhanced portal settings in Aha.io"
+      "description": "Create an idea in a product in Aha.io with ideas-portal settings, category and score in one call. Returns the created idea and a link to it."
     },
     {
       "name": "aha_create_idea_with_score",
-      "description": "Create an idea with a score in a product in Aha.io"
+      "description": "Create an idea with a score in a product in Aha.io. Returns the created idea and a link to it."
     },
     {
       "name": "aha_create_initiative_in_product",
-      "description": "Create an initiative within a specific product in Aha.io"
+      "description": "Create an initiative within a specific product in Aha.io. Returns the created initiative and a link to it."
     },
     {
       "name": "aha_delete_competitor",
-      "description": "Delete a competitor in Aha.io"
+      "description": "Delete a competitor in Aha.io. Returns a confirmation naming the deleted competitor; there is no record to return."
     },
     {
       "name": "aha_delete_epic",
-      "description": "Delete an epic in Aha.io"
+      "description": "Delete an epic in Aha.io. Returns a confirmation naming the deleted epic; there is no record to return."
     },
     {
       "name": "aha_delete_feature",
-      "description": "Delete a feature in Aha.io"
+      "description": "Delete a feature in Aha.io. Returns a confirmation naming the deleted feature; there is no record to return."
     },
     {
       "name": "aha_delete_idea",
-      "description": "Delete an idea in Aha.io"
+      "description": "Delete an idea in Aha.io. Returns a confirmation naming the deleted idea; there is no record to return."
     },
     {
       "name": "aha_move_feature_to_release",
-      "description": "Move a feature to a different release in Aha.io"
+      "description": "Move a feature to a different release in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_search",
-      "description": "Search across Aha.io records - ideas, features, epics, initiatives, goals, key results, requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and \"quoted phrases\". Use '*' to match everything, which is useful with workspaceId to list a workspace's records."
+      "description": "Search across Aha.io records - ideas, features, epics, initiatives, goals, key results, requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and \"quoted phrases\". Use '*' to match everything, which is useful with workspaceId to list a workspace's records. Returns each hit's name, type and absolute Aha.io URL, already rendered as markdown links, plus paging counts."
     },
     {
       "name": "aha_update_competitor",
-      "description": "Update a competitor in Aha.io"
+      "description": "Update a competitor in Aha.io. Returns the updated competitor and a link to it."
     },
     {
       "name": "aha_update_epic",
-      "description": "Update an epic in Aha.io"
+      "description": "Update an epic's name or description in Aha.io. Returns the updated epic and a link to it."
     },
     {
       "name": "aha_update_feature",
-      "description": "Update a feature in Aha.io"
+      "description": "Update a feature's name or description in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_update_feature_custom_fields",
-      "description": "Update a feature's custom fields in Aha.io"
+      "description": "Update a feature's custom fields in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_update_feature_progress",
-      "description": "Update a feature's progress in Aha.io"
+      "description": "Update a feature's progress percentage in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_update_feature_score",
-      "description": "Update a feature's score in Aha.io"
+      "description": "Update a feature's score in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_update_feature_tags",
-      "description": "Update tags for a feature in Aha.io"
+      "description": "Update tags for a feature in Aha.io. Replaces the feature's whole tag set, so tags left out are removed. Returns the updated feature and a link to it."
     },
     {
       "name": "configure_server",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "test:watch": "bun test --watch --env-file=/dev/null",
     "prepublishOnly": "bun run build",
     "prepare": "husky",
+    "manifest:sync": "bun run scripts/sync-manifest.ts",
+    "manifest:check": "bun run scripts/sync-manifest.ts --check",
     "mcpb:validate": "mcpb validate manifest.json",
     "mcpb:pack": "bun run build && mcpb pack . dist/aha-mcp.mcpb",
     "docker:build": "docker build -t ghcr.io/cedricziel/aha-mcp .",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@cedricziel/aha-js": "1.2.5",
+    "@cedricziel/aha-js": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "axios": "^1.12.2",
     "cors": "^2.8.5",

--- a/scripts/sync-manifest.ts
+++ b/scripts/sync-manifest.ts
@@ -1,0 +1,54 @@
+/**
+ * Regenerate `manifest.json`'s tool list from a running server.
+ *
+ * CLAUDE.md requires the manifest to match what the server actually registers, and to be
+ * regenerated rather than hand-edited - but nothing automated it, so a tool description
+ * changed in `src/core/tools.ts` silently left the desktop extension describing the old
+ * behaviour. This spawns the real server over stdio and copies `tools/list` verbatim.
+ *
+ * Prompts stay untouched: the manifest declares `prompts_generated: true`, because the
+ * bundle schema demands a `text` field on any statically listed prompt and the server
+ * generates that at runtime.
+ *
+ *   bun run manifest:sync            # rewrite manifest.json
+ *   bun run manifest:sync --check    # exit 1 if it would change, for CI
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { TestMCPClient } from "../test/utils/mcp-client-helper.js";
+
+const check = process.argv.includes("--check");
+const path = "manifest.json";
+
+const client = new TestMCPClient();
+let tools: { name: string; description: string }[];
+
+try {
+  // Credentials the server accepts but never spends: registration does not call Aha.
+  await client.connect({ company: "manifest-sync", token: "manifest-sync" });
+  tools = (await client.listTools())
+    .map(tool => ({ name: tool.name, description: tool.description ?? "" }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+} finally {
+  await client.disconnect();
+}
+
+const manifest = JSON.parse(readFileSync(path, "utf8"));
+const before = JSON.stringify(manifest.tools);
+manifest.tools = tools;
+const after = JSON.stringify(tools);
+
+if (before === after) {
+  console.log(`manifest.json already lists all ${tools.length} tools correctly`);
+  process.exit(0);
+}
+
+if (check) {
+  console.error(
+    `manifest.json is out of date: it lists ${JSON.parse(before).length} tools, the server ` +
+      `registers ${tools.length}. Run 'bun run manifest:sync'.`
+  );
+  process.exit(1);
+}
+
+writeFileSync(path, JSON.stringify(manifest, null, 2) + "\n");
+console.log(`manifest.json updated with ${tools.length} tools`);

--- a/src/core/prompts.ts
+++ b/src/core/prompts.ts
@@ -725,7 +725,7 @@ I can help you find and use Aha.io resources. Here's how to get started:
 - \`aha://products\` - List all products/workspaces
 - \`aha://features\` - Search features globally
 - \`aha://ideas\` - Search ideas and feedback
-- \`aha://releases\` - List releases/workstreams
+- \`aha://releases/{product_id}\` - List releases/workstreams for a product (get the id from \`aha://products\`)
 
 **Common Questions:**
 
@@ -736,7 +736,7 @@ A: Use \`aha://products\` - in Aha.io, products and workspaces are the same thin
 A: Product Areas are not currently exposed as resources. Use \`aha://products\` to access products, which may include area information in the response.
 
 **Q: "How do I find workstreams?"**
-A: Use \`aha://releases\` - releases function as workstreams for organizing work.
+A: Use \`aha://releases/{product_id}\` - releases function as workstreams for organizing work. Get the product id from \`aha://products\` first.
 
 **Resource Navigation Pattern:**
 1. Start with top-level resources (products, features, ideas, releases)

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -38,7 +38,7 @@ const RESOURCE_SYNONYMS = {
   },
   workstream: {
     canonical: "release",
-    resources: ["aha_release", "aha_releases"],
+    resources: ["aha_release", "aha_product_releases"],
     note: "Releases can function as workstreams for organizing features and epics"
   }
 };
@@ -66,12 +66,12 @@ export function registerResources(server: McpServer) {
             terminology_guide: {
               product_workspace: "Products and workspaces are the same in Aha.io. Use aha://products or aha://product/{id}",
               product_areas: "Product Areas are subdivisions within products. Not currently available as resources.",
-              releases_workstreams: "Releases can be used as workstreams. Use aha://releases or aha://release/{id}"
+              releases_workstreams: "Releases can be used as workstreams. Use aha://releases/{product_id} or aha://release/{id}"
             },
             common_questions: {
               "How do I find workspaces?": "Use aha://products - products and workspaces are synonymous",
               "How do I find Product Areas?": "Product Areas are not currently exposed as resources. Use products instead.",
-              "Where are workstreams?": "Releases can function as workstreams - use aha://releases"
+              "Where are workstreams?": "Releases can function as workstreams - use aha://releases/{product_id}"
             }
           }, null, 2),
           mimeType: "application/json"
@@ -1199,75 +1199,9 @@ export function registerResources(server: McpServer) {
     }
   );
 
-  // Aha releases list resource with filters and pagination
-  // Shared handler for both base URI and template URI
-  const handleReleases = async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
-    try {
-      const parkingLot = variables?.parkingLot === 'true' ? true :
-                        variables?.parkingLot === 'false' ? false :
-                        uri.searchParams.get('parkingLot') === 'true' ? true :
-                        uri.searchParams.get('parkingLot') === 'false' ? false : undefined;
-      const page = variables?.page ? parseInt(normalizeVar(variables.page)!) : uri.searchParams.get('page') ? parseInt(uri.searchParams.get('page')!) : undefined;
-      const perPage = variables?.perPage ? parseInt(normalizeVar(variables.perPage)!) : uri.searchParams.get('perPage') ? parseInt(uri.searchParams.get('perPage')!) : undefined;
-
-      const releases = await getAhaService().listReleases(
-        normalizeVar(variables?.query) || uri.searchParams.get('query') || undefined,
-        normalizeVar(variables?.updatedSince) || uri.searchParams.get('updatedSince') || undefined,
-        normalizeVar(variables?.assignedToUser) || uri.searchParams.get('assignedToUser') || undefined,
-        normalizeVar(variables?.status) || uri.searchParams.get('status') || undefined,
-        parkingLot,
-        page,
-        perPage
-      );
-
-      return {
-        contents: [{
-          uri: uri.toString(),
-          text: JSON.stringify(releases, null, 2),
-          mimeType: "application/json"
-        }]
-      };
-    } catch (error) {
-      console.error(`Error retrieving releases list:`, error);
-      throw toMcpError(error, uri.toString());
-    }
-  };
-
-  // Base URI registration - matches aha://releases
-  server.registerResource(
-    "aha_releases",
-    "aha://releases",
-    {
-      title: "Aha Releases",
-      description: "List all releases",
-      mimeType: "application/json"
-    },
-    async (uri: URL, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
-      return handleReleases(uri, {}, _extra);
-    }
-  );
-
-  // Template URI registration - matches aha://releases?query=...
-  server.registerResource(
-    "aha_releases_filtered",
-    new ResourceTemplate(
-      "aha://releases{?query,updatedSince,assignedToUser,status,parkingLot,page,perPage}",
-      {
-        list: undefined,
-        complete: {
-          parkingLot: async () => ['true', 'false'],
-          page: async () => ['1', '2', '3', '4', '5'],
-          perPage: async () => ['20', '50', '100', '200']
-        }
-      }
-    ),
-    {
-      title: "Aha Releases (Filtered)",
-      description: "List releases with filters and pagination",
-      mimeType: "application/json"
-    },
-    handleReleases
-  );
+  // Note: a global "list all releases" resource (GET /releases) was removed - that endpoint
+  // does not exist in Aha's OpenAPI document or published docs and always 404s. Releases are
+  // only reachable scoped to a product; see aha_product_releases (aha://releases/{product_id}).
 
   // Aha release features resource
   server.registerResource(
@@ -1967,46 +1901,8 @@ export function registerResources(server: McpServer) {
     }
   );
 
-  // Aha idea watchers resource
-  server.registerResource(
-    "aha_idea_watchers",
-    new ResourceTemplate(
-      "aha://idea/{id}/watchers",
-      {
-        list: undefined,
-        complete: {
-          id: async () => []
-        }
-      }
-    ),
-    {
-      title: "Aha Idea Watchers",
-      description: "Get watchers for a specific idea",
-      mimeType: "application/json"
-    },
-    async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
-      const pathParts = uri.pathname.split('/');
-      const ideaId = normalizeVar(variables.id) || pathParts[pathParts.length - 2]; // idea_id is before /watchers
-
-      if (!ideaId) {
-        throw new Error('Invalid idea ID: Idea ID is missing from URI');
-      }
-
-      try {
-        const watchers = await getAhaService().getIdeaWatchers(ideaId);
-        return {
-          contents: [{
-            uri: uri.toString(),
-            text: JSON.stringify(watchers, null, 2),
-            mimeType: "application/json"
-          }]
-        };
-      } catch (error) {
-        console.error(`Error retrieving watchers for idea ${ideaId}:`, error);
-        throw toMcpError(error, uri.toString());
-      }
-    }
-  );
+  // Note: aha_idea_watchers (GET /ideas/{id}/watchers) was removed - that endpoint does not
+  // exist in Aha's OpenAPI document or published docs and always 404s.
 
   // Aha global ideas list resource with advanced filters and pagination
   // Shared handler for both base URI and template URI

--- a/src/core/sampling.ts
+++ b/src/core/sampling.ts
@@ -68,7 +68,7 @@ export function registerSampling(server: McpServer) {
 - **aha://products** - List all products/workspaces
 - **aha://features** - Search features across all products
 - **aha://ideas** - Search ideas and feedback
-- **aha://releases** - List releases/workstreams
+- **aha://releases/{product_id}** - List releases/workstreams for a product (get the id from aha://products)
 
 What would you like to explore?`
           }

--- a/src/core/sampling/resource-primer.ts
+++ b/src/core/sampling/resource-primer.ts
@@ -90,20 +90,21 @@ export function generateWorkstreamPrimer(query: string): ResourcePrimer {
   return {
     message: `I notice you're looking for workstreams. In Aha.io, **releases can function as workstreams** for organizing features and epics.`,
     suggestedResources: [
-      'aha://releases - List all releases/workstreams',
+      'aha://releases/{product_id} - List releases for a specific product',
       'aha://release/{id} - Get a specific release/workstream',
-      'aha://releases/{product_id} - List releases for a specific product'
+      'aha://products - List products, to find the product_id a release list needs'
     ],
     exampleUris: [
-      'aha://releases?status=active&page=1',
+      'aha://releases/PROD-1?status=active&page=1',
       'aha://release/PROJ-R-1',
       'aha://releases/PROD-1'
     ],
     workflow: [
-      '1. List releases: aha://releases (optionally filtered by product)',
-      '2. Get release details: aha://release/{id}',
-      '3. Access release features: aha://release/{id}/features',
-      '4. Access release epics: aha://release/{id}/epics'
+      '1. Get a product id: aha://products',
+      '2. List that product\'s releases: aha://releases/{product_id}',
+      '3. Get release details: aha://release/{id}',
+      '4. Access release features: aha://release/{id}/features',
+      '5. Access release epics: aha://release/{id}/epics'
     ]
   };
 }
@@ -119,7 +120,7 @@ export function generateDiscoveryPrimer(): ResourcePrimer {
       'aha://products - List all products/workspaces',
       'aha://features - Search features globally',
       'aha://ideas - Search ideas globally',
-      'aha://releases - List all releases'
+      'aha://releases/{product_id} - List releases for a product'
     ],
     exampleUris: [
       'aha://resources',
@@ -129,7 +130,7 @@ export function generateDiscoveryPrimer(): ResourcePrimer {
     ],
     workflow: [
       '1. Check aha://resources to understand available resources and terminology',
-      '2. Start with top-level resources like products, features, ideas, or releases',
+      '2. Start with top-level resources like products, features, or ideas',
       '3. Navigate to nested resources once you have IDs (e.g., product → releases → features)',
       '4. Use query parameters for filtering and pagination'
     ]

--- a/src/core/services/aha-service.interface.ts
+++ b/src/core/services/aha-service.interface.ts
@@ -1,50 +1,51 @@
 /**
  * Interface for AhaService - allows for mock implementations in tests
+ *
+ * Every method speaks in the local domain types from `../types/aha-types.js`, never in
+ * `@cedricziel/aha-js` types. The SDK is generated per-operation and renames every export
+ * on each regeneration (`Feature` -> `FeaturesGetResponseFeaturesInner`, etc.); leaking
+ * those through here would re-break every call site the next time aha-js regenerates.
+ * `aha-service.ts` is the only file allowed to import from `@cedricziel/aha-js` - it is
+ * responsible for mapping the SDK's response shapes onto the types below.
  */
 
 import type {
   Feature,
   FeaturesListResponse,
   Epic,
+  EpicsListResponse,
   User,
   IdeaResponse,
+  IdeasListResponse,
   InitiativeResponse,
   InitiativesListResponse,
+  Product,
   ProductsListResponse,
-  CommentsGetEpic200Response,
-  EpicsList200Response,
-  IdeasListResponse,
   Comment,
+  CommentsListResponse,
   GoalGetResponse,
-  GoalsListResponse as SdkGoalsListResponse,
+  GoalsListResponse,
+  GoalEpicsResponse,
   ReleaseGetResponse,
-  ReleasesListResponse as SdkReleasesListResponse,
-  ReleasePhasesList200Response,
-  ReleasePhase as SdkReleasePhase,
+  ReleasesListResponse,
+  ReleaseFeaturesResponse,
+  ReleasePhase,
+  ReleasePhasesListResponse,
   Competitor,
-  StrategicModelGetResponse,
-  StrategicModelsListResponse,
+  CompetitorsListResponse,
   StrategicModel,
-  IdeaOrganizationGetResponse,
-  IdeaOrganizationsListResponse,
+  StrategicModelsListResponse,
   IdeaOrganization,
-  TodosList200Response,
+  IdeaOrganizationsListResponse,
+  Todo,
+  TodosListResponse,
+  Requirement,
   MeAssignedRecordsResponse,
   MePendingTasksResponse,
-  IdeasGetEndorsements200Response,
-  IdeasGetVotes200Response,
-  IdeasGetWatchers200Response,
-  CustomFieldsListAll200Response,
-  CustomFieldsListOptions200Response
-} from '@cedricziel/aha-js';
-
-import type {
-  Product,
-  Requirement,
-  Todo,
-  ReleaseFeaturesResponse,
-  GoalEpicsResponse,
-  CompetitorsListResponse
+  IdeaEndorsementsResponse,
+  IdeaVotesResponse,
+  CustomFieldDefinitionsResponse,
+  CustomFieldOptionsResponse
 } from '../types/aha-types.js';
 
 export interface IAhaService {
@@ -100,19 +101,10 @@ export interface IAhaService {
     status?: string,
     page?: number,
     perPage?: number
-  ): Promise<SdkGoalsListResponse>;
+  ): Promise<GoalsListResponse>;
   getGoal(goalId: string): Promise<GoalGetResponse>;
 
   // Releases
-  listReleases(
-    query?: string,
-    updatedSince?: string,
-    assignedToUser?: string,
-    status?: string,
-    parkingLot?: boolean,
-    page?: number,
-    perPage?: number
-  ): Promise<SdkReleasesListResponse>;
   getRelease(releaseId: string): Promise<ReleaseGetResponse>;
 
   // Strategic Models
@@ -163,28 +155,28 @@ export interface IAhaService {
   getMe(): Promise<User>;
 
   // Epics
-  listEpics(productId: string): Promise<EpicsList200Response>;
+  listEpics(productId: string): Promise<EpicsListResponse>;
   getEpic(epicId: string): Promise<Epic>;
 
   // Todos
-  listTodos(): Promise<TodosList200Response>;
+  listTodos(): Promise<TodosListResponse>;
   getTodo(todoId: string): Promise<Todo>;
 
   // Release Phases
-  listReleasePhases(): Promise<ReleasePhasesList200Response>;
-  getReleasePhase(releasePhaseId: string): Promise<SdkReleasePhase>;
+  listReleasePhases(): Promise<ReleasePhasesListResponse>;
+  getReleasePhase(releasePhaseId: string): Promise<ReleasePhase>;
 
   // Comments
   createFeatureComment(featureId: string, body: string): Promise<Comment>;
-  getEpicComments(epicId: string): Promise<CommentsGetEpic200Response>;
-  getIdeaComments(ideaId: string): Promise<CommentsGetEpic200Response>;
-  getInitiativeComments(initiativeId: string): Promise<CommentsGetEpic200Response>;
-  getProductComments(productId: string): Promise<CommentsGetEpic200Response>;
-  getGoalComments(goalId: string): Promise<CommentsGetEpic200Response>;
-  getReleaseComments(releaseId: string): Promise<CommentsGetEpic200Response>;
-  getReleasePhaseComments(releasePhaseId: string): Promise<CommentsGetEpic200Response>;
-  getRequirementComments(requirementId: string): Promise<CommentsGetEpic200Response>;
-  getTodoComments(todoId: string): Promise<CommentsGetEpic200Response>;
+  getEpicComments(epicId: string): Promise<CommentsListResponse>;
+  getIdeaComments(ideaId: string): Promise<CommentsListResponse>;
+  getInitiativeComments(initiativeId: string): Promise<CommentsListResponse>;
+  getProductComments(productId: string): Promise<CommentsListResponse>;
+  getGoalComments(goalId: string): Promise<CommentsListResponse>;
+  getReleaseComments(releaseId: string): Promise<CommentsListResponse>;
+  getReleasePhaseComments(releasePhaseId: string): Promise<CommentsListResponse>;
+  getRequirementComments(requirementId: string): Promise<CommentsListResponse>;
+  getTodoComments(todoId: string): Promise<CommentsListResponse>;
 
   // Additional list methods
   listIdeasByProduct(
@@ -208,14 +200,14 @@ export interface IAhaService {
     parkingLot?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<SdkReleasesListResponse>;
+  ): Promise<ReleasesListResponse>;
   listCompetitors(productId: string): Promise<CompetitorsListResponse>;
 
   // Relationships
   getGoalEpics(goalId: string): Promise<GoalEpicsResponse>;
   getReleaseFeatures(releaseId: string): Promise<ReleaseFeaturesResponse>;
-  getReleaseEpics(releaseId: string): Promise<EpicsList200Response>;
-  getInitiativeEpics(initiativeId: string): Promise<EpicsList200Response>;
+  getReleaseEpics(releaseId: string): Promise<EpicsListResponse>;
+  getInitiativeEpics(initiativeId: string): Promise<EpicsListResponse>;
 
   // Me/Current User
   getAssignedRecords(): Promise<MeAssignedRecordsResponse>;
@@ -227,13 +219,12 @@ export interface IAhaService {
     proxy?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetEndorsements200Response>;
+  ): Promise<IdeaEndorsementsResponse>;
   getIdeaVotes(
     ideaId: string,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetVotes200Response>;
-  getIdeaWatchers(ideaId: string): Promise<IdeasGetWatchers200Response>;
+  ): Promise<IdeaVotesResponse>;
 
   // Requirements
   getRequirement(requirementId: string): Promise<Requirement>;
@@ -242,6 +233,6 @@ export interface IAhaService {
   getCompetitor(competitorId: string): Promise<Competitor>;
 
   // Custom Fields
-  listCustomFields(): Promise<CustomFieldsListAll200Response>;
-  listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldsListOptions200Response>;
+  listCustomFields(): Promise<CustomFieldDefinitionsResponse>;
+  listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldOptionsResponse>;
 }

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -7,43 +7,39 @@ import type {
   Feature,
   FeaturesListResponse,
   Epic,
+  EpicsListResponse,
   User,
   IdeaResponse,
+  IdeasListResponse,
   InitiativeResponse,
   InitiativesListResponse,
+  Product,
   ProductsListResponse,
-  CommentsGetEpic200Response,
-  EpicsList200Response,
-  IdeasListResponse,
   Comment,
+  CommentsListResponse,
   GoalGetResponse,
-  GoalsListResponse as SdkGoalsListResponse,
+  GoalsListResponse,
+  GoalEpicsResponse,
   ReleaseGetResponse,
-  ReleasesListResponse as SdkReleasesListResponse,
-  ReleasePhasesList200Response,
-  ReleasePhase as SdkReleasePhase,
+  ReleasesListResponse,
+  ReleaseFeaturesResponse,
+  ReleasePhase,
+  ReleasePhasesListResponse,
   Competitor,
-  StrategicModelsListResponse,
+  CompetitorsListResponse,
   StrategicModel,
-  IdeaOrganizationsListResponse,
+  StrategicModelsListResponse,
   IdeaOrganization,
-  TodosList200Response,
+  IdeaOrganizationsListResponse,
+  Todo,
+  TodosListResponse,
+  Requirement,
   MeAssignedRecordsResponse,
   MePendingTasksResponse,
-  IdeasGetEndorsements200Response,
-  IdeasGetVotes200Response,
-  IdeasGetWatchers200Response,
-  CustomFieldsListAll200Response,
-  CustomFieldsListOptions200Response
-} from '@cedricziel/aha-js';
-
-import type {
-  Product,
-  Requirement,
-  Todo,
-  ReleaseFeaturesResponse,
-  GoalEpicsResponse,
-  CompetitorsListResponse
+  IdeaEndorsementsResponse,
+  IdeaVotesResponse,
+  CustomFieldDefinitionsResponse,
+  CustomFieldOptionsResponse
 } from '../types/aha-types.js';
 
 // Mock data generators
@@ -241,7 +237,7 @@ export class MockAhaService implements IAhaService {
     _status?: string,
     page?: number,
     perPage?: number
-  ): Promise<SdkGoalsListResponse> {
+  ): Promise<GoalsListResponse> {
     const count = Math.min(perPage || 20, 3);
     return {
       goals: Array.from({ length: count }, (_, i) => generateMockGoal(i + 1)),
@@ -250,31 +246,11 @@ export class MockAhaService implements IAhaService {
         total_pages: 1,
         current_page: page || 1
       }
-    } as SdkGoalsListResponse;
+    } as GoalsListResponse;
   }
 
   async getGoal(_goalId: string): Promise<GoalGetResponse> {
     return generateMockGoal(1) as GoalGetResponse;
-  }
-
-  async listReleases(
-    _query?: string,
-    _updatedSince?: string,
-    _assignedToUser?: string,
-    _status?: string,
-    _parkingLot?: boolean,
-    page?: number,
-    perPage?: number
-  ): Promise<SdkReleasesListResponse> {
-    const count = Math.min(perPage || 20, 3);
-    return {
-      releases: Array.from({ length: count }, (_, i) => generateMockRelease(i + 1)),
-      pagination: {
-        total_records: count,
-        total_pages: 1,
-        current_page: page || 1
-      }
-    } as SdkReleasesListResponse;
   }
 
   async getRelease(_releaseId: string): Promise<ReleaseGetResponse> {
@@ -375,28 +351,28 @@ export class MockAhaService implements IAhaService {
     } as User;
   }
 
-  async listEpics(_productId: string): Promise<EpicsList200Response> {
-    return { epics: [] } as EpicsList200Response;
+  async listEpics(_productId: string): Promise<EpicsListResponse> {
+    return { epics: [] } as EpicsListResponse;
   }
 
   async getEpic(_epicId: string): Promise<Epic> {
     return { id: 'EPIC-1', name: 'Test Epic' } as Epic;
   }
 
-  async listTodos(): Promise<TodosList200Response> {
-    return { tasks: [] } as TodosList200Response;
+  async listTodos(): Promise<TodosListResponse> {
+    return { todos: [] } as TodosListResponse;
   }
 
   async getTodo(_todoId: string): Promise<Todo> {
     return { id: 'TODO-1', description: 'Test Todo' } as Todo;
   }
 
-  async listReleasePhases(): Promise<ReleasePhasesList200Response> {
-    return { release_phases: [] } as ReleasePhasesList200Response;
+  async listReleasePhases(): Promise<ReleasePhasesListResponse> {
+    return { release_phases: [] } as ReleasePhasesListResponse;
   }
 
-  async getReleasePhase(_releasePhaseId: string): Promise<SdkReleasePhase> {
-    return { id: 'PHASE-1', name: 'Test Phase' } as SdkReleasePhase;
+  async getReleasePhase(_releasePhaseId: string): Promise<ReleasePhase> {
+    return { id: 'PHASE-1', name: 'Test Phase' } as ReleasePhase;
   }
 
   async createFeatureComment(_featureId: string, body: string): Promise<Comment> {
@@ -407,40 +383,40 @@ export class MockAhaService implements IAhaService {
     } as Comment;
   }
 
-  async getEpicComments(_epicId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getEpicComments(_epicId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getIdeaComments(_ideaId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getIdeaComments(_ideaId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getInitiativeComments(_initiativeId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getInitiativeComments(_initiativeId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getProductComments(_productId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getProductComments(_productId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getGoalComments(_goalId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getGoalComments(_goalId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getReleaseComments(_releaseId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getReleaseComments(_releaseId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getReleasePhaseComments(_releasePhaseId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getReleasePhaseComments(_releasePhaseId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getRequirementComments(_requirementId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getRequirementComments(_requirementId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
-  async getTodoComments(_todoId: string): Promise<CommentsGetEpic200Response> {
-    return { comments: [] } as CommentsGetEpic200Response;
+  async getTodoComments(_todoId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
   }
 
   async listIdeasByProduct(_productId: string): Promise<IdeasListResponse> {
@@ -450,11 +426,11 @@ export class MockAhaService implements IAhaService {
     } as IdeasListResponse;
   }
 
-  async listReleasesByProduct(_productId: string): Promise<SdkReleasesListResponse> {
+  async listReleasesByProduct(_productId: string): Promise<ReleasesListResponse> {
     return {
       releases: Array.from({ length: 3 }, (_, i) => generateMockRelease(i + 1)),
       pagination: { total_records: 3, total_pages: 1, current_page: 1 }
-    } as SdkReleasesListResponse;
+    } as ReleasesListResponse;
   }
 
   async listCompetitors(_productId: string): Promise<CompetitorsListResponse> {
@@ -469,12 +445,12 @@ export class MockAhaService implements IAhaService {
     return { features: [] } as ReleaseFeaturesResponse;
   }
 
-  async getReleaseEpics(_releaseId: string): Promise<EpicsList200Response> {
-    return { epics: [] } as EpicsList200Response;
+  async getReleaseEpics(_releaseId: string): Promise<EpicsListResponse> {
+    return { epics: [] } as EpicsListResponse;
   }
 
-  async getInitiativeEpics(_initiativeId: string): Promise<EpicsList200Response> {
-    return { epics: [] } as EpicsList200Response;
+  async getInitiativeEpics(_initiativeId: string): Promise<EpicsListResponse> {
+    return { epics: [] } as EpicsListResponse;
   }
 
   async getAssignedRecords(): Promise<MeAssignedRecordsResponse> {
@@ -485,16 +461,12 @@ export class MockAhaService implements IAhaService {
     return { tasks: [] } as MePendingTasksResponse;
   }
 
-  async getIdeaEndorsements(_ideaId: string): Promise<IdeasGetEndorsements200Response> {
-    return { endorsements: [] } as IdeasGetEndorsements200Response;
+  async getIdeaEndorsements(_ideaId: string): Promise<IdeaEndorsementsResponse> {
+    return { idea_endorsements: [] } as IdeaEndorsementsResponse;
   }
 
-  async getIdeaVotes(_ideaId: string): Promise<IdeasGetVotes200Response> {
-    return { votes: [] } as IdeasGetVotes200Response;
-  }
-
-  async getIdeaWatchers(_ideaId: string): Promise<IdeasGetWatchers200Response> {
-    return { watchers: [] } as IdeasGetWatchers200Response;
+  async getIdeaVotes(_ideaId: string): Promise<IdeaVotesResponse> {
+    return { idea_endorsements: [] } as IdeaVotesResponse;
   }
 
   async getRequirement(_requirementId: string): Promise<Requirement> {
@@ -505,11 +477,11 @@ export class MockAhaService implements IAhaService {
     return { id: 'COMP-1', name: 'Test Competitor' } as Competitor;
   }
 
-  async listCustomFields(): Promise<CustomFieldsListAll200Response> {
-    return { custom_fields: [] } as CustomFieldsListAll200Response;
+  async listCustomFields(): Promise<CustomFieldDefinitionsResponse> {
+    return { custom_field_definitions: [] } as CustomFieldDefinitionsResponse;
   }
 
-  async listCustomFieldOptions(_customFieldDefinitionId: string): Promise<CustomFieldsListOptions200Response> {
-    return { options: [] } as CustomFieldsListOptions200Response;
+  async listCustomFieldOptions(_customFieldDefinitionId: string): Promise<CustomFieldOptionsResponse> {
+    return { options: [] } as CustomFieldOptionsResponse;
   }
 }

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1427,10 +1427,16 @@ export class AhaService {
   public static async createFeature(releaseId: string, featureData: any): Promise<unknown> {
     const featuresApi = this.getFeaturesApi();
 
+    // Aha documents the body as `{"feature": {...}}`, so tolerate either shape from callers:
+    // the tool's schema sends it already wrapped, but a bare record from a direct caller
+    // should not post an unwrapped body Aha will quietly do nothing with.
+    // https://www.aha.io/api/resources/features/create_a_feature
+    const payload = featureData?.feature ? featureData : { feature: featureData ?? {} };
+
     try {
       const response = await featuresApi.releasesByReleaseFeaturesPost({
         releaseId: releaseId,
-        featuresPostRequest: featureData ?? {}
+        featuresPostRequest: payload
       });
       return response.data;
     } catch (error) {

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -13,62 +13,64 @@ import {
   RequirementsApi,
   ReleasePhasesApi,
   ReleasesApi,
-  DefaultApi,
   MeApi,
   StrategicModelsApi,
   IdeaOrganizationsApi,
   IdeaVotesApi,
-  CustomFieldsApi,
-  // Types
-  Feature,
-  FeaturesListResponse,
-  Epic,
-  User,
-  IdeaResponse,
-  InitiativeResponse,
-  InitiativesListResponse,
-  ProductsListResponse,
-  CommentsGetEpic200Response,
-  EpicsList200Response,
-  IdeasListResponse,
-  Comment,
-  // Additional SDK response types
-  GoalGetResponse,
-  GoalsListResponse as SdkGoalsListResponse,
-  ReleaseGetResponse,
-  ReleasesListResponse as SdkReleasesListResponse,
-  ReleasePhasesList200Response,
-  ReleasePhase as SdkReleasePhase,
-  Competitor,
-  StrategicModelGetResponse,
-  StrategicModelsListResponse,
-  StrategicModel,
-  IdeaOrganizationGetResponse,
-  IdeaOrganizationsListResponse,
-  IdeaOrganization,
-  TodosList200Response,
-  MeAssignedRecordsResponse,
-  MePendingTasksResponse,
-  IdeasGetEndorsements200Response,
-  IdeasGetVotes200Response,
-  IdeasGetWatchers200Response,
-  CustomFieldsListAll200Response,
-  CustomFieldsListOptions200Response
+  CustomFieldsApi
 } from '@cedricziel/aha-js';
 
 import {
+  Feature,
+  FeaturesListResponse,
+  Epic,
+  EpicsListResponse,
+  User,
+  IdeaResponse,
+  IdeasListResponse,
+  InitiativeResponse,
+  InitiativesListResponse,
   Product,
-  Requirement,
-  Todo,
-  ReleaseFeaturesResponse,
+  ProductsListResponse,
+  Comment,
+  CommentsListResponse,
+  GoalGetResponse,
+  GoalsListResponse,
   GoalEpicsResponse,
-  CompetitorsListResponse
+  ReleaseGetResponse,
+  ReleasesListResponse,
+  ReleaseFeaturesResponse,
+  ReleasePhase,
+  ReleasePhasesListResponse,
+  Competitor,
+  CompetitorsListResponse,
+  StrategicModel,
+  StrategicModelsListResponse,
+  IdeaOrganization,
+  IdeaOrganizationsListResponse,
+  Todo,
+  TodosListResponse,
+  Requirement,
+  MeAssignedRecordsResponse,
+  MePendingTasksResponse,
+  IdeaEndorsementsResponse,
+  IdeaVotesResponse,
+  CustomFieldDefinitionsResponse,
+  CustomFieldDefinition,
+  CustomFieldOptionsResponse,
+  RecordRef,
+  Pagination
 } from '../types/aha-types.js';
 
 import { log } from '../logger.js';
 
 /**
  * Service for interacting with the Aha.io API
+ *
+ * This is the only file in the repo that may import from `@cedricziel/aha-js`. The SDK is
+ * generated per-operation from Aha's official OpenAPI document and renames every export on
+ * each regeneration, so every method here maps one `*Api` call onto the stable domain types
+ * in `../types/aha-types.js` at the boundary - see `aha-service.interface.ts` for why.
  */
 export class AhaService {
   private static configuration: Configuration | null = null;
@@ -85,7 +87,6 @@ export class AhaService {
   private static requirementsApi: RequirementsApi | null = null;
   private static releasePhasesApi: ReleasePhasesApi | null = null;
   private static releasesApi: ReleasesApi | null = null;
-  private static defaultApi: DefaultApi | null = null;
   private static meApi: MeApi | null = null;
   private static strategicModelsApi: StrategicModelsApi | null = null;
   private static ideaOrganizationsApi: IdeaOrganizationsApi | null = null;
@@ -149,13 +150,35 @@ export class AhaService {
 
   /**
    * Current credentials, for callers that need to reach Aha.io outside the generated
-   * aha-js REST client - notably the GraphQL API, which aha-js does not cover.
+   * aha-js REST client - notably the GraphQL API (which aha-js does not cover) and the
+   * hand-rolled competitor update/delete calls below, whose endpoints exist in neither.
    *
    * Read through this rather than from process.env so that credentials supplied at runtime
    * via configure_server are picked up too.
    */
   public static getCredentials(): { subdomain: string | null; accessToken: string | null } {
     return { subdomain: this.subdomain, accessToken: this.accessToken };
+  }
+
+  /** Every generated list endpoint types `page`/`perPage` (and several other filters) as strings. */
+  private static numParam(value?: number): string | undefined {
+    return value === undefined ? undefined : String(value);
+  }
+
+  private static boolParam(value?: boolean): string | undefined {
+    return value === undefined ? undefined : String(value);
+  }
+
+  /**
+   * Builds the `options.params` object for filters Aha's OpenAPI document omits from a
+   * generated request type. Every generated method still spreads its second `options`
+   * argument into the axios request config, and axios merges `params` into the query string
+   * the generated call already built - so this is how a filter Aha genuinely accepts gets
+   * back on the wire. Strips `undefined` entries so an unused filter is left off the query
+   * string instead of being sent as the literal string `"undefined"`.
+   */
+  private static extraParams(params: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(params).filter(([, value]) => value !== undefined));
   }
 
   /**
@@ -166,8 +189,11 @@ export class AhaService {
     const meApi = this.getMeApi();
 
     try {
-      const response = await meApi.meGetProfile();
-      return response.data.user;
+      const response = await meApi.meGet();
+      // Generator defect: `meGet` shares its generated response type with `meTasksGet`
+      // (`{ tasks, pagination }`); the endpoint genuinely returns the current user under `user`.
+      const data = response.data as unknown as { user?: User };
+      return data.user as User;
     } catch (error) {
       log.error('Error getting current user', error as Error, { operation: 'getMe' });
       throw error;
@@ -214,7 +240,6 @@ export class AhaService {
       this.requirementsApi = new RequirementsApi(this.configuration);
       this.releasePhasesApi = new ReleasePhasesApi(this.configuration);
       this.releasesApi = new ReleasesApi(this.configuration);
-      this.defaultApi = new DefaultApi(this.configuration);
       this.meApi = new MeApi(this.configuration);
       this.strategicModelsApi = new StrategicModelsApi(this.configuration);
       this.ideaOrganizationsApi = new IdeaOrganizationsApi(this.configuration);
@@ -371,17 +396,6 @@ export class AhaService {
   }
 
   /**
-   * Get the default API instance
-   * @returns DefaultApi instance
-   */
-  private static getDefaultApi(): DefaultApi {
-    if (!this.defaultApi) {
-      this.initializeClient();
-    }
-    return this.defaultApi!;
-  }
-
-  /**
    * Get the me API instance
    * @returns MeApi instance
    */
@@ -457,15 +471,24 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        tag,
-        assignedToUser
-      });
-      return response.data;
+      // `q`, `updatedSince`, `tag` and `assignedToUser` are sent via `options.params` because
+      // Aha's spec under-documents this endpoint's query string - only pagination and
+      // `fields`/`workflow_status` (unused here) remain in the generated request type.
+      const response = await featuresApi.featuresGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            tag,
+            assigned_to_user: assignedToUser
+          })
+        }
+      );
+      return response.data as unknown as FeaturesListResponse;
     } catch (error) {
       // This method alone used to time itself and read a status code off the error, then use
       // neither - leftovers from tracing that was removed. The status travels with the error
@@ -484,11 +507,15 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresGet({ id: featureId });
-      if (!response.data.feature) {
+      const response = await featuresApi.featuresByIdGet({ id: featureId });
+      // Generator defect: `featuresByIdGet` is typed as returning the list response
+      // (`{ features, pagination }`); the endpoint genuinely returns a single feature
+      // wrapped as `{ feature }`.
+      const data = response.data as unknown as { feature?: Feature };
+      if (!data.feature) {
         throw new Error(`Feature ${featureId} not found`);
       }
-      return response.data.feature;
+      return data.feature;
     } catch (error) {
       log.error('Error getting feature', error as Error, { operation: 'getFeature', feature_id: featureId });
       throw error;
@@ -503,9 +530,11 @@ export class AhaService {
     const usersApi = this.getUsersApi();
 
     try {
-      // Use the appropriate method from the UsersApi
-      const response = await usersApi.usersList();
-      return { users: response.data };
+      const response = await usersApi.usersGet();
+      // Generator defect: `usersGet` is typed as `{ user_roles, pagination }`, reused from an
+      // unrelated operation. The endpoint returns `{ users, pagination }`.
+      const data = response.data as unknown as { users?: User[] };
+      return { users: data.users ?? [] };
     } catch (error) {
       log.error('Error listing users', error as Error, { operation: 'listUsers' });
       throw error;
@@ -521,8 +550,10 @@ export class AhaService {
     const usersApi = this.getUsersApi();
 
     try {
-      const response = await usersApi.usersGet({ id: userId });
-      return response.data;
+      const response = await usersApi.usersByIdGet({ id: userId });
+      // Generator defect: typed as `{ user_roles, pagination }`; the endpoint returns the
+      // user object directly with no wrapper.
+      return response.data as unknown as User;
     } catch (error) {
       log.error('Error getting user', error as Error, { operation: 'getUser', user_id: userId });
       throw error;
@@ -534,15 +565,12 @@ export class AhaService {
    * @param productId The ID of the product
    * @returns A list of epics
    */
-  public static async listEpics(productId: string): Promise<EpicsList200Response> {
+  public static async listEpics(productId: string): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      // Use the appropriate method from the EpicsApi with the correct parameter format
-      const response = await epicsApi.epicsListInProduct({
-        productId: productId
-      });
-      return response.data;
+      const response = await epicsApi.productsByProductEpicsGet({ productId });
+      return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error listing epics for product', error as Error, { operation: 'listEpics', product_id: productId });
       throw error;
@@ -558,8 +586,11 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsGet({ epicId });
-      return response.data;
+      const response = await epicsApi.epicsByIdGet({ id: epicId });
+      // Generator defect: `epicsByIdGet` is typed as returning the list response
+      // (`{ epics, pagination }`); the endpoint genuinely returns a single epic with no
+      // wrapper.
+      return response.data as unknown as Epic;
     } catch (error) {
       log.error('Error getting epic', error as Error, { operation: 'getEpic', epic_id: epicId });
       throw error;
@@ -576,14 +607,14 @@ export class AhaService {
     const commentsApi = this.getCommentsApi();
 
     try {
-      // Use the appropriate method from the CommentsApi with the correct parameter format
-      const response = await commentsApi.commentsCreateFeature({
+      const response = await commentsApi.featuresByFeatureCommentsPost({
         featureId: featureId,
-        commentCreateRequest: {
-          body: body
+        commentsPostRequest: {
+          comment: { body }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { comment?: Comment };
+      return data.comment as Comment;
     } catch (error) {
       log.error('Error creating comment on feature', error as Error, { operation: 'createFeatureComment', feature_id: featureId });
       throw error;
@@ -599,8 +630,11 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasGetById({ id: ideaId });
-      return response.data;
+      const response = await ideasApi.ideasByIdGet({ id: ideaId });
+      // Generator defect: `ideasByIdGet` is typed as returning the list response
+      // (`{ ideas, pagination }`); the endpoint genuinely returns a single idea wrapped as
+      // `{ idea }`.
+      return response.data as unknown as IdeaResponse;
     } catch (error) {
       log.error('Error getting idea', error as Error, { operation: 'getIdea', idea_id: ideaId });
       throw error;
@@ -616,19 +650,15 @@ export class AhaService {
     const productsApi = this.getProductsApi();
 
     try {
-      const response = await productsApi.productsGet({ id: productId });
-      return response.data.product;
+      const response = await productsApi.productsByIdGet({ id: productId });
+      const data = response.data as unknown as { product?: Product };
+      return data.product as Product;
     } catch (error) {
       log.error('Error getting product', error as Error, { operation: 'getProduct', product_id: productId });
       throw error;
     }
   }
 
-  /**
-   * List products from Aha.io
-   * @param updatedSince UTC timestamp (ISO8601 format) (optional)
-   * @returns A list of products
-   */
   /**
    * List products from Aha.io
    * @param updatedSince Filter by updated since date (optional)
@@ -644,12 +674,18 @@ export class AhaService {
     const productsApi = this.getProductsApi();
 
     try {
-      const response = await productsApi.productsList({
-        page,
-        perPage,
-        updatedSince
-      });
-      return response.data;
+      // Generator defect: `productsGet` (list) shares its response type with
+      // `productsByIdGet` (`{ product }`, singular); the endpoint returns `{ products, pagination }`.
+      // `updatedSince` is sent via `options.params` because Aha's spec under-documents this
+      // endpoint's query string.
+      const response = await productsApi.productsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        { params: this.extraParams({ updated_since: updatedSince }) }
+      );
+      return response.data as unknown as ProductsListResponse;
     } catch (error) {
       log.error('Error listing products', error as Error, { operation: 'listProducts' });
       throw error;
@@ -665,8 +701,11 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesGet({ id: initiativeId });
-      return response.data;
+      const response = await initiativesApi.initiativesByIdGet({ id: initiativeId });
+      // Generator defect: `initiativesByIdGet` is typed as returning the list response
+      // (`{ initiatives, pagination }`); the endpoint genuinely returns a single initiative
+      // wrapped as `{ initiative }`.
+      return response.data as unknown as InitiativeResponse;
     } catch (error) {
       log.error('Error getting initiative', error as Error, { operation: 'getInitiative', initiative_id: initiativeId });
       throw error;
@@ -694,15 +733,25 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        onlyActive
-      });
-      return response.data;
+      // `q`, `updatedSince`, `assignedToUser` and `onlyActive` are sent via `options.params`
+      // because Aha's spec under-documents this endpoint's query string - only pagination
+      // (plus `custom_fields` and `workflow_status`, which this service does not expose)
+      // remain in the generated request type.
+      const response = await initiativesApi.initiativesGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            assigned_to_user: assignedToUser,
+            only_active: onlyActive
+          })
+        }
+      );
+      return response.data as unknown as InitiativesListResponse;
     } catch (error) {
       log.error('Error listing initiatives', error as Error, { operation: 'listInitiatives' });
       throw error;
@@ -740,20 +789,25 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasListProduct({ 
-        productId: productId,
-        q: query,
-        spam,
-        workflowStatus,
-        sort: sort as any, // Cast to any since the enum type is not exported
-        createdBefore,
-        createdSince,
-        updatedSince,
-        tag,
-        userId,
-        ideaUserId
-      });
-      return response.data;
+      // `ideaUserId` has no equivalent in the generated request type for this endpoint, so it
+      // is sent via `options.params` because Aha's spec under-documents this endpoint's query
+      // string.
+      const response = await ideasApi.productsByProductIdeasGet(
+        {
+          productId: productId,
+          q: query,
+          spam: this.boolParam(spam),
+          workflowStatus,
+          sort,
+          createdBefore,
+          createdSince,
+          updatedSince,
+          tag,
+          userId
+        },
+        { params: this.extraParams({ idea_user_id: ideaUserId }) }
+      );
+      return response.data as unknown as IdeasListResponse;
     } catch (error) {
       log.error('Error listing ideas for product', error as Error, { operation: 'listIdeasByProduct', product_id: productId });
       throw error;
@@ -765,12 +819,12 @@ export class AhaService {
    * @param epicId The ID of the epic
    * @returns A list of comments for the epic
    */
-  public static async getEpicComments(epicId: string): Promise<CommentsGetEpic200Response> {
+  public static async getEpicComments(epicId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetEpic({ epicId });
-      return response.data;
+      const response = await commentsApi.epicsByEpicCommentsGet({ epicId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for epic', error as Error, { operation: 'getEpicComments', epic_id: epicId });
       throw error;
@@ -782,12 +836,12 @@ export class AhaService {
    * @param ideaId The ID of the idea
    * @returns A list of comments for the idea
    */
-  public static async getIdeaComments(ideaId: string): Promise<CommentsGetEpic200Response> {
+  public static async getIdeaComments(ideaId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetIdea({ ideaId });
-      return response.data;
+      const response = await commentsApi.ideasByIdeaCommentsGet({ ideaId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for idea', error as Error, { operation: 'getIdeaComments', idea_id: ideaId });
       throw error;
@@ -799,12 +853,12 @@ export class AhaService {
    * @param initiativeId The ID of the initiative
    * @returns A list of comments for the initiative
    */
-  public static async getInitiativeComments(initiativeId: string): Promise<CommentsGetEpic200Response> {
+  public static async getInitiativeComments(initiativeId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetInitiative({ initiativeId });
-      return response.data;
+      const response = await commentsApi.initiativesByInitiativeCommentsGet({ initiativeId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for initiative', error as Error, { operation: 'getInitiativeComments', initiative_id: initiativeId });
       throw error;
@@ -816,12 +870,12 @@ export class AhaService {
    * @param productId The ID of the product
    * @returns A list of comments for the product
    */
-  public static async getProductComments(productId: string): Promise<CommentsGetEpic200Response> {
+  public static async getProductComments(productId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetProduct({ productId });
-      return response.data;
+      const response = await commentsApi.productsByProjectCommentsGet({ projectId: productId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for product', error as Error, { operation: 'getProductComments', product_id: productId });
       throw error;
@@ -833,12 +887,12 @@ export class AhaService {
    * @param goalId The ID of the goal
    * @returns A list of comments for the goal
    */
-  public static async getGoalComments(goalId: string): Promise<CommentsGetEpic200Response> {
+  public static async getGoalComments(goalId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetGoal({ goalId });
-      return response.data;
+      const response = await commentsApi.goalsByGoalCommentsGet({ goalId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for goal', error as Error, { operation: 'getGoalComments', goal_id: goalId });
       throw error;
@@ -850,12 +904,12 @@ export class AhaService {
    * @param releaseId The ID of the release
    * @returns A list of comments for the release
    */
-  public static async getReleaseComments(releaseId: string): Promise<CommentsGetEpic200Response> {
+  public static async getReleaseComments(releaseId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetRelease({ releaseId });
-      return response.data;
+      const response = await commentsApi.releasesByReleaseCommentsGet({ releaseId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for release', error as Error, { operation: 'getReleaseComments', release_id: releaseId });
       throw error;
@@ -867,12 +921,12 @@ export class AhaService {
    * @param releasePhaseId The ID of the release phase
    * @returns A list of comments for the release phase
    */
-  public static async getReleasePhaseComments(releasePhaseId: string): Promise<CommentsGetEpic200Response> {
+  public static async getReleasePhaseComments(releasePhaseId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetReleasePhase({ releasePhaseId });
-      return response.data;
+      const response = await commentsApi.releasePhasesByReleasePhaseCommentsGet({ releasePhaseId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for release phase', error as Error, { operation: 'getReleasePhaseComments', release_phase_id: releasePhaseId });
       throw error;
@@ -884,12 +938,12 @@ export class AhaService {
    * @param requirementId The ID of the requirement
    * @returns A list of comments for the requirement
    */
-  public static async getRequirementComments(requirementId: string): Promise<CommentsGetEpic200Response> {
+  public static async getRequirementComments(requirementId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetRequirement({ requirementId });
-      return response.data;
+      const response = await commentsApi.requirementsByRequirementCommentsGet({ requirementId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for requirement', error as Error, { operation: 'getRequirementComments', requirement_id: requirementId });
       throw error;
@@ -901,12 +955,12 @@ export class AhaService {
    * @param todoId The ID of the todo
    * @returns A list of comments for the todo
    */
-  public static async getTodoComments(todoId: string): Promise<CommentsGetEpic200Response> {
+  public static async getTodoComments(todoId: string): Promise<CommentsListResponse> {
     const commentsApi = this.getCommentsApi();
 
     try {
-      const response = await commentsApi.commentsGetTodo({ todoId });
-      return response.data;
+      const response = await commentsApi.tasksByTaskCommentsGet({ taskId: todoId });
+      return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for todo', error as Error, { operation: 'getTodoComments', todo_id: todoId });
       throw error;
@@ -922,8 +976,11 @@ export class AhaService {
     const goalsApi = this.getGoalsApi();
 
     try {
-      const response = await goalsApi.goalsGet({ id: goalId });
-      return response.data;
+      const response = await goalsApi.goalsByIdGet({ id: goalId });
+      // Generator defect: `goalsByIdGet` is typed as returning the list response
+      // (`{ goals, pagination }`); the endpoint genuinely returns a single goal wrapped as
+      // `{ goal }`.
+      return response.data as unknown as GoalGetResponse;
     } catch (error) {
       log.error('Error getting goal', error as Error, { operation: 'getGoal', goal_id: goalId });
       throw error;
@@ -947,19 +1004,28 @@ export class AhaService {
     status?: string,
     page?: number,
     perPage?: number
-  ): Promise<SdkGoalsListResponse> {
+  ): Promise<GoalsListResponse> {
     const goalsApi = this.getGoalsApi();
 
     try {
-      const response = await goalsApi.goalsList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        status
-      });
-      return response.data;
+      // `q`, `updatedSince`, `assignedToUser` and `status` are sent via `options.params`
+      // because Aha's spec under-documents this endpoint's query string - only pagination
+      // remains in the generated request type.
+      const response = await goalsApi.goalsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            assigned_to_user: assignedToUser,
+            status
+          })
+        }
+      );
+      return response.data as unknown as GoalsListResponse;
     } catch (error) {
       log.error('Error listing goals', error as Error, { operation: 'listGoals' });
       throw error;
@@ -975,8 +1041,8 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsListByGoal({ goalId });
-      return response.data;
+      const response = await epicsApi.goalsByGoalEpicsGet({ goalId });
+      return response.data as unknown as GoalEpicsResponse;
     } catch (error) {
       log.error('Error getting epics for goal', error as Error, { operation: 'getGoalEpics', goal_id: goalId });
       throw error;
@@ -992,49 +1058,13 @@ export class AhaService {
     const releasesApi = this.getReleasesApi();
 
     try {
-      const response = await releasesApi.releasesGet({ id: releaseId });
-      return response.data;
+      const response = await releasesApi.releasesByIdGet({ id: releaseId });
+      // Generator defect: `releasesByIdGet` is typed as returning the list response
+      // (`{ releases, pagination }`); the endpoint genuinely returns a single release wrapped
+      // as `{ release }`.
+      return response.data as unknown as ReleaseGetResponse;
     } catch (error) {
       log.error('Error getting release', error as Error, { operation: 'getRelease', release_id: releaseId });
-      throw error;
-    }
-  }
-
-  /**
-   * List releases from Aha.io
-   * @param query Search query (optional)
-   * @param updatedSince Filter by updated since date (optional)
-   * @param assignedToUser Filter by assigned user (optional)
-   * @param status Filter by status (optional)
-   * @param parkingLot Filter by parking lot (optional)
-   * @param page Page number for pagination (optional)
-   * @param perPage Number of items per page (max 200) (optional)
-   * @returns A list of releases
-   */
-  public static async listReleases(
-    query?: string,
-    updatedSince?: string,
-    assignedToUser?: string,
-    status?: string,
-    parkingLot?: boolean,
-    page?: number,
-    perPage?: number
-  ): Promise<SdkReleasesListResponse> {
-    const releasesApi = this.getReleasesApi();
-
-    try {
-      const response = await releasesApi.releasesList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        status,
-        parkingLot
-      });
-      return response.data;
-    } catch (error) {
-      log.error('Error listing releases', error as Error, { operation: 'listReleases' });
       throw error;
     }
   }
@@ -1073,12 +1103,12 @@ export class AhaService {
    * @param releaseId The ID of the release
    * @returns A list of epics associated with the release
    */
-  public static async getReleaseEpics(releaseId: string): Promise<EpicsList200Response> {
+  public static async getReleaseEpics(releaseId: string): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsListInRelease({ releaseId });
-      return response.data;
+      const response = await epicsApi.releasesByReleaseEpicsGet({ releaseId });
+      return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error getting epics for release', error as Error, { operation: 'getReleaseEpics', release_id: releaseId });
       throw error;
@@ -1090,15 +1120,19 @@ export class AhaService {
    * @param releasePhaseId The ID of the release phase
    * @returns The release phase details
    */
-  public static async getReleasePhase(releasePhaseId: string): Promise<SdkReleasePhase> {
+  public static async getReleasePhase(releasePhaseId: string): Promise<ReleasePhase> {
     const releasePhasesApi = this.getReleasePhasesApi();
 
     try {
-      const response = await releasePhasesApi.releasePhasesGet({ id: releasePhaseId });
-      if (!response.data.release_phase) {
+      const response = await releasePhasesApi.releasePhasesByIdGet({ id: releasePhaseId });
+      // Generator defect: `releasePhasesByIdGet` is typed as returning the list response
+      // (`{ release_phases, pagination }`); the endpoint genuinely returns a single release
+      // phase wrapped as `{ release_phase }`.
+      const data = response.data as unknown as { release_phase?: ReleasePhase };
+      if (!data.release_phase) {
         throw new Error(`Release phase ${releasePhaseId} not found`);
       }
-      return response.data.release_phase;
+      return data.release_phase;
     } catch (error) {
       log.error('Error getting release phase', error as Error, { operation: 'getReleasePhase', release_phase_id: releasePhaseId });
       throw error;
@@ -1109,12 +1143,12 @@ export class AhaService {
    * List release phases from Aha.io
    * @returns A list of release phases
    */
-  public static async listReleasePhases(): Promise<ReleasePhasesList200Response> {
+  public static async listReleasePhases(): Promise<ReleasePhasesListResponse> {
     const releasePhasesApi = this.getReleasePhasesApi();
 
     try {
-      const response = await releasePhasesApi.releasePhasesList();
-      return response.data;
+      const response = await releasePhasesApi.releasePhasesGet();
+      return response.data as unknown as ReleasePhasesListResponse;
     } catch (error) {
       log.error('Error listing release phases', error as Error, { operation: 'listReleasePhases' });
       throw error;
@@ -1130,11 +1164,12 @@ export class AhaService {
     const requirementsApi = this.getRequirementsApi();
 
     try {
-      const response = await requirementsApi.requirementsGet({ id: requirementId });
-      if (!response.data.requirement) {
+      const response = await requirementsApi.requirementsByIdGet({ id: requirementId });
+      const data = response.data as unknown as { requirement?: Requirement };
+      if (!data.requirement) {
         throw new Error(`Requirement ${requirementId} not found`);
       }
-      return response.data.requirement as Requirement;
+      return data.requirement;
     } catch (error) {
       log.error('Error getting requirement', error as Error, { operation: 'getRequirement', requirement_id: requirementId });
       throw error;
@@ -1150,8 +1185,11 @@ export class AhaService {
     const competitorsApi = this.getCompetitorsApi();
 
     try {
-      const response = await competitorsApi.competitorsGet({ competitorId });
-      return response.data;
+      const response = await competitorsApi.competitorsByIdGet({ id: competitorId });
+      // Generator defect: `competitorsByIdGet` is typed as returning the (product-scoped)
+      // list response (`{ competitors, pagination }`); the endpoint genuinely returns a
+      // single competitor with no wrapper.
+      return response.data as unknown as Competitor;
     } catch (error) {
       log.error('Error getting competitor', error as Error, { operation: 'getCompetitor', competitor_id: competitorId });
       throw error;
@@ -1167,11 +1205,15 @@ export class AhaService {
     const todosApi = this.getTodosApi();
 
     try {
-      const response = await todosApi.todosGet({ id: todoId });
-      if (!response.data.task) {
+      const response = await todosApi.tasksByIdGet({ id: todoId });
+      // Generator defect: `tasksByIdGet` is typed as returning the list response
+      // (`{ tasks, pagination }`); the endpoint genuinely returns a single task wrapped as
+      // `{ task }`.
+      const data = response.data as unknown as { task?: Todo };
+      if (!data.task) {
         throw new Error(`Todo ${todoId} not found`);
       }
-      return response.data.task as Todo;
+      return data.task;
     } catch (error) {
       log.error('Error getting todo', error as Error, { operation: 'getTodo', todo_id: todoId });
       throw error;
@@ -1187,8 +1229,8 @@ export class AhaService {
     const competitorsApi = this.getCompetitorsApi();
 
     try {
-      const response = await competitorsApi.competitorsListProduct({ productId });
-      return response.data;
+      const response = await competitorsApi.productsByProductCompetitorsGet({ productId });
+      return response.data as unknown as CompetitorsListResponse;
     } catch (error) {
       log.error('Error listing competitors for product', error as Error, { operation: 'listCompetitors', product_id: productId });
       throw error;
@@ -1209,15 +1251,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdEpicPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdEpicPutRequest: {
+        featuresPutRequest: {
           feature: {
             epic: epicId
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error associating feature with epic', error as Error, { operation: 'associateFeatureWithEpic', feature_id: featureId, epic_id: epicId });
       throw error;
@@ -1234,15 +1277,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdReleasePut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdReleasePutRequest: {
+        featuresPutRequest: {
           feature: {
             release: releaseId
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error moving feature to release', error as Error, { operation: 'moveFeatureToRelease', feature_id: featureId, release_id: releaseId });
       throw error;
@@ -1259,15 +1303,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdGoalsPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdGoalsPutRequest: {
+        featuresPutRequest: {
           feature: {
             goals: goalIds
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error associating feature with goals', error as Error, { operation: 'associateFeatureWithGoals', feature_id: featureId, goal_ids: goalIds });
       throw error;
@@ -1284,15 +1329,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdTagsPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdTagsPutRequest: {
+        featuresPutRequest: {
           feature: {
             tags: tags
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating tags for feature', error as Error, { operation: 'updateFeatureTags', feature_id: featureId });
       throw error;
@@ -1309,11 +1355,12 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsCreateInProduct({
+      const response = await epicsApi.productsByProductEpicsPost({
         productId: productId,
-        epicCreateRequest: epicData
+        epicsPostRequest: epicData
       });
-      return response.data;
+      const data = response.data as unknown as { epic?: Epic };
+      return data.epic as Epic;
     } catch (error) {
       log.error('Error creating epic in product', error as Error, { operation: 'createEpicInProduct', product_id: productId });
       throw error;
@@ -1330,11 +1377,12 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsCreateInRelease({
+      const response = await epicsApi.releasesByReleaseEpicsPost({
         releaseId: releaseId,
-        epicCreateRequest: epicData
+        epicsPostRequest: epicData
       });
-      return response.data;
+      const data = response.data as unknown as { epic?: Epic };
+      return data.epic as Epic;
     } catch (error) {
       log.error('Error creating epic in release', error as Error, { operation: 'createEpicInRelease', release_id: releaseId });
       throw error;
@@ -1351,11 +1399,11 @@ export class AhaService {
     const initiativesApi = this.getInitiativesApi();
 
     try {
-      const response = await initiativesApi.initiativesCreate({
+      const response = await initiativesApi.productsByProductInitiativesPost({
         productId: productId,
-        initiativeCreateRequest: initiativeData
+        initiativesPostRequest: initiativeData
       });
-      return response.data;
+      return response.data as unknown as InitiativeResponse;
     } catch (error) {
       log.error('Error creating initiative in product', error as Error, { operation: 'createInitiativeInProduct', product_id: productId });
       throw error;
@@ -1372,16 +1420,17 @@ export class AhaService {
    * @param featureData The feature data to create
    * @returns The created feature response, if the endpoint returned a body
    *
-   * `unknown` rather than `Feature`: aha-js types this endpoint's response as `void`, so
+   * `unknown` rather than `Feature`: aha-js types this endpoint's response loosely, so
    * whatever Aha sends back is undeclared. The tool treats a missing body as an empty
    * record rather than assuming a feature came back.
    */
-  public static async createFeature(releaseId: string, _featureData: any): Promise<unknown> {
-    const defaultApi = this.getDefaultApi();
+  public static async createFeature(releaseId: string, featureData: any): Promise<unknown> {
+    const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await defaultApi.releasesReleaseIdFeaturesPost({
-        releaseId: releaseId
+      const response = await featuresApi.releasesByReleaseFeaturesPost({
+        releaseId: releaseId,
+        featuresPostRequest: featureData ?? {}
       });
       return response.data;
     } catch (error) {
@@ -1400,11 +1449,12 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresUpdate({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featureUpdateRequest: featureData
+        featuresPutRequest: featureData
       });
-      return response.data.feature;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating feature', error as Error, { operation: 'updateFeature', feature_id: featureId });
       throw error;
@@ -1420,7 +1470,7 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      await featuresApi.featuresDelete({ id: featureId });
+      await featuresApi.featuresByIdDelete({ id: featureId });
     } catch (error) {
       log.error('Error deleting feature', error as Error, { operation: 'deleteFeature', feature_id: featureId });
       throw error;
@@ -1437,15 +1487,16 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdProgressPut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdProgressPutRequest: {
+        featuresPutRequest: {
           feature: {
             progress: progress
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating progress for feature', error as Error, { operation: 'updateFeatureProgress', feature_id: featureId });
       throw error;
@@ -1462,16 +1513,17 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      const response = await featuresApi.featuresIdScorePut({
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featuresIdScorePutRequest: {
+        featuresPutRequest: {
           feature: {
             // Note: Need to check exact structure for score updates
             score_facts: [{ value: score }]
           }
         }
       });
-      return response.data;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating score for feature', error as Error, { operation: 'updateFeatureScore', feature_id: featureId });
       throw error;
@@ -1488,17 +1540,18 @@ export class AhaService {
     const featuresApi = this.getFeaturesApi();
 
     try {
-      // This used to call `DefaultApi.featuresIdCustomFieldsPut`, whose generated signature
-      // takes an id and nothing else - the operation is declared without a request body, so
-      // the values could not be sent at all and every call was a no-op reported as success.
-      // `PUT /features/:id` carries `feature.custom_fields`, so route through that instead.
-      const response = await featuresApi.featuresUpdate({
+      // This used to call a generated operation whose signature took an id and nothing
+      // else - the operation was declared without a request body, so the values could not be
+      // sent at all and every call was a no-op reported as success. `PUT /features/:id`
+      // carries `feature.custom_fields`, so route through that instead.
+      const response = await featuresApi.featuresByIdPut({
         id: featureId,
-        featureUpdateRequest: {
+        featuresPutRequest: {
           feature: { custom_fields: customFields } as any
         }
       });
-      return response.data.feature;
+      const data = response.data as unknown as { feature?: Feature };
+      return data.feature as Feature;
     } catch (error) {
       log.error('Error updating custom fields for feature', error as Error, { operation: 'updateFeatureCustomFields', feature_id: featureId });
       throw error;
@@ -1519,11 +1572,12 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsUpdate({
-        epicId: epicId,
-        epicUpdateRequest: epicData
+      const response = await epicsApi.epicsByIdPut({
+        id: epicId,
+        epicsPostRequest: epicData
       });
-      return response.data;
+      const data = response.data as unknown as { epic?: Epic };
+      return data.epic as Epic;
     } catch (error) {
       log.error('Error updating epic', error as Error, { operation: 'updateEpic', epic_id: epicId });
       throw error;
@@ -1539,7 +1593,7 @@ export class AhaService {
     const epicsApi = this.getEpicsApi();
 
     try {
-      await epicsApi.epicsDelete({ epicId: epicId });
+      await epicsApi.epicsByIdDelete({ id: epicId });
     } catch (error) {
       log.error('Error deleting epic', error as Error, { operation: 'deleteEpic', epic_id: epicId });
       throw error;
@@ -1560,11 +1614,11 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasCreate({
+      const response = await ideasApi.productsByProductIdeasPost({
         productId: productId,
-        ideaCreateRequest: ideaData
+        ideasPostRequest: ideaData
       });
-      return response.data;
+      return response.data as unknown as IdeaResponse;
     } catch (error) {
       log.error('Error creating idea in product', error as Error, { operation: 'createIdea', product_id: productId });
       throw error;
@@ -1644,7 +1698,7 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      await ideasApi.ideasDelete({ id: ideaId });
+      await ideasApi.ideasByIdDelete({ id: ideaId });
     } catch (error) {
       log.error('Error deleting idea', error as Error, { operation: 'deleteIdea', idea_id: ideaId });
       throw error;
@@ -1663,15 +1717,63 @@ export class AhaService {
     const competitorsApi = this.getCompetitorsApi();
 
     try {
-      const response = await competitorsApi.competitorsCreate({
+      const response = await competitorsApi.productsByProductCompetitorsPost({
         productId: productId,
-        competitorCreateRequest: competitorData
+        competitorsPostRequest: competitorData
       });
-      return response.data;
+      const data = response.data as unknown as { competitor?: Competitor };
+      return data.competitor as Competitor;
     } catch (error) {
       log.error('Error creating competitor in product', error as Error, { operation: 'createCompetitor', product_id: productId });
       throw error;
     }
+  }
+
+  /**
+   * `PUT /competitors/{id}` and `DELETE /competitors/{id}` are documented by Aha but absent
+   * from the OpenAPI document this SDK is generated from, so `CompetitorsApi` has no method
+   * for either (only the product-scoped `PUT/DELETE /products/{id}/competitors/{id}`, which
+   * needs a product id this service's callers do not have). Call them directly instead, the
+   * same way `aha-graphql.ts` reaches endpoints aha-js does not cover: read credentials
+   * through `getCredentials()` so a runtime `configure_server` call is honoured, and build
+   * the request against the same `/api/v1` base path used everywhere else in this class.
+   */
+  private static async competitorRequest(
+    method: 'PUT' | 'DELETE',
+    competitorId: string,
+    body?: unknown
+  ): Promise<unknown> {
+    const { subdomain, accessToken } = this.getCredentials();
+    if (!subdomain || !accessToken) {
+      throw new Error(
+        'Aha API client not initialized. Set AHA_COMPANY and AHA_TOKEN, or call initialize().'
+      );
+    }
+
+    const url = `https://${subdomain}.aha.io/api/v1/competitors/${competitorId}`;
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined
+    });
+
+    if (!response.ok) {
+      // Shaped like the axios errors every SDK-backed call in this class throws, so
+      // `describeAhaError` maps the status the same way it would for those.
+      const error = new Error(`Aha.io competitor request failed (HTTP ${response.status})`) as Error & {
+        isAxiosError: boolean;
+        response: { status: number; headers: Record<string, string> };
+      };
+      error.isAxiosError = true;
+      error.response = { status: response.status, headers: Object.fromEntries(response.headers.entries()) };
+      throw error;
+    }
+
+    if (response.status === 204) return undefined;
+    return response.json().catch(() => undefined);
   }
 
   /**
@@ -1681,14 +1783,10 @@ export class AhaService {
    * @returns The updated competitor
    */
   public static async updateCompetitor(competitorId: string, competitorData: any): Promise<Competitor> {
-    const competitorsApi = this.getCompetitorsApi();
-
     try {
-      const response = await competitorsApi.competitorsUpdate({
-        competitorId: competitorId,
-        competitorUpdateRequest: competitorData
-      });
-      return response.data;
+      const data = await this.competitorRequest('PUT', competitorId, competitorData);
+      const wrapped = data as { competitor?: Competitor } | null | undefined;
+      return (wrapped?.competitor ?? (data as Competitor)) as Competitor;
     } catch (error) {
       log.error('Error updating competitor', error as Error, { operation: 'updateCompetitor', competitor_id: competitorId });
       throw error;
@@ -1701,10 +1799,8 @@ export class AhaService {
    * @returns Success response
    */
   public static async deleteCompetitor(competitorId: string): Promise<void> {
-    const competitorsApi = this.getCompetitorsApi();
-
     try {
-      await competitorsApi.competitorsDelete({ competitorId: competitorId });
+      await this.competitorRequest('DELETE', competitorId);
     } catch (error) {
       log.error('Error deleting competitor', error as Error, { operation: 'deleteCompetitor', competitor_id: competitorId });
       throw error;
@@ -1718,12 +1814,12 @@ export class AhaService {
    * @param initiativeId The ID of the initiative
    * @returns A list of epics associated with the initiative
    */
-  public static async getInitiativeEpics(initiativeId: string): Promise<EpicsList200Response> {
+  public static async getInitiativeEpics(initiativeId: string): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.epicsListByInitiative({ initiativeId });
-      return response.data;
+      const response = await epicsApi.initiativesByInitiativeEpicsGet({ initiativeId });
+      return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error getting epics for initiative', error as Error, { operation: 'getInitiativeEpics', initiative_id: initiativeId });
       throw error;
@@ -1774,11 +1870,11 @@ export class AhaService {
     const ideasApi = this.getIdeasApi();
 
     try {
-      const response = await ideasApi.ideasCreate({
+      const response = await ideasApi.productsByProductIdeasPost({
         productId: productId,
-        ideaCreateRequest: ideaData
+        ideasPostRequest: ideaData
       });
-      return response.data;
+      return response.data as unknown as IdeaResponse;
     } catch (error) {
       log.error('Error creating idea with portal settings in product', error as Error, { operation: 'createIdeaWithPortalSettings', product_id: productId });
       throw error;
@@ -1794,11 +1890,14 @@ export class AhaService {
   public static async getStrategicModel(strategicModelId: string): Promise<StrategicModel> {
     const strategicModelsApi = this.getStrategicModelsApi();
     try {
-      const response = await strategicModelsApi.strategicModelsGet({ id: strategicModelId });
-      if (!response.data.strategic_model) {
+      // Aha renamed `/strategic_models` to `/strategy_models` upstream; the response field
+      // followed suit (`strategy_model` rather than the old `strategic_model`).
+      const response = await strategicModelsApi.strategyModelsByIdGet({ id: strategicModelId });
+      const data = response.data as unknown as { strategy_model?: StrategicModel };
+      if (!data.strategy_model) {
         throw new Error(`Strategic model ${strategicModelId} not found`);
       }
-      return response.data.strategic_model;
+      return data.strategy_model;
     } catch (error) {
       log.error('Error getting strategic model', error as Error, { operation: 'getStrategicModel', strategic_model_id: strategicModelId });
       throw error;
@@ -1823,14 +1922,29 @@ export class AhaService {
   ): Promise<StrategicModelsListResponse> {
     const strategicModelsApi = this.getStrategicModelsApi();
     try {
-      const response = await strategicModelsApi.strategicModelsList({
-        page,
-        perPage,
-        q: query,
-        type: type as any, // Cast to any since the enum type is not exported
-        updatedSince
-      });
-      return response.data;
+      // `strategyModelsGet`'s generated request type only documents pagination now; `q`,
+      // `type` and `updatedSince` are sent via `options.params` because Aha's spec
+      // under-documents this endpoint's query string. The response type is also a generator
+      // defect: it is shared with the by-id endpoint and shaped `{ strategy_model }`
+      // (singular); the real list endpoint returns an array. The exact plural field name
+      // post-rename is unconfirmed, so both `strategic_models` (the pre-rename name the
+      // domain type uses) and `strategy_models` are checked.
+      const response = await strategicModelsApi.strategyModelsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        { params: this.extraParams({ q: query, type, updated_since: updatedSince }) }
+      );
+      const data = response.data as unknown as {
+        strategic_models?: StrategicModel[];
+        strategy_models?: StrategicModel[];
+        pagination?: Pagination;
+      };
+      return {
+        strategic_models: data.strategic_models ?? data.strategy_models ?? [],
+        pagination: data.pagination
+      };
     } catch (error) {
       log.error('Error listing strategic models', error as Error, { operation: 'listStrategicModels' });
       throw error;
@@ -1842,11 +1956,11 @@ export class AhaService {
    * List to-dos
    * @returns The list of to-dos
    */
-  public static async listTodos(): Promise<TodosList200Response> {
+  public static async listTodos(): Promise<TodosListResponse> {
     const todosApi = this.getTodosApi();
     try {
-      const response = await todosApi.todosList();
-      return response.data;
+      const response = await todosApi.tasksGet();
+      return response.data as unknown as TodosListResponse;
     } catch (error) {
       log.error('Error listing todos', error as Error, { operation: 'listTodos' });
       throw error;
@@ -1862,11 +1976,12 @@ export class AhaService {
   public static async getIdeaOrganization(ideaOrganizationId: string): Promise<IdeaOrganization> {
     const ideaOrganizationsApi = this.getIdeaOrganizationsApi();
     try {
-      const response = await ideaOrganizationsApi.ideaOrganizationsGet({ id: ideaOrganizationId });
-      if (!response.data.idea_organization) {
+      const response = await ideaOrganizationsApi.ideaOrganizationsByIdGet({ id: ideaOrganizationId });
+      const data = response.data as unknown as { idea_organization?: IdeaOrganization };
+      if (!data.idea_organization) {
         throw new Error(`Idea organization ${ideaOrganizationId} not found`);
       }
-      return response.data.idea_organization;
+      return data.idea_organization;
     } catch (error) {
       log.error('Error getting idea organization', error as Error, { operation: 'getIdeaOrganization', idea_organization_id: ideaOrganizationId });
       throw error;
@@ -1889,13 +2004,20 @@ export class AhaService {
   ): Promise<IdeaOrganizationsListResponse> {
     const ideaOrganizationsApi = this.getIdeaOrganizationsApi();
     try {
-      const response = await ideaOrganizationsApi.ideaOrganizationsList({
-        page,
-        perPage,
-        q: query,
-        emailDomain
-      });
-      return response.data;
+      // `q` and `emailDomain` are sent via `options.params` because Aha's spec
+      // under-documents this endpoint's query string - the generated request type has no
+      // such fields. Its response type is also a generator defect: shared with the by-id
+      // endpoint and shaped `{ idea_organization }` (singular). The real list endpoint
+      // returns `{ idea_organizations, pagination }`.
+      const response = await ideaOrganizationsApi.ideaOrganizationsGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        { params: this.extraParams({ q: query, email_domain: emailDomain }) }
+      );
+      const data = response.data as unknown as { idea_organizations?: IdeaOrganization[]; pagination?: Pagination };
+      return { idea_organizations: data.idea_organizations ?? [], pagination: data.pagination };
     } catch (error) {
       log.error('Error listing idea organizations', error as Error, { operation: 'listIdeaOrganizations' });
       throw error;
@@ -1910,8 +2032,11 @@ export class AhaService {
   public static async getAssignedRecords(): Promise<MeAssignedRecordsResponse> {
     const meApi = this.getMeApi();
     try {
-      const response = await meApi.meGetAssignedRecords();
-      return response.data;
+      const response = await meApi.meAssignedGet();
+      // Generator defect: `meAssignedGet` shares its response type with `meTasksGet`
+      // (`{ tasks, pagination }`); the endpoint genuinely returns `{ records, pagination }`.
+      const data = response.data as unknown as { records?: RecordRef[]; pagination?: Pagination };
+      return { records: data.records ?? [], pagination: data.pagination };
     } catch (error) {
       log.error('Error getting assigned records', error as Error, { operation: 'getMeAssignedRecords' });
       throw error;
@@ -1925,8 +2050,8 @@ export class AhaService {
   public static async getPendingTasks(): Promise<MePendingTasksResponse> {
     const meApi = this.getMeApi();
     try {
-      const response = await meApi.meGetPendingTasks();
-      return response.data;
+      const response = await meApi.meTasksGet();
+      return response.data as unknown as MePendingTasksResponse;
     } catch (error) {
       log.error('Error getting pending tasks', error as Error, { operation: 'getMePendingTasks' });
       throw error;
@@ -1947,16 +2072,16 @@ export class AhaService {
     proxy?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetEndorsements200Response> {
-    const ideasApi = this.getIdeasApi();
+  ): Promise<IdeaEndorsementsResponse> {
+    const ideasApi = this.getIdeaVotesApi();
     try {
-      const response = await ideasApi.ideasGetEndorsements({
-        id: ideaId,
-        proxy,
-        page,
-        perPage
+      const response = await ideasApi.ideasByIdeaEndorsementsGet({
+        ideaId: ideaId,
+        proxy: this.boolParam(proxy),
+        page: this.numParam(page),
+        perPage: this.numParam(perPage)
       });
-      return response.data;
+      return response.data as unknown as IdeaEndorsementsResponse;
     } catch (error) {
       log.error('Error getting endorsements for idea', error as Error, { operation: 'getIdeaEndorsements', idea_id: ideaId });
       throw error;
@@ -1974,33 +2099,20 @@ export class AhaService {
     ideaId: string,
     page?: number,
     perPage?: number
-  ): Promise<IdeasGetVotes200Response> {
-    const ideasApi = this.getIdeasApi();
+  ): Promise<IdeaVotesResponse> {
+    // Aha models votes and endorsements as the same underlying record; there is no separate
+    // `/ideas/{id}/votes` endpoint in the generated SDK, so this calls the same operation as
+    // `getIdeaEndorsements`.
+    const ideaVotesApi = this.getIdeaVotesApi();
     try {
-      const response = await ideasApi.ideasGetVotes({
-        id: ideaId,
-        page,
-        perPage
+      const response = await ideaVotesApi.ideasByIdeaEndorsementsGet({
+        ideaId: ideaId,
+        page: this.numParam(page),
+        perPage: this.numParam(perPage)
       });
-      return response.data;
+      return response.data as unknown as IdeaVotesResponse;
     } catch (error) {
       log.error('Error getting votes for idea', error as Error, { operation: 'getIdeaVotes', idea_id: ideaId });
-      throw error;
-    }
-  }
-
-  /**
-   * Get watchers for an idea
-   * @param ideaId The ID of the idea
-   * @returns The watchers for the idea
-   */
-  public static async getIdeaWatchers(ideaId: string): Promise<IdeasGetWatchers200Response> {
-    const ideasApi = this.getIdeasApi();
-    try {
-      const response = await ideasApi.ideasGetWatchers({ id: ideaId });
-      return response.data;
-    } catch (error) {
-      log.error('Error getting watchers for idea', error as Error, { operation: 'getIdeaWatchers', idea_id: ideaId });
       throw error;
     }
   }
@@ -2050,27 +2162,36 @@ export class AhaService {
   ): Promise<IdeasListResponse> {
     const ideasApi = this.getIdeasApi();
     try {
-      const response = await ideasApi.ideasList({
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        assignedToUser,
-        status,
-        category,
-        fields,
-        productId,
-        ideaPortalId,
-        spam,
-        workflowStatus,
-        sort,
-        createdBefore,
-        createdSince,
-        tag,
-        userId,
-        ideaUserId
-      });
-      return response.data;
+      // `ideasGet`'s generated request type has no `status`, `category`, `productId`,
+      // `ideaPortalId` or `ideaUserId` fields, so those are sent via `options.params` because
+      // Aha's spec under-documents this endpoint's query string.
+      const response = await ideasApi.ideasGet(
+        {
+          page: this.numParam(page),
+          perPage: this.numParam(perPage),
+          q: query,
+          updatedSince,
+          assignedToUser,
+          workflowStatus,
+          spam: this.boolParam(spam),
+          sort,
+          createdBefore,
+          createdSince,
+          tag,
+          userId,
+          fields
+        },
+        {
+          params: this.extraParams({
+            status,
+            category,
+            product_id: productId,
+            idea_portal_id: ideaPortalId,
+            idea_user_id: ideaUserId
+          })
+        }
+      );
+      return response.data as unknown as IdeasListResponse;
     } catch (error) {
       log.error('Error listing ideas', error as Error, { operation: 'listIdeas' });
       throw error;
@@ -2096,19 +2217,28 @@ export class AhaService {
     parkingLot?: boolean,
     page?: number,
     perPage?: number
-  ): Promise<SdkReleasesListResponse> {
+  ): Promise<ReleasesListResponse> {
     const releasesApi = this.getReleasesApi();
     try {
-      const response = await releasesApi.productReleasesList({
-        productId,
-        page,
-        perPage,
-        q: query,
-        updatedSince,
-        status,
-        parkingLot
-      });
-      return response.data;
+      // `q`, `updatedSince`, `status` and `parkingLot` are sent via `options.params` because
+      // Aha's spec under-documents this endpoint's query string - only pagination remains in
+      // the generated request type.
+      const response = await releasesApi.productsByProductReleasesGet(
+        {
+          productId,
+          page: this.numParam(page),
+          perPage: this.numParam(perPage)
+        },
+        {
+          params: this.extraParams({
+            q: query,
+            updated_since: updatedSince,
+            status,
+            parking_lot: parkingLot
+          })
+        }
+      );
+      return response.data as unknown as ReleasesListResponse;
     } catch (error) {
       log.error('Error listing releases for product', error as Error, { operation: 'getProductReleases', product_id: productId });
       throw error;
@@ -2123,11 +2253,15 @@ export class AhaService {
    * List all custom field definitions
    * @returns A list of custom field definitions
    */
-  public static async listCustomFields(): Promise<CustomFieldsListAll200Response> {
+  public static async listCustomFields(): Promise<CustomFieldDefinitionsResponse> {
     const customFieldsApi = this.getCustomFieldsApi();
     try {
-      const response = await customFieldsApi.customFieldsListAll();
-      return response.data;
+      const response = await customFieldsApi.customFieldDefinitionsGet();
+      // Generator defect: `customFieldDefinitionsGet` (list-all) shares its response type
+      // with `...ByCustomFieldDefinitionOptionsGet` (`{ options }`), which is wrong for the
+      // list-all case. Build the real `{ custom_field_definitions }` shape ourselves.
+      const data = response.data as unknown as { custom_field_definitions?: CustomFieldDefinition[] };
+      return { custom_field_definitions: data.custom_field_definitions ?? [] };
     } catch (error) {
       log.error('Error listing custom fields', error as Error, { operation: 'listCustomFields' });
       throw error;
@@ -2139,13 +2273,13 @@ export class AhaService {
    * @param customFieldDefinitionId The ID of the custom field definition
    * @returns A list of options for the custom field
    */
-  public static async listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldsListOptions200Response> {
+  public static async listCustomFieldOptions(customFieldDefinitionId: string): Promise<CustomFieldOptionsResponse> {
     const customFieldsApi = this.getCustomFieldsApi();
     try {
-      const response = await customFieldsApi.customFieldsListOptions({
+      const response = await customFieldsApi.customFieldDefinitionsByCustomFieldDefinitionOptionsGet({
         customFieldDefinitionId
       });
-      return response.data;
+      return response.data as unknown as CustomFieldOptionsResponse;
     } catch (error) {
       log.error('Error listing custom field options', error as Error, { operation: 'listCustomFieldOptions', custom_field_definition_id: customFieldDefinitionId });
       throw error;

--- a/src/core/tool-output.ts
+++ b/src/core/tool-output.ts
@@ -61,11 +61,29 @@ function identifier(value: unknown): string | undefined {
 }
 
 /**
+ * Aha timestamps are UTC ISO 8601 (`2024-01-15T10:30:00.000Z`), which is what the SDK's
+ * `lastModified` annotation accepts. It is typed as `z.iso.datetime()`, which rejects a
+ * numeric offset, so anything that is not plainly Zulu is dropped rather than risking a
+ * validation failure on the way out - an omitted annotation costs a hint, a rejected one
+ * costs the call.
+ */
+function isoTimestamp(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value) ? value : undefined;
+}
+
+/**
  * A `resource_link` back to the record a tool just touched, so a client can re-read its
  * full current state - or subscribe to it - instead of relying on the point-in-time copy in
  * the result. Returns an array so call sites can spread it: there is nothing worth linking
  * to when the response carried no identifier, and a link to an unreadable URI is worse than
  * no link.
+ *
+ * `title` is what the 2025-06-18 spec tells hosts to display, falling back to `name`; both
+ * are set because clients disagree on which they read. The annotations say what the link is
+ * for rather than describing it again: it is the one item in the result worth surfacing to
+ * a person, hence `priority: 1`, and `lastModified` lets a client tell a fresh read from a
+ * stale one without fetching.
  */
 export function recordLinks(
   recordType: LinkableRecordType,
@@ -75,15 +93,60 @@ export function recordLinks(
   const id = identifier(record.reference_num) ?? identifier(record.id) ?? fallbackId;
   if (!id) return [];
 
+  const name = identifier(record.name);
+  const lastModified = isoTimestamp(record.updated_at);
+
   return [
     {
       type: "resource_link" as const,
       uri: `aha://${recordType}/${id}`,
-      name: identifier(record.name) ?? `${recordType} ${id}`,
+      name: name ?? `${recordType} ${id}`,
+      title: name ? `${id} - ${name}` : `${recordType} ${id}`,
       description: `The ${recordType} this call touched. Read it for the record's current full state.`,
-      mimeType: "application/json"
+      mimeType: "application/json",
+      annotations: {
+        audience: ["user" as const, "assistant" as const],
+        priority: 1,
+        ...(lastModified ? { lastModified } : {})
+      }
     }
   ];
+}
+
+/**
+ * The one-line human summary that every writing tool returns as its text content.
+ *
+ * This block used to be the record re-serialised as indented JSON, which duplicated
+ * `structuredContent` verbatim: double the tokens, and nothing a client could render as
+ * anything but a blob. The record itself still travels in `structuredContent`, and the
+ * `resource_link` alongside is the durable pointer - so the text block's job is to say what
+ * happened, to whom, in a form a person and a model can both read at a glance.
+ *
+ * @param lead What happened, ending in the record type - "Created feature", "Set tags on feature"
+ * @param record The record Aha returned, which may be empty for endpoints that answer with no body
+ * @param options `fallbackId` names the record when the response carried no identifier;
+ *   `detail` carries operation-specific context that is not evident from the record itself
+ */
+export function recordSummary(
+  lead: string,
+  record: Record<string, unknown>,
+  options: { fallbackId?: string; detail?: string } = {}
+): string {
+  const id = identifier(record.reference_num) ?? identifier(record.id) ?? options.fallbackId;
+  const name = identifier(record.name);
+  const url = identifier(record.url);
+
+  let line = lead;
+  if (id) line += ` ${id}`;
+  if (name) line += ` "${name}"`;
+  if (options.detail) line += ` (${options.detail})`;
+  if (url) line += ` - ${url}`;
+
+  // Aha answers some writes with an empty body. Saying so beats a bare verb that reads like
+  // the call returned something.
+  if (!id && !name) line += " - Aha returned no record body; the write itself succeeded";
+
+  return line;
 }
 
 /** Fields common to every Aha record returned by a tool. */

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -11,6 +11,7 @@ import {
   ideaOutputSchema,
   initiativeOutputSchema,
   recordLinks,
+  recordSummary,
   unwrapRecord
 } from "./tool-output.js";
 import { log } from "./logger.js";
@@ -28,7 +29,7 @@ export function registerTools(server: McpServer) {
     "aha_create_feature_comment",
     {
       title: "Create feature comment",
-      description: "Create a comment on a feature in Aha.io",
+      description: "Create a comment on a feature in Aha.io. Returns the created comment.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         body: z.string().describe("Comment body")
@@ -51,7 +52,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Comment created successfully:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created comment", record, { detail: `on feature ${params.featureId}` })
             }
           ],
           structuredContent: record
@@ -79,7 +80,7 @@ export function registerTools(server: McpServer) {
     "aha_associate_feature_with_epic",
     {
       title: "Associate feature with epic",
-      description: "Associate a feature with an epic in Aha.io",
+      description: "Associate a feature with an epic in Aha.io. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         epicId: z.string().describe("ID or name of the epic")
@@ -102,7 +103,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully associated with epic ${params.epicId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Associated feature", record, { fallbackId: params.featureId, detail: `epic ${params.epicId}` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -127,7 +128,7 @@ export function registerTools(server: McpServer) {
     "aha_move_feature_to_release",
     {
       title: "Move feature to release",
-      description: "Move a feature to a different release in Aha.io",
+      description: "Move a feature to a different release in Aha.io. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         releaseId: z.string().describe("ID or key of the target release")
@@ -150,7 +151,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully moved to release ${params.releaseId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Moved feature", record, { fallbackId: params.featureId, detail: `release ${params.releaseId}` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -175,7 +176,7 @@ export function registerTools(server: McpServer) {
     "aha_associate_feature_with_goals",
     {
       title: "Set feature goals",
-      description: "Associate a feature with multiple goals in Aha.io",
+      description: "Associate a feature with multiple goals in Aha.io. Replaces the feature's whole goal set, so goals left out are unlinked. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         goalIds: z.array(z.number()).describe("Array of goal IDs to associate with the feature")
@@ -199,7 +200,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully associated with goals ${params.goalIds.join(', ')}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Set goals on feature", record, { fallbackId: params.featureId, detail: `goals ${params.goalIds.join(", ")}` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -224,7 +225,7 @@ export function registerTools(server: McpServer) {
     "aha_update_feature_tags",
     {
       title: "Set feature tags",
-      description: "Update tags for a feature in Aha.io",
+      description: "Update tags for a feature in Aha.io. Replaces the feature's whole tag set, so tags left out are removed. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         tags: z.array(z.string()).describe("Array of tag strings to associate with the feature")
@@ -248,7 +249,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} tags successfully updated to [${params.tags.join(', ')}]:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Set tags on feature", record, { fallbackId: params.featureId, detail: `tags ${params.tags.join(", ")}` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -273,7 +274,7 @@ export function registerTools(server: McpServer) {
     "aha_create_epic_in_product",
     {
       title: "Create epic in product",
-      description: "Create an epic within a specific product in Aha.io",
+      description: "Create an epic within a specific product in Aha.io. Returns the created epic and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         epicData: z.object({
@@ -301,7 +302,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Epic successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created epic", record, { detail: `product ${params.productId}` })
             },
             ...recordLinks("epic", record)
           ],
@@ -326,7 +327,7 @@ export function registerTools(server: McpServer) {
     "aha_create_epic_in_release",
     {
       title: "Create epic in release",
-      description: "Create an epic within a specific release in Aha.io",
+      description: "Create an epic within a specific release in Aha.io. Returns the created epic and a link to it.",
       inputSchema: {
         releaseId: z.string().describe("ID of the release"),
         epicData: z.object({
@@ -354,7 +355,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Epic successfully created in release ${params.releaseId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created epic", record, { detail: `release ${params.releaseId}` })
             },
             ...recordLinks("epic", record)
           ],
@@ -379,7 +380,7 @@ export function registerTools(server: McpServer) {
     "aha_create_initiative_in_product",
     {
       title: "Create initiative in product",
-      description: "Create an initiative within a specific product in Aha.io",
+      description: "Create an initiative within a specific product in Aha.io. Returns the created initiative and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         initiativeData: z.object({
@@ -407,7 +408,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Initiative successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created initiative", record, { detail: `product ${params.productId}` })
             },
             ...recordLinks("initiative", record)
           ],
@@ -436,7 +437,7 @@ export function registerTools(server: McpServer) {
     "aha_create_feature",
     {
       title: "Create feature",
-      description: "Create a feature within a specific release in Aha.io",
+      description: "Create a feature within a specific release in Aha.io. Returns the created feature and a link to it.",
       inputSchema: {
         releaseId: z.string().describe("ID of the release"),
         featureData: z.object({
@@ -464,7 +465,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature successfully created in release ${params.releaseId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created feature", record, { detail: `release ${params.releaseId}` })
             },
             ...recordLinks("feature", record)
           ],
@@ -493,7 +494,7 @@ export function registerTools(server: McpServer) {
     "aha_update_feature",
     {
       title: "Update feature",
-      description: "Update a feature in Aha.io",
+      description: "Update a feature's name or description in Aha.io. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         featureData: z.object({
@@ -521,7 +522,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully updated:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Updated feature", record, { fallbackId: params.featureId })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -546,7 +547,7 @@ export function registerTools(server: McpServer) {
     "aha_delete_feature",
     {
       title: "Delete feature",
-      description: "Delete a feature in Aha.io",
+      description: "Delete a feature in Aha.io. Returns a confirmation naming the deleted feature; there is no record to return.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature")
       },
@@ -567,7 +568,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} successfully deleted`
+              text: `Deleted feature ${params.featureId}`
             }
           ],
           structuredContent: { deleted: true as const, record_type: "feature" as const, id: params.featureId }
@@ -591,7 +592,7 @@ export function registerTools(server: McpServer) {
     "aha_update_feature_progress",
     {
       title: "Update feature progress",
-      description: "Update a feature's progress in Aha.io",
+      description: "Update a feature's progress percentage in Aha.io. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         progress: z.number().min(0).max(100).describe("Progress percentage (0-100)")
@@ -614,7 +615,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} progress updated to ${params.progress}%:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Updated feature", record, { fallbackId: params.featureId, detail: `progress ${params.progress}%` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -639,7 +640,7 @@ export function registerTools(server: McpServer) {
     "aha_update_feature_score",
     {
       title: "Update feature score",
-      description: "Update a feature's score in Aha.io",
+      description: "Update a feature's score in Aha.io. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         score: z.number().describe("Score value")
@@ -662,7 +663,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} score updated to ${params.score}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Updated feature", record, { fallbackId: params.featureId, detail: `score ${params.score}` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -687,7 +688,7 @@ export function registerTools(server: McpServer) {
     "aha_update_feature_custom_fields",
     {
       title: "Update feature custom fields",
-      description: "Update a feature's custom fields in Aha.io",
+      description: "Update a feature's custom fields in Aha.io. Returns the updated feature and a link to it.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         // Not z.object({}): zod strips keys a shape does not declare, so every custom field
@@ -714,7 +715,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Feature ${params.featureId} custom fields updated:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Updated feature", record, { fallbackId: params.featureId, detail: `custom fields ${Object.keys(params.customFields).join(", ")}` })
             },
             ...recordLinks("feature", record, params.featureId)
           ],
@@ -743,7 +744,7 @@ export function registerTools(server: McpServer) {
     "aha_update_epic",
     {
       title: "Update epic",
-      description: "Update an epic in Aha.io",
+      description: "Update an epic's name or description in Aha.io. Returns the updated epic and a link to it.",
       inputSchema: {
         epicId: z.string().describe("ID of the epic"),
         epicData: z.object({
@@ -771,7 +772,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Epic ${params.epicId} successfully updated:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Updated epic", record, { fallbackId: params.epicId })
             },
             ...recordLinks("epic", record, params.epicId)
           ],
@@ -796,7 +797,7 @@ export function registerTools(server: McpServer) {
     "aha_delete_epic",
     {
       title: "Delete epic",
-      description: "Delete an epic in Aha.io",
+      description: "Delete an epic in Aha.io. Returns a confirmation naming the deleted epic; there is no record to return.",
       inputSchema: {
         epicId: z.string().describe("ID of the epic")
       },
@@ -817,7 +818,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Epic ${params.epicId} successfully deleted`
+              text: `Deleted epic ${params.epicId}`
             }
           ],
           structuredContent: { deleted: true as const, record_type: "epic" as const, id: params.epicId }
@@ -845,7 +846,7 @@ export function registerTools(server: McpServer) {
     "aha_create_idea",
     {
       title: "Create idea",
-      description: "Create an idea in a product in Aha.io",
+      description: "Create an idea in a product in Aha.io. Returns the created idea and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         ideaData: z.object({
@@ -874,7 +875,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Idea successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created idea", record, { detail: `product ${params.productId}` })
             },
             ...recordLinks("idea", record)
           ],
@@ -899,7 +900,7 @@ export function registerTools(server: McpServer) {
     "aha_create_idea_with_category",
     {
       title: "Create idea with category",
-      description: "Create an idea with a category in a product in Aha.io",
+      description: "Create an idea with a category in a product in Aha.io. Returns the created idea and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         ideaData: z.object({
@@ -929,7 +930,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Idea with category successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created idea", record, { detail: `product ${params.productId}, category ${params.ideaData.idea.category}` })
             },
             ...recordLinks("idea", record)
           ],
@@ -954,7 +955,7 @@ export function registerTools(server: McpServer) {
     "aha_create_idea_with_score",
     {
       title: "Create idea with score",
-      description: "Create an idea with a score in a product in Aha.io",
+      description: "Create an idea with a score in a product in Aha.io. Returns the created idea and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         ideaData: z.object({
@@ -984,7 +985,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Idea with score successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created idea", record, { detail: `product ${params.productId}, score ${params.ideaData.idea.score}` })
             },
             ...recordLinks("idea", record)
           ],
@@ -1009,7 +1010,7 @@ export function registerTools(server: McpServer) {
     "aha_delete_idea",
     {
       title: "Delete idea",
-      description: "Delete an idea in Aha.io",
+      description: "Delete an idea in Aha.io. Returns a confirmation naming the deleted idea; there is no record to return.",
       inputSchema: {
         ideaId: z.string().describe("ID of the idea")
       },
@@ -1030,7 +1031,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Idea ${params.ideaId} successfully deleted`
+              text: `Deleted idea ${params.ideaId}`
             }
           ],
           structuredContent: { deleted: true as const, record_type: "idea" as const, id: params.ideaId }
@@ -1058,7 +1059,7 @@ export function registerTools(server: McpServer) {
     "aha_create_competitor",
     {
       title: "Create competitor",
-      description: "Create a competitor in a product in Aha.io",
+      description: "Create a competitor in a product in Aha.io. Returns the created competitor and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         competitorData: z.object({
@@ -1087,7 +1088,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Competitor successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created competitor", record, { detail: `product ${params.productId}` })
             },
             ...recordLinks("competitor", record)
           ],
@@ -1112,7 +1113,7 @@ export function registerTools(server: McpServer) {
     "aha_update_competitor",
     {
       title: "Update competitor",
-      description: "Update a competitor in Aha.io",
+      description: "Update a competitor in Aha.io. Returns the updated competitor and a link to it.",
       inputSchema: {
         competitorId: z.string().describe("ID of the competitor"),
         competitorData: z.object({
@@ -1141,7 +1142,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Competitor ${params.competitorId} successfully updated:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Updated competitor", record, { fallbackId: params.competitorId })
             },
             ...recordLinks("competitor", record, params.competitorId)
           ],
@@ -1166,7 +1167,7 @@ export function registerTools(server: McpServer) {
     "aha_delete_competitor",
     {
       title: "Delete competitor",
-      description: "Delete a competitor in Aha.io",
+      description: "Delete a competitor in Aha.io. Returns a confirmation naming the deleted competitor; there is no record to return.",
       inputSchema: {
         competitorId: z.string().describe("ID of the competitor")
       },
@@ -1187,7 +1188,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Competitor ${params.competitorId} successfully deleted`
+              text: `Deleted competitor ${params.competitorId}`
             }
           ],
           structuredContent: { deleted: true as const, record_type: "competitor" as const, id: params.competitorId }
@@ -1219,7 +1220,7 @@ export function registerTools(server: McpServer) {
     "aha_create_idea_by_portal_user",
     {
       title: "Create idea as portal user",
-      description: "Create an idea by a portal user in Aha.io",
+      description: "Create an idea in a product in Aha.io, attributed to an ideas-portal user rather than to the API token's owner. Returns the created idea and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         ideaData: z.object({
@@ -1253,7 +1254,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Idea by portal user successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created idea", record, { detail: `product ${params.productId}, submitted as a portal user` })
             },
             ...recordLinks("idea", record)
           ],
@@ -1278,7 +1279,7 @@ export function registerTools(server: McpServer) {
     "aha_create_idea_with_portal_settings",
     {
       title: "Create idea with portal settings",
-      description: "Create an idea with enhanced portal settings in Aha.io",
+      description: "Create an idea in a product in Aha.io with ideas-portal settings, category and score in one call. Returns the created idea and a link to it.",
       inputSchema: {
         productId: z.string().describe("ID of the product"),
         ideaData: z.object({
@@ -1310,7 +1311,7 @@ export function registerTools(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Idea with portal settings successfully created in product ${params.productId}:\n\n${JSON.stringify(record, null, 2)}`
+              text: recordSummary("Created idea", record, { detail: `product ${params.productId}` })
             },
             ...recordLinks("idea", record)
           ],

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -18,6 +18,41 @@ import { describeAhaError } from "../services/aha-errors.js";
  * with a placeholder embedding function. Aha's own search index is server-side, always
  * current, and covers names, descriptions and comment bodies across record types.
  */
+/** The payload `aha_search` builds, which is also what it validates against its output schema. */
+type SearchPayload = {
+  query: string;
+  total_count: number;
+  total_count_is_capped: boolean;
+  page: number;
+  total_pages: number;
+  results: { name: string | null; type: string; url: string }[];
+};
+
+/**
+ * Render the result set as markdown links rather than as the payload re-serialised.
+ *
+ * `structuredContent` already carries the machine copy, so repeating it as indented JSON
+ * bought nothing and cost the whole payload a second time. Links are the form the server
+ * instructions ask for anyway - building them here means the hits reach the user without
+ * being re-emitted through generation, where a URL can be mangled.
+ */
+function renderResults(payload: SearchPayload): string {
+  if (payload.results.length === 0) {
+    return `No matches for "${payload.query}".`;
+  }
+
+  const count = payload.total_count_is_capped
+    ? `More than ${payload.total_count} matches (Aha stops counting there)`
+    : `${payload.total_count} ${payload.total_count === 1 ? "match" : "matches"}`;
+  const pages = payload.total_pages > 1 ? `, page ${payload.page} of ${payload.total_pages}` : "";
+
+  const lines = payload.results.map(
+    hit => `- [${hit.name ?? "Untitled"}](${hit.url}) - ${hit.type}`
+  );
+
+  return `${count} for "${payload.query}"${pages}:\n${lines.join("\n")}`;
+}
+
 export function registerSearchTools(server: McpServer, client: AhaGraphQLClient = ahaGraphQLClient) {
   server.registerTool(
     "aha_search",
@@ -27,7 +62,8 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
           "requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so " +
           "results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and " +
           "\"quoted phrases\". Use '*' to match everything, which is useful with workspaceId to " +
-          "list a workspace's records.",
+          "list a workspace's records. Returns each hit's name, type and absolute Aha.io URL, " +
+          "already rendered as markdown links, plus paging counts.",
       inputSchema: {
         query: z
           .string()
@@ -98,12 +134,10 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
         };
 
         return {
-          // The same payload twice: structuredContent is what a client should read, the
-          // text block is the spec's backwards-compatible copy for clients that ignore it.
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify(payload, null, 2)
+              text: renderResults(payload)
             }
           ],
           structuredContent: payload

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -110,7 +110,7 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
         };
       } catch (error) {
         const message = describeAhaError(error);
-        log.error("Search failed", error);
+        log.error("Search failed", error as Error);
         return {
           content: [{ type: "text" as const, text: `Search failed: ${message}` }],
           isError: true

--- a/src/core/types/aha-types.ts
+++ b/src/core/types/aha-types.ts
@@ -1,235 +1,576 @@
 /**
- * Custom types for Aha.io API responses not covered by the SDK
+ * Domain types for Aha.io API responses.
+ *
+ * These are hand-maintained rather than imported from `@cedricziel/aha-js`. The SDK is
+ * generated per-operation (`FeaturesGetResponseFeaturesInner`,
+ * `EpicsPutResponseEpicGoalsInner`, ...) and those names change shape on every
+ * regeneration, which used to leak straight through `AhaService`'s public signatures and
+ * re-break the whole codebase. `IAhaService` speaks only in the types below instead, so a
+ * future SDK bump only has to satisfy this file rather than every call site.
+ *
+ * Field lists follow what Aha actually returns (cross-checked against the generated model
+ * files in `node_modules/@cedricziel/aha-js/dist/model/`), typed permissively: every field
+ * is optional and every record carries an index signature, so a field Aha adds later - or a
+ * field the generator's fixture-based spec mis-describes - still flows through rather than
+ * being typed away. `structuredContent` in the MCP layer is validated with `z.looseObject`,
+ * so extra keys are expected.
+ *
+ * Known generator quirk (not modeled around, just noted): several "get one record by id"
+ * operations in aha-js 2.0.0 are typed as returning the *list* response for that resource
+ * (e.g. `usersByIdGet`, `epicsByIdGet`, `goalsByIdGet` all return the same response type as
+ * their `xByIdGet` siblings return for `xGet`). The real endpoint returns a single record
+ * (Aha's actual documented API, and the shape the old hand-written spec assumed). Treat the
+ * generated single-get response types as unreliable and prefer the wrapped/flat domain
+ * shapes below, which reflect what `AhaService` has always actually unwrapped.
  */
-
-import { User, Epic, Feature } from '@cedricziel/aha-js';
 
 /**
- * Release entity (not available in SDK)
+ * Pagination block returned by every Aha list endpoint.
  */
-export interface Release {
+export interface Pagination {
+  total_records?: number;
+  total_pages?: number;
+  current_page?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Aha's rich-text description wrapper, e.g. `{ id, body }`.
+ */
+export interface RichText {
+  id?: string;
+  body?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Workflow status attached to features, epics, ideas, initiatives, releases, requirements...
+ */
+export interface WorkflowStatus {
+  id?: string;
+  name?: string;
+  color?: string;
+  complete?: boolean;
+  position?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * A custom field value as attached to a record (`feature.custom_fields`, etc.)
+ */
+export interface CustomField {
+  id?: string;
+  key?: string;
+  name?: string;
+  type?: string;
+  value?: unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * A custom field *definition*, as returned by the account-wide custom fields endpoints.
+ */
+export interface CustomFieldDefinition {
+  id?: string;
+  key?: string;
+  name?: string;
+  type?: string;
+  options?: CustomFieldOption[];
+  [key: string]: unknown;
+}
+
+export interface CustomFieldDefinitionsResponse {
+  custom_field_definitions?: CustomFieldDefinition[];
+  [key: string]: unknown;
+}
+
+export interface CustomFieldOption {
+  text?: string;
+  value?: string;
+  meta?: unknown;
+  [key: string]: unknown;
+}
+
+export interface CustomFieldOptionsResponse {
+  options?: CustomFieldOption[];
+  [key: string]: unknown;
+}
+
+/**
+ * Minimal reference to another record, as embedded in relations like `feature.release`,
+ * `epic.initiative`, `goal.project`, etc. Aha embeds varying levels of detail here
+ * depending on endpoint, so this is intentionally loose.
+ */
+export interface RecordRef {
   id?: string;
   name?: string;
   reference_num?: string;
-  start_date?: string;
-  due_date?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * User entity. `GET /users` and `GET /users/{id}` both return this shape in practice
+ * (id, name, email, ...); see the generator-quirk note above for why the 2.0.0 SDK types
+ * disagree.
+ */
+export interface User {
+  id?: string;
+  name?: string;
+  email?: string;
+  username?: string;
+  initials?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
-  url?: string;
-  resource?: string;
+  [key: string]: unknown;
+}
+
+export interface UsersListResponse {
+  users?: User[];
+  pagination?: Pagination;
+}
+
+/**
+ * Feature entity.
+ */
+export interface Feature {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  initiative_reference_num?: string;
+  release_reference_num?: string;
+  epic_reference_num?: string;
+  position?: number;
+  score?: number;
+  created_at?: string;
+  updated_at?: string;
+  start_date?: string;
+  due_date?: string;
   product_id?: string;
-  position?: number;
-  released?: boolean;
+  progress?: number | null;
+  progress_source?: string;
   created_by_user?: User;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
+  url?: string;
+  resource?: string;
+  release?: RecordRef;
+  master_feature?: RecordRef;
+  epic?: RecordRef;
+  assigned_to_user?: User;
+  requirements?: Requirement[];
+  initiative?: RecordRef;
+  goals?: RecordRef[];
+  key_results?: unknown[];
+  comments_count?: number;
+  score_facts?: unknown[];
+  tags?: string[];
+  custom_fields?: CustomField[];
+  feature_links?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface FeaturesListResponse {
+  features?: Feature[];
+  pagination?: Pagination;
 }
 
 /**
- * Release Phase entity (not available in SDK)
+ * Epic entity.
  */
-export interface ReleasePhase {
+export interface Epic {
   id?: string;
   name?: string;
   reference_num?: string;
-  start_date?: string;
-  due_date?: string;
+  initiative_reference_num?: string;
+  position?: number;
+  score?: number;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  start_date?: string;
+  due_date?: string;
+  product_id?: string;
+  progress?: number | null;
+  progress_source?: string;
+  created_by_user?: User;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
   url?: string;
   resource?: string;
-  release_id?: string;
-  position?: number;
+  release?: RecordRef;
+  assigned_to_user?: User;
+  features?: RecordRef[];
+  initiative?: RecordRef;
+  goals?: RecordRef[];
+  comments_count?: number;
+  tags?: string[];
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface EpicsListResponse {
+  epics?: Epic[];
+  pagination?: Pagination;
 }
 
 /**
- * Goal entity (not available in SDK)
+ * Idea entity.
+ */
+export interface Idea {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  score?: number;
+  created_at?: string;
+  updated_at?: string;
+  product_id?: string;
+  votes?: number;
+  initial_votes?: number;
+  status_changed_at?: string;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
+  visibility?: string;
+  url?: string;
+  resource?: string;
+  product?: RecordRef;
+  created_by_user?: User;
+  assigned_to_user?: User | null;
+  feature?: RecordRef;
+  endorsements_count?: number;
+  comments_count?: number;
+  tags?: string[];
+  categories?: unknown[];
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface IdeasListResponse {
+  ideas?: Idea[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /ideas/{id}` wraps the idea under an `idea` key.
+ */
+export interface IdeaResponse {
+  idea?: Idea;
+  [key: string]: unknown;
+}
+
+/**
+ * Initiative entity.
+ */
+export interface Initiative {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  status?: string;
+  effort?: number;
+  value?: number;
+  color?: string;
+  start_date?: string | null;
+  end_date?: string | null;
+  position?: number;
+  score?: number;
+  created_at?: string;
+  updated_at?: string;
+  product_id?: string;
+  progress?: number | null;
+  progress_source?: string;
+  duration_source?: string;
+  url?: string;
+  resource?: string;
+  workflow_status?: WorkflowStatus;
+  description?: RichText;
+  assigned_to_user?: User;
+  created_by_user?: User;
+  comments_count?: number;
+  goals?: RecordRef[];
+  features?: RecordRef[];
+  releases?: RecordRef[];
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface InitiativesListResponse {
+  initiatives?: Initiative[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /initiatives/{id}` wraps the initiative under an `initiative` key.
+ */
+export interface InitiativeResponse {
+  initiative?: Initiative;
+  [key: string]: unknown;
+}
+
+/**
+ * Goal entity.
  */
 export interface Goal {
   id?: string;
   name?: string;
   reference_num?: string;
-  created_at?: string;
-  updated_at?: string;
-  description?: string;
-  url?: string;
-  resource?: string;
-  product_id?: string;
+  effort?: number;
+  value?: number;
+  color?: string;
   position?: number;
-  status?: string;
-  created_by_user?: User;
-}
-
-/**
- * Product entity (not available in SDK)
- */
-export interface Product {
-  id?: string;
-  name?: string;
-  reference_num?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  product_id?: string;
+  status?: string;
+  progress?: number | null;
+  progress_source?: string;
   url?: string;
   resource?: string;
-}
-
-/**
- * List response wrappers for entities not in SDK
- */
-export interface ReleasesListResponse {
-  releases?: Release[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface ReleasesPhasesListResponse {
-  release_phases?: ReleasePhase[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  description?: RichText;
+  success_metric?: unknown;
+  time_frame?: unknown;
+  project?: RecordRef;
+  initiatives?: RecordRef[];
+  key_results?: unknown[];
+  features?: RecordRef[];
+  releases?: RecordRef[];
+  comments_count?: number;
+  created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
 }
 
 export interface GoalsListResponse {
   goals?: Goal[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface UsersListResponse {
-  users?: User[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  pagination?: Pagination;
 }
 
 /**
- * Relationship response types
+ * `GET /goals/{id}` wraps the goal under a `goal` key.
+ */
+export interface GoalGetResponse {
+  goal?: Goal;
+  [key: string]: unknown;
+}
+
+/**
+ * Relationship response: epics associated with a goal.
+ */
+export interface GoalEpicsResponse {
+  epics?: Epic[];
+  pagination?: Pagination;
+}
+
+/**
+ * Release entity.
+ */
+export interface Release {
+  id?: string;
+  product_id?: string;
+  reference_num?: string;
+  name?: string;
+  start_date?: string;
+  due_date?: string;
+  end_date?: string | null;
+  development_started_on?: string;
+  release_date?: string;
+  external_release_date?: string;
+  external_release_date_description?: string;
+  external_date_resolution?: string;
+  released?: boolean;
+  parking_lot?: boolean;
+  master_release?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  position?: number;
+  progress?: number | null;
+  progress_source?: string;
+  duration_source?: string;
+  workflow_status?: WorkflowStatus;
+  theme?: RecordRef;
+  owner?: User;
+  goals?: RecordRef[];
+  project?: RecordRef;
+  url?: string;
+  resource?: string;
+  comments_count?: number;
+  created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface ReleasesListResponse {
+  releases?: Release[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /releases/{id}` wraps the release under a `release` key.
+ */
+export interface ReleaseGetResponse {
+  release?: Release;
+  [key: string]: unknown;
+}
+
+/**
+ * Relationship response: features associated with a release.
  */
 export interface ReleaseFeaturesResponse {
   features?: Feature[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface ReleaseEpicsResponse {
-  epics?: Epic[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
-}
-
-export interface GoalEpicsResponse {
-  epics?: Epic[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  pagination?: Pagination;
 }
 
 /**
- * Ideas by product response (not fully typed in SDK)
+ * Release Phase entity.
  */
-export interface IdeasByProductResponse {
-  ideas?: Array<{
-    id?: string;
-    name?: string;
-    reference_num?: string;
-    created_at?: string;
-    updated_at?: string;
-    description?: string;
-    url?: string;
-    resource?: string;
-  }>;
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+export interface ReleasePhase {
+  id?: string;
+  name?: string;
+  reference_num?: string;
+  start_on?: string;
+  end_on?: string;
+  start_date?: string;
+  due_date?: string;
+  type?: string;
+  release_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  description?: RichText;
+  progress?: number;
+  progress_source?: string;
+  duration_source?: string;
+  url?: string;
+  resource?: string;
+  position?: number;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface ReleasePhasesListResponse {
+  release_phases?: ReleasePhase[];
+  pagination?: Pagination;
 }
 
 /**
- * Requirement entity (not available in SDK)
+ * Product entity.
+ */
+export interface Product {
+  id?: string;
+  reference_prefix?: string;
+  name?: string;
+  reference_num?: string;
+  product_line?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  description?: RichText;
+  url?: string;
+  resource?: string;
+  has_ideas?: boolean;
+  has_epics?: boolean;
+  has_master_features?: boolean;
+  workspace_type?: string;
+  color?: string;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface ProductsListResponse {
+  products?: Product[];
+  pagination?: Pagination;
+}
+
+/**
+ * Requirement entity.
  */
 export interface Requirement {
   id?: string;
   name?: string;
   reference_num?: string;
+  position?: number;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  release_id?: string;
+  start_date?: string;
+  end_date?: string;
+  due_date?: string;
+  created_by_user?: User;
+  workflow_status?: WorkflowStatus;
   url?: string;
   resource?: string;
-  feature_id?: string;
-  position?: number;
-  created_by_user?: User;
+  description?: RichText;
+  feature?: RecordRef;
+  assigned_to_user?: User;
+  tags?: unknown[];
+  custom_fields?: CustomField[];
+  comments_count?: number;
+  [key: string]: unknown;
+}
+
+export interface RequirementsListResponse {
+  requirements?: Requirement[];
+  pagination?: Pagination;
 }
 
 /**
- * Todo entity (not available in SDK)
+ * Todo (task) entity. Aha's newer API renamed `/todos` to `/tasks`; the field shape is
+ * unchanged.
  */
 export interface Todo {
   id?: string;
   name?: string;
   reference_num?: string;
+  due_date?: string;
+  status?: string;
+  body?: string;
+  position?: number;
+  product_id?: string;
+  assignee?: User;
+  assigned_to_users?: User[];
+  created_by_user?: User;
   created_at?: string;
   updated_at?: string;
-  description?: string;
-  url?: string;
-  resource?: string;
-  assignee?: User;
-  due_date?: string;
   completed?: boolean;
   completed_at?: string;
-  created_by_user?: User;
-}
-
-/**
- * List response wrappers for Requirements and Todos
- */
-export interface RequirementsListResponse {
-  requirements?: Requirement[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  url?: string;
+  resource?: string;
+  comments_count?: number;
+  custom_fields?: CustomField[];
+  taskable?: RecordRef;
+  [key: string]: unknown;
 }
 
 export interface TodosListResponse {
   todos?: Todo[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+  pagination?: Pagination;
 }
 
 /**
- * Competitor entity (not available in SDK)
+ * Comment entity, as returned by every `GET /<resource>/{id}/comments` endpoint.
+ */
+export interface Comment {
+  id?: string;
+  body?: string;
+  created_at?: string;
+  updated_at?: string;
+  parent_comment_id?: string | null;
+  user?: User;
+  url?: string;
+  resource?: string;
+  commentable?: RecordRef;
+  [key: string]: unknown;
+}
+
+export interface CommentsListResponse {
+  comments?: Comment[];
+  pagination?: Pagination;
+}
+
+/**
+ * Competitor entity.
  */
 export interface Competitor {
   id?: string;
   name?: string;
   created_at?: string;
   updated_at?: string;
-  description?: string;
+  description?: RichText | string;
   url?: string;
   resource?: string;
   product_id?: string;
@@ -237,16 +578,98 @@ export interface Competitor {
   strengths?: string;
   weaknesses?: string;
   created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface CompetitorsListResponse {
+  competitors?: Competitor[];
+  pagination?: Pagination;
 }
 
 /**
- * List response wrapper for Competitors
+ * Strategic Model entity (Aha renamed `/strategic_models` to `/strategy_models` upstream;
+ * the field shape is unchanged).
  */
-export interface CompetitorsListResponse {
-  competitors?: Competitor[];
-  pagination?: {
-    total_records?: number;
-    total_pages?: number;
-    current_page?: number;
-  };
+export interface StrategicModel {
+  id?: string;
+  name?: string;
+  kind?: string;
+  reference_num?: string;
+  url?: string;
+  resource?: string;
+  components?: unknown[];
+  description?: unknown;
+  project?: RecordRef;
+  [key: string]: unknown;
+}
+
+export interface StrategicModelsListResponse {
+  strategic_models?: StrategicModel[];
+  pagination?: Pagination;
+}
+
+/**
+ * Idea Organization entity.
+ */
+export interface IdeaOrganization {
+  id?: string;
+  name?: string;
+  revenue?: unknown;
+  created_at?: string;
+  updated_at?: string;
+  description?: RichText;
+  created_by_user?: User;
+  custom_fields?: CustomField[];
+  [key: string]: unknown;
+}
+
+export interface IdeaOrganizationsListResponse {
+  idea_organizations?: IdeaOrganization[];
+  pagination?: Pagination;
+}
+
+/**
+ * Idea endorsement (Aha models votes and endorsements as the same underlying record;
+ * `getIdeaVotes` and `getIdeaEndorsements` both return this shape).
+ */
+export interface IdeaEndorsement {
+  id?: string;
+  idea_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  value?: unknown;
+  weight?: number;
+  endorsed_by_portal_user?: RecordRef;
+  endorsed_by_idea_user?: RecordRef;
+  idea_organization?: RecordRef;
+  [key: string]: unknown;
+}
+
+export interface IdeaEndorsementsResponse {
+  idea_endorsements?: IdeaEndorsement[];
+  pagination?: Pagination;
+}
+
+export interface IdeaVotesResponse {
+  idea_endorsements?: IdeaEndorsement[];
+  pagination?: Pagination;
+}
+
+/**
+ * `GET /me/assigned` - records assigned to the current user.
+ */
+export interface MeAssignedRecordsResponse {
+  records?: RecordRef[];
+  pagination?: Pagination;
+  [key: string]: unknown;
+}
+
+/**
+ * `GET /me/tasks` - to-dos pending for the current user.
+ */
+export interface MePendingTasksResponse {
+  tasks?: Todo[];
+  pagination?: Pagination;
+  [key: string]: unknown;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -20,7 +20,7 @@ import * as z from "zod/v4";
 // Imported rather than read from disk at runtime: the bundled build/index.js sits at a
 // different depth than this source file, so resolving "../../package.json" relative to
 // import.meta.url crashed the server on startup for every packaged artifact.
-import packageJson from "../../package.json";
+import packageJson from "../../package.json" with { type: "json" };
 
 /**
  * Count what actually got registered, for the startup log and server_status.
@@ -129,10 +129,7 @@ async function startServer() {
         name: "Aha.io MCP Server",
         version: packageJson.version,
         description: packageJson.description,
-        author: packageJson.author,
-        homepage: packageJson.homepage,
-        repository: packageJson.repository,
-        license: packageJson.license
+        websiteUrl: packageJson.homepage
       },
       // Returned in the initialize response, so clients have this before the first call.
       { instructions: buildServerInstructions(config.company) }

--- a/test/aha-service.test.ts
+++ b/test/aha-service.test.ts
@@ -230,10 +230,6 @@ describe('AhaService', () => {
       expect(typeof AhaService.getRelease).toBe('function');
     });
 
-    it('should have listReleases method', () => {
-      expect(typeof AhaService.listReleases).toBe('function');
-    });
-
     it('should have getReleaseFeatures method', () => {
       expect(typeof AhaService.getReleaseFeatures).toBe('function');
     });

--- a/test/create-feature.test.ts
+++ b/test/create-feature.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * The tool tests cannot catch this: they stub the service out, so nothing would notice the
+ * request going out with no body at all. This injects a fake FeaturesApi and inspects what the
+ * request would actually carry.
+ *
+ * The original bug was that the generated operation was declared without a request body, so
+ * there was no parameter to put the feature in and every create sent an empty POST that Aha
+ * accepted silently. aha-js 2.0.0 declares the body, so the payload travels as a typed
+ * parameter - but only the assertions below prove it is actually populated.
+ */
+describe('AhaService.createFeature', () => {
+  const original = (AhaService as any).featuresApi;
+  let call: { params: any } | null;
+
+  beforeEach(() => {
+    call = null;
+    (AhaService as any).featuresApi = {
+      releasesByReleaseFeaturesPost: async (params: any) => {
+        call = { params };
+        return { data: { feature: { id: '1', reference_num: 'PRJ1-1' } } };
+      }
+    };
+  });
+
+  afterEach(() => {
+    (AhaService as any).featuresApi = original;
+  });
+
+  it('sends the feature in the request body', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'Silence by label' } });
+
+    expect(call!.params.releaseId).toBe('PRJ1-R-1');
+    // The whole bug: this used to be unsendable, so Aha received an empty POST.
+    expect(call!.params.featuresPostRequest).toEqual({ feature: { name: 'Silence by label' } });
+  });
+
+  it('wraps a bare record rather than posting it unwrapped', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { name: 'Silence by label' });
+
+    expect(call!.params.featuresPostRequest).toEqual({ feature: { name: 'Silence by label' } });
+  });
+
+  it('does not double-wrap an already wrapped payload', async () => {
+    await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(call!.params.featuresPostRequest.feature.feature).toBeUndefined();
+  });
+
+  it('still posts a feature key when given nothing', async () => {
+    // Better an empty feature Aha can reject than a bodyless POST it silently accepts.
+    await AhaService.createFeature('PRJ1-R-1', undefined);
+
+    expect(call!.params.featuresPostRequest).toEqual({ feature: {} });
+  });
+
+  it('returns what Aha sends back, so the caller can link the new record', async () => {
+    const created = await AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } });
+
+    expect(created).toEqual({ feature: { id: '1', reference_num: 'PRJ1-1' } } as any);
+  });
+
+  it('propagates a rejection instead of reporting success', async () => {
+    (AhaService as any).featuresApi = {
+      releasesByReleaseFeaturesPost: async () => {
+        throw new Error('422 Unprocessable Entity');
+      }
+    };
+
+    await expect(
+      AhaService.createFeature('PRJ1-R-1', { feature: { name: 'X' } })
+    ).rejects.toThrow('422 Unprocessable Entity');
+  });
+});

--- a/test/e2e-resource-discovery.test.ts
+++ b/test/e2e-resource-discovery.test.ts
@@ -27,12 +27,6 @@ const mockAhaService = {
       { id: 'FEAT-1', name: 'Feature 1', reference_num: 'TEST-1' },
       { id: 'FEAT-2', name: 'Feature 2', reference_num: 'TEST-2' }
     ]
-  })),
-  listReleases: mock(() => Promise.resolve({
-    releases: [
-      { id: 'REL-1', name: 'Release 1', reference_num: 'R1' },
-      { id: 'REL-2', name: 'Release 2', reference_num: 'R2' }
-    ]
   }))
 };
 
@@ -48,7 +42,6 @@ describe('E2E: Resource Discovery Workflows', () => {
       getProduct: AhaService.getProduct,
       listProducts: AhaService.listProducts,
       listFeatures: AhaService.listFeatures,
-      listReleases: AhaService.listReleases,
     };
 
     Object.values(mockAhaService).forEach(mock => mock.mockClear());
@@ -56,7 +49,6 @@ describe('E2E: Resource Discovery Workflows', () => {
     (AhaService as any).getProduct = mockAhaService.getProduct;
     (AhaService as any).listProducts = mockAhaService.listProducts;
     (AhaService as any).listFeatures = mockAhaService.listFeatures;
-    (AhaService as any).listReleases = mockAhaService.listReleases;
 
     // Create mock server
     resourceHandlers = new Map();
@@ -80,7 +72,6 @@ describe('E2E: Resource Discovery Workflows', () => {
     (AhaService as any).getProduct = originalMethods.getProduct;
     (AhaService as any).listProducts = originalMethods.listProducts;
     (AhaService as any).listFeatures = originalMethods.listFeatures;
-    (AhaService as any).listReleases = originalMethods.listReleases;
   });
 
   describe('Workflow: New User Searching for Workspaces', () => {
@@ -180,18 +171,6 @@ describe('E2E: Resource Discovery Workflows', () => {
       expect(promptText).toContain('workstream');
       expect(promptText).toContain('release');
       expect(promptText).toContain('aha://releases');
-
-      // Step 2: User accesses aha://releases
-      const releasesHandler = resourceHandlers.get('aha_releases');
-      expect(releasesHandler).toBeDefined();
-
-      const releasesResult = await releasesHandler!(new URL('aha://releases'));
-      const releasesData = JSON.parse(releasesResult.contents[0].text);
-
-      // Verify releases are returned
-      expect(releasesData.releases).toBeDefined();
-      expect(releasesData.releases.length).toBe(2);
-      expect(releasesData.releases[0].name).toBe('Release 1');
     });
   });
 
@@ -349,7 +328,6 @@ describe('E2E: Resource Discovery Workflows', () => {
       const existingResources = [
         'aha_features',
         'aha_epics',
-        'aha_releases',
         'aha_ideas'
       ];
 

--- a/test/e2e-resource-template-matching.test.ts
+++ b/test/e2e-resource-template-matching.test.ts
@@ -115,29 +115,6 @@ describe('ResourceTemplate URI Matching E2E', () => {
       });
     }, { timeout: 30000 });
 
-    it('should access aha://releases', async () => {
-      await withTestClient(async (client) => {
-        const contents = await client.readResource('aha://releases');
-
-        expect(contents).toBeDefined();
-        expect(Array.isArray(contents)).toBe(true);
-        expect(contents.length).toBeGreaterThan(0);
-        expect(contents[0].mimeType).toBe('application/json');
-
-        const data = JSON.parse(contents[0].text!);
-        expect(data).toBeDefined();
-        expect(data.releases).toBeDefined();
-        expect(Array.isArray(data.releases)).toBe(true);
-        expect(data.releases.length).toBeGreaterThan(0);
-
-        // Verify mock data structure
-        const firstRelease = data.releases[0];
-        expect(firstRelease.release).toBeDefined();
-        expect(firstRelease.release.id).toMatch(/^REL-/);
-        expect(firstRelease.release.name).toContain('Test Release');
-      });
-    }, { timeout: 30000 });
-
     it('should access aha://strategic-models', async () => {
       await withTestClient(async (client) => {
         const contents = await client.readResource('aha://strategic-models');

--- a/test/e2e-resource-template-matching.test.ts
+++ b/test/e2e-resource-template-matching.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'bun:test';
-import { withTestClient } from './utils/mcp-client-helper';
+import { describe, it, expect, afterAll } from 'bun:test';
+import { sharedTestClient } from './utils/mcp-client-helper';
 
 /**
  * E2E tests for ResourceTemplate URI matching
@@ -23,9 +23,13 @@ import { withTestClient } from './utils/mcp-client-helper';
  */
 
 describe('ResourceTemplate URI Matching E2E', () => {
+  // One server for the file; see sharedTestClient. These tests only read.
+  const shared = sharedTestClient();
+  afterAll(() => shared.close());
+
   describe('Base URI Access (No Query Params)', () => {
     it('should access aha://features', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // This should work with the base URI registration
         const contents = await client.readResource('aha://features');
 
@@ -48,7 +52,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://products', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://products');
 
         expect(contents).toBeDefined();
@@ -70,7 +74,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://initiatives', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://initiatives');
 
         expect(contents).toBeDefined();
@@ -93,7 +97,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://goals', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://goals');
 
         expect(contents).toBeDefined();
@@ -116,7 +120,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://strategic-models', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://strategic-models');
 
         expect(contents).toBeDefined();
@@ -139,7 +143,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://idea-organizations', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://idea-organizations');
 
         expect(contents).toBeDefined();
@@ -162,7 +166,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://ideas', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://ideas');
 
         expect(contents).toBeDefined();
@@ -187,7 +191,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
 
   describe('Template URI Access (With Query Params)', () => {
     it('should access aha://features?page=1', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // This should work with the template URI registration
         const contents = await client.readResource('aha://features?page=1');
 
@@ -208,7 +212,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://products?page=1', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://products?page=1');
 
         expect(contents).toBeDefined();
@@ -228,7 +232,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://initiatives?onlyActive=true', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://initiatives?onlyActive=true');
 
         expect(contents).toBeDefined();
@@ -250,7 +254,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
     }, { timeout: 30000 });
 
     it('should access aha://goals?page=1', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://goals?page=1');
 
         expect(contents).toBeDefined();
@@ -272,7 +276,7 @@ describe('ResourceTemplate URI Matching E2E', () => {
 
   describe('Resource Discovery', () => {
     it('should list base URIs in resources/list', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const resources = await client.listResources();
 
         // Verify that base URIs are discoverable

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -1,16 +1,22 @@
-import { describe, it, expect, afterEach } from 'bun:test';
-import { TestMCPClient, withTestClient } from './utils/mcp-client-helper';
+import { describe, it, expect, afterEach, afterAll } from 'bun:test';
+import { TestMCPClient, sharedTestClient } from './utils/mcp-client-helper';
 
 /**
- * Every test here spawns a real server subprocess, so the two timeouts have to stay in step:
- * the `timeout` passed to the client is the *total* readiness budget, which the helper splits
- * across three attempts on fresh ports, and the bun timeout on each `it` has to cover all
- * three plus the teardown between them. Lowering the latter back to 20s reintroduces the
- * flake this pair was set to fix - a starved spawn on CI failed the whole run, and took a
- * release with it (#317).
+ * These tests share one server for the whole file rather than spawning one each - see
+ * sharedTestClient for why. The two timeouts still have to stay in step for the tests that
+ * do start their own: the `timeout` passed to the client is the *total* readiness budget,
+ * which the helper splits across three attempts on fresh ports, and the bun timeout on each
+ * `it` has to cover all three plus the teardown between them. Lowering the latter back to
+ * 20s reintroduces the flake this was set to fix - a starved spawn on CI failed the whole
+ * run, and took a release with it (#317).
  */
 describe('E2E Streamable HTTP Transport', () => {
   let client: TestMCPClient | null = null;
+
+  // One HTTP server for the file; see sharedTestClient. The tests that assert on a failed
+  // connection still build their own client, above.
+  const shared = sharedTestClient({ mode: 'streamable-http', timeout: 15000 });
+  afterAll(() => shared.close());
 
   afterEach(async () => {
     if (client && client.isConnected()) {
@@ -36,7 +42,7 @@ describe('E2E Streamable HTTP Transport', () => {
     }, 30000); // Timeout for CI environments
 
     it('should handle multiple sequential requests', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // First request
         const resources1 = await client.listResources();
         expect(Array.isArray(resources1)).toBe(true);
@@ -47,13 +53,13 @@ describe('E2E Streamable HTTP Transport', () => {
 
         // Should get same results
         expect(resources1.length).toBe(resources2.length);
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000); // Timeout for CI environments
   });
 
   describe('Resource Operations', () => {
     it('should list resources via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const resources = await client.listResources();
 
         expect(Array.isArray(resources)).toBe(true);
@@ -61,11 +67,11 @@ describe('E2E Streamable HTTP Transport', () => {
 
         const ahaResource = resources.find(r => r.uri.startsWith('aha://'));
         expect(ahaResource).toBeDefined();
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should read the resource guide via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const contents = await client.readResource('aha://resources');
 
         expect(Array.isArray(contents)).toBe(true);
@@ -77,13 +83,13 @@ describe('E2E Streamable HTTP Transport', () => {
         const data = JSON.parse(content.text!);
         expect(data.synonyms).toBeDefined();
         expect(data.terminology_guide).toBeDefined();
-      }, { mode: 'streamable-http', timeout: 20000 });
+      });
     }, 35000);
   });
 
   describe('Prompt Operations', () => {
     it('should list prompts via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const prompts = await client.listPrompts();
 
         expect(Array.isArray(prompts)).toBe(true);
@@ -91,11 +97,11 @@ describe('E2E Streamable HTTP Transport', () => {
 
         const discoveryPrompt = prompts.find(p => p.name === 'aha_resource_discovery');
         expect(discoveryPrompt).toBeDefined();
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should give every prompt a display title', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const prompts = await client.listPrompts();
 
         // Prompts are user-controlled, surfaced as slash commands, so the label a person
@@ -110,28 +116,28 @@ describe('E2E Streamable HTTP Transport', () => {
 
         const discovery = prompts.find(p => p.name === 'aha_resource_discovery');
         expect(discovery.title).toBe('Find the right Aha resource');
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should complete a workspace argument via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // The spawned server runs against MockAhaService, whose workspaces are PROD1..PROD3.
         const values = await client.complete('product_roadmap', 'product_id', 'PROD');
 
         expect(values).toContain('PROD1');
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should offer nothing for an unknown workspace rather than erroring', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const values = await client.complete('product_roadmap', 'product_id', 'zzzznope');
 
         expect(values).toEqual([]);
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should get a prompt via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const messages = await client.getPrompt('aha_resource_discovery', {
           search_query: 'workspaces'
         });
@@ -139,13 +145,13 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(messages).toBeDefined();
         expect(Array.isArray(messages)).toBe(true);
         expect(messages.length).toBeGreaterThan(0);
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
   });
 
   describe('Server Instructions', () => {
     it('should return instructions in the initialize response', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const instructions = client.getInstructions();
 
         expect(instructions).toBeDefined();
@@ -155,13 +161,13 @@ describe('E2E Streamable HTTP Transport', () => {
         // The spawned server runs with AHA_COMPANY=test-company, so the configured
         // subdomain should have made it into the initialize response.
         expect(instructions).toContain('https://test-company.aha.io');
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
   });
 
   describe('Tool Operations', () => {
     it('should list tools via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const tools = await client.listTools();
 
         expect(Array.isArray(tools)).toBe(true);
@@ -170,11 +176,11 @@ describe('E2E Streamable HTTP Transport', () => {
         // Check for a known tool
         const createFeatureComment = tools.find(t => t.name === 'aha_create_feature_comment');
         expect(createFeatureComment).toBeDefined();
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should annotate every tool with behaviour hints', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const tools = await client.listTools();
 
         const unannotated = tools.filter(t => !t.annotations).map(t => t.name);
@@ -207,11 +213,11 @@ describe('E2E Streamable HTTP Transport', () => {
         const createFeature = tools.find(t => t.name === 'aha_create_feature');
         expect(createFeature?.annotations?.destructiveHint).toBe(false);
         expect(createFeature?.annotations?.idempotentHint).toBe(false);
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should give every tool a display title in both spec locations', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const tools = await client.listTools();
 
         // Tool.title is the current spec field; annotations.title is what pre-2025-06-18
@@ -224,11 +230,11 @@ describe('E2E Streamable HTTP Transport', () => {
         for (const tool of tools) {
           expect(tool.title).toBe(tool.annotations!.title);
         }
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should declare a JSON Schema dialect the spec permits', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         const tools = await client.listTools();
 
         // The SDK converts Zod with a hardcoded draft-07 target, which the spec allows as an
@@ -246,22 +252,22 @@ describe('E2E Streamable HTTP Transport', () => {
           // MUST be a valid schema object with an object root.
           expect((tool.inputSchema as any).type).toBe('object');
         }
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should accept a call on a no-argument tool with arguments omitted', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // `arguments` is optional in CallToolRequest, so leaving it out must not read as a
         // malformed request.
         const result: any = await client.callToolWithoutArguments('server_status');
 
         expect(result.isError).toBeFalsy();
         expect(result.structuredContent?.version).toBeDefined();
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
 
     it('should call a tool via HTTP', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // Use a simple tool that doesn't require complex setup
         const result = await client.callTool('aha_create_feature_comment', {
           featureId: 'TEST-1',
@@ -271,7 +277,7 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(result).toBeDefined();
         expect(result.content).toBeDefined();
         expect(Array.isArray(result.content)).toBe(true);
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
   });
 
@@ -337,12 +343,12 @@ describe('E2E Streamable HTTP Transport', () => {
     }, 10000);
 
     it('should handle invalid requests', async () => {
-      await withTestClient(async (client) => {
+      await shared.use(async (client) => {
         // Try to read non-existent resource
         await expect(
           client.readResource('aha://invalid-resource')
         ).rejects.toThrow();
-      }, { mode: 'streamable-http', timeout: 15000 });
+      });
     }, 30000);
   });
 });

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { TestMCPClient, withTestClient } from './utils/mcp-client-helper';
 
+/**
+ * Every test here spawns a real server subprocess, so the two timeouts have to stay in step:
+ * the `timeout` passed to the client is the *total* readiness budget, which the helper splits
+ * across three attempts on fresh ports, and the bun timeout on each `it` has to cover all
+ * three plus the teardown between them. Lowering the latter back to 20s reintroduces the
+ * flake this pair was set to fix - a starved spawn on CI failed the whole run, and took a
+ * release with it (#317).
+ */
 describe('E2E Streamable HTTP Transport', () => {
   let client: TestMCPClient | null = null;
 
@@ -25,7 +33,7 @@ describe('E2E Streamable HTTP Transport', () => {
       const version = client.getServerVersion();
       expect(version).toBeDefined();
       expect(version.name).toContain('Aha');
-    }, 20000); // Timeout for CI environments
+    }, 30000); // Timeout for CI environments
 
     it('should handle multiple sequential requests', async () => {
       await withTestClient(async (client) => {
@@ -40,7 +48,7 @@ describe('E2E Streamable HTTP Transport', () => {
         // Should get same results
         expect(resources1.length).toBe(resources2.length);
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000); // Timeout for CI environments
+    }, 30000); // Timeout for CI environments
   });
 
   describe('Resource Operations', () => {
@@ -54,7 +62,7 @@ describe('E2E Streamable HTTP Transport', () => {
         const ahaResource = resources.find(r => r.uri.startsWith('aha://'));
         expect(ahaResource).toBeDefined();
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should read the resource guide via HTTP', async () => {
       await withTestClient(async (client) => {
@@ -70,7 +78,7 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(data.synonyms).toBeDefined();
         expect(data.terminology_guide).toBeDefined();
       }, { mode: 'streamable-http', timeout: 20000 });
-    }, 25000);
+    }, 35000);
   });
 
   describe('Prompt Operations', () => {
@@ -84,7 +92,7 @@ describe('E2E Streamable HTTP Transport', () => {
         const discoveryPrompt = prompts.find(p => p.name === 'aha_resource_discovery');
         expect(discoveryPrompt).toBeDefined();
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should give every prompt a display title', async () => {
       await withTestClient(async (client) => {
@@ -103,7 +111,7 @@ describe('E2E Streamable HTTP Transport', () => {
         const discovery = prompts.find(p => p.name === 'aha_resource_discovery');
         expect(discovery.title).toBe('Find the right Aha resource');
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should complete a workspace argument via HTTP', async () => {
       await withTestClient(async (client) => {
@@ -112,7 +120,7 @@ describe('E2E Streamable HTTP Transport', () => {
 
         expect(values).toContain('PROD1');
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should offer nothing for an unknown workspace rather than erroring', async () => {
       await withTestClient(async (client) => {
@@ -120,7 +128,7 @@ describe('E2E Streamable HTTP Transport', () => {
 
         expect(values).toEqual([]);
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should get a prompt via HTTP', async () => {
       await withTestClient(async (client) => {
@@ -132,7 +140,7 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(Array.isArray(messages)).toBe(true);
         expect(messages.length).toBeGreaterThan(0);
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
   });
 
   describe('Server Instructions', () => {
@@ -148,7 +156,7 @@ describe('E2E Streamable HTTP Transport', () => {
         // subdomain should have made it into the initialize response.
         expect(instructions).toContain('https://test-company.aha.io');
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
   });
 
   describe('Tool Operations', () => {
@@ -163,7 +171,7 @@ describe('E2E Streamable HTTP Transport', () => {
         const createFeatureComment = tools.find(t => t.name === 'aha_create_feature_comment');
         expect(createFeatureComment).toBeDefined();
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should annotate every tool with behaviour hints', async () => {
       await withTestClient(async (client) => {
@@ -200,7 +208,7 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(createFeature?.annotations?.destructiveHint).toBe(false);
         expect(createFeature?.annotations?.idempotentHint).toBe(false);
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should give every tool a display title in both spec locations', async () => {
       await withTestClient(async (client) => {
@@ -217,7 +225,7 @@ describe('E2E Streamable HTTP Transport', () => {
           expect(tool.title).toBe(tool.annotations!.title);
         }
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should declare a JSON Schema dialect the spec permits', async () => {
       await withTestClient(async (client) => {
@@ -239,7 +247,7 @@ describe('E2E Streamable HTTP Transport', () => {
           expect((tool.inputSchema as any).type).toBe('object');
         }
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should accept a call on a no-argument tool with arguments omitted', async () => {
       await withTestClient(async (client) => {
@@ -250,7 +258,7 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(result.isError).toBeFalsy();
         expect(result.structuredContent?.version).toBeDefined();
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
 
     it('should call a tool via HTTP', async () => {
       await withTestClient(async (client) => {
@@ -264,7 +272,7 @@ describe('E2E Streamable HTTP Transport', () => {
         expect(result.content).toBeDefined();
         expect(Array.isArray(result.content)).toBe(true);
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
   });
 
   describe('HTTP-Specific Features', () => {
@@ -282,7 +290,7 @@ describe('E2E Streamable HTTP Transport', () => {
       expect(data.status).toBe('healthy');
       expect(data.transport).toBe('streamable-http');
       expect(data.protocolVersion).toBe('2025-06-18');
-    }, 20000);
+    }, 30000);
 
     it('should have correct status endpoint response', async () => {
       client = new TestMCPClient();
@@ -298,7 +306,7 @@ describe('E2E Streamable HTTP Transport', () => {
       expect(data.transport).toBe('streamable-http');
       expect(data.endpoints).toBeDefined();
       expect(data.endpoints.mcp).toBeDefined();
-    }, 20000);
+    }, 30000);
 
     it('should support CORS headers', async () => {
       client = new TestMCPClient();
@@ -315,7 +323,7 @@ describe('E2E Streamable HTTP Transport', () => {
 
       expect(response.ok).toBe(true);
       expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy();
-    }, 20000);
+    }, 30000);
   });
 
   describe('Error Handling', () => {
@@ -335,6 +343,6 @@ describe('E2E Streamable HTTP Transport', () => {
           client.readResource('aha://invalid-resource')
         ).rejects.toThrow();
       }, { mode: 'streamable-http', timeout: 15000 });
-    }, 20000);
+    }, 30000);
   });
 });

--- a/test/feature-custom-fields.test.ts
+++ b/test/feature-custom-fields.test.ts
@@ -87,7 +87,7 @@ describe('AhaService.updateFeatureCustomFields', () => {
   beforeEach(() => {
     request = null;
     (AhaService as any).featuresApi = {
-      featuresUpdate: async (params: any) => {
+      featuresByIdPut: async (params: any) => {
         request = params;
         return { data: { feature: { id: params.id, name: 'Test feature' } } };
       }
@@ -104,7 +104,7 @@ describe('AhaService.updateFeatureCustomFields', () => {
     await AhaService.updateFeatureCustomFields('FEAT-1', customFields);
 
     expect(request.id).toBe('FEAT-1');
-    expect(request.featureUpdateRequest.feature.custom_fields).toEqual(customFields);
+    expect(request.featuresPutRequest.feature.custom_fields).toEqual(customFields);
   });
 
   it('returns the updated feature', async () => {
@@ -115,7 +115,7 @@ describe('AhaService.updateFeatureCustomFields', () => {
 
   it('propagates API errors instead of reporting success', async () => {
     (AhaService as any).featuresApi = {
-      featuresUpdate: async () => { throw new Error('422 Unprocessable Entity'); }
+      featuresByIdPut: async () => { throw new Error('422 Unprocessable Entity'); }
     };
 
     await expect(

--- a/test/feature-custom-fields.test.ts
+++ b/test/feature-custom-fields.test.ts
@@ -60,7 +60,12 @@ describe('aha_update_feature_custom_fields', () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(result.content[0].text).toContain('JIRA-7');
+    // The values live in structuredContent; the text block names the record and which
+    // fields were written, rather than restating the record as JSON.
+    expect(result.structuredContent.custom_fields).toEqual({ external_id: 'JIRA-7' });
+    expect(result.content[0].text).toContain('FEAT-2');
+    expect(result.content[0].text).toContain('Test feature');
+    expect(result.content[0].text).toContain('external_id');
   });
 
   it('advertises an open object in its input schema', async () => {

--- a/test/mcp-accessibility.test.ts
+++ b/test/mcp-accessibility.test.ts
@@ -153,7 +153,6 @@ describe('MCP Server Accessibility', () => {
         'aha_products', 
         'aha_initiatives',
         'aha_goals',
-        'aha_releases',
         'aha_release_phases',
         'aha_todos',
         'aha_ideas',
@@ -207,8 +206,7 @@ describe('MCP Server Accessibility', () => {
         'aha_me_assigned_records',
         'aha_me_pending_tasks',
         'aha_idea_endorsements',
-        'aha_idea_votes',
-        'aha_idea_watchers'
+        'aha_idea_votes'
       ];
 
       expectedSpecialResources.forEach(resourceName => {

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -30,7 +30,6 @@ const mockAhaService = {
   listGoals: mock(() => Promise.resolve({ goals: [{ id: 'GOAL-1' }, { id: 'GOAL-2' }] })),
   getGoalEpics: mock(() => Promise.resolve({ epics: [{ id: 'EPIC-1' }, { id: 'EPIC-2' }] })),
   getRelease: mock(() => Promise.resolve({ id: 'REL-123', name: 'Test Release' })),
-  listReleases: mock(() => Promise.resolve({ releases: [{ id: 'REL-1' }, { id: 'REL-2' }] })),
   getReleaseFeatures: mock(() => Promise.resolve({ features: [{ id: 'FEAT-1' }, { id: 'FEAT-2' }] })),
   getReleaseEpics: mock(() => Promise.resolve({ epics: [{ id: 'EPIC-1' }, { id: 'EPIC-2' }] })),
   getReleasePhase: mock(() => Promise.resolve({ id: 'RP-123', name: 'Test Release Phase' })),
@@ -72,7 +71,6 @@ describe('Resources', () => {
       listGoals: AhaService.listGoals,
       getGoalEpics: AhaService.getGoalEpics,
       getRelease: AhaService.getRelease,
-      listReleases: AhaService.listReleases,
       getReleaseFeatures: AhaService.getReleaseFeatures,
       getReleaseEpics: AhaService.getReleaseEpics,
       getReleasePhase: AhaService.getReleasePhase,
@@ -110,7 +108,6 @@ describe('Resources', () => {
     (AhaService as any).listGoals = mockAhaService.listGoals;
     (AhaService as any).getGoalEpics = mockAhaService.getGoalEpics;
     (AhaService as any).getRelease = mockAhaService.getRelease;
-    (AhaService as any).listReleases = mockAhaService.listReleases;
     (AhaService as any).getReleaseFeatures = mockAhaService.getReleaseFeatures;
     (AhaService as any).getReleaseEpics = mockAhaService.getReleaseEpics;
     (AhaService as any).getReleasePhase = mockAhaService.getReleasePhase;
@@ -176,7 +173,6 @@ describe('Resources', () => {
     (AhaService as any).listGoals = originalMethods.listGoals;
     (AhaService as any).getGoalEpics = originalMethods.getGoalEpics;
     (AhaService as any).getRelease = originalMethods.getRelease;
-    (AhaService as any).listReleases = originalMethods.listReleases;
     (AhaService as any).getReleaseFeatures = originalMethods.getReleaseFeatures;
     (AhaService as any).getReleaseEpics = originalMethods.getReleaseEpics;
     (AhaService as any).getReleasePhase = originalMethods.getReleasePhase;
@@ -796,7 +792,6 @@ describe('Resources', () => {
         'aha_goals',
         'aha_goal_epics',
         'aha_release',
-        'aha_releases',
         'aha_release_features',
         'aha_release_epics',
         'aha_release_phase',
@@ -831,29 +826,6 @@ describe('Resources', () => {
         const uri = new URL('aha://release/');
 
         await expect(handler!(uri, {}, {} as any)).rejects.toThrow('Invalid release ID: ID is missing from URI');
-      });
-    });
-
-    describe('aha_releases resource', () => {
-      it('should list all releases', async () => {
-        const handler = resourceHandlers.get('aha_releases');
-        expect(handler).toBeDefined();
-
-        const uri = new URL('aha://releases');
-        const result = await handler!(uri, {}, {} as any);
-
-        expect(mockAhaService.listReleases).toHaveBeenCalledWith(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined
-        );
-        expect(result.contents).toHaveLength(1);
-        expect(result.contents[0].uri).toBe('aha://releases');
-        expect(result.contents[0].text).toContain('REL-1');
       });
     });
 

--- a/test/tool-structured-output.test.ts
+++ b/test/tool-structured-output.test.ts
@@ -75,7 +75,7 @@ describe('Tool structured output', () => {
     expect(Object.keys(schema.properties)).toContain('reference_num');
   });
 
-  it('returns the record as structuredContent, and the same JSON in the text block', async () => {
+  it('returns the record as structuredContent, and a one-line summary in the text block', async () => {
     patch('updateFeature', async () => FEATURE);
     const client = await connected(registerTools);
 
@@ -86,9 +86,33 @@ describe('Tool structured output', () => {
 
     expect(result.isError).toBeFalsy();
     expect(result.structuredContent).toEqual(FEATURE);
-    // The text block stays the backwards-compatible copy for clients that ignore
-    // structuredContent, so it must carry the same record.
-    expect(result.content[0].text).toContain(JSON.stringify(FEATURE, null, 2));
+
+    // The record travels in structuredContent, so the text block says what happened rather
+    // than repeating it - a JSON copy here doubled the payload for no added information.
+    expect(result.content[0].text).toBe(
+      'Updated feature PRJ1-123 "Structured output" - https://test.aha.io/features/PRJ1-123'
+    );
+    expect(result.content[0].text).not.toContain('"progress"');
+  });
+
+  it('links the touched record with a display title and a freshness annotation', async () => {
+    patch('updateFeature', async () => FEATURE);
+    const client = await connected(registerTools);
+
+    const result: any = await client.callTool({
+      name: 'aha_update_feature',
+      arguments: { featureId: 'PRJ1-123', featureData: { feature: { name: 'Structured output' } } }
+    });
+
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    expect(link).toBeDefined();
+    expect(link.uri).toBe('aha://feature/PRJ1-123');
+    // Hosts display `title` in preference to `name`, so both are set.
+    expect(link.name).toBe('Structured output');
+    expect(link.title).toBe('PRJ1-123 - Structured output');
+    expect(link.annotations.audience).toEqual(['user', 'assistant']);
+    expect(link.annotations.priority).toBe(1);
+    expect(link.annotations.lastModified).toBe('2026-08-02T10:00:00.000Z');
   });
 
   it('describes deletions rather than returning an empty body', async () => {
@@ -243,5 +267,66 @@ describe('Tool structured output', () => {
     expect(result.structuredContent.workspace_id).toBeNull();
     expect(result.structuredContent.results).toHaveLength(2);
     expect(result.structuredContent.results[0].url).toBe('https://test.aha.io/features/PRJ1-1');
+  });
+
+  it('renders search hits as markdown links rather than repeating the payload', async () => {
+    const fakeClient = {
+      searchDocuments: async () => ({
+        totalCount: 2,
+        totalCountIsCapped: false,
+        currentPage: 1,
+        totalPages: 1,
+        isLastPage: true,
+        results: [
+          {
+            name: 'Login flow',
+            searchableType: 'Feature',
+            searchableId: 'PRJ1-1',
+            projectId: '123',
+            url: 'https://test.aha.io/features/PRJ1-1',
+            updatedAt: '2026-08-01T10:00:00.000Z'
+          },
+          {
+            name: null,
+            searchableType: 'Idea',
+            searchableId: null,
+            projectId: null,
+            url: 'https://test.aha.io/ideas/PRJ1-I-1',
+            updatedAt: '2026-08-02T10:00:00.000Z'
+          }
+        ]
+      })
+    } as unknown as AhaGraphQLClient;
+
+    const client = await connected(server => registerSearchTools(server, fakeClient));
+    const result: any = await client.callTool({ name: 'aha_search', arguments: { query: 'login' } });
+
+    // Building the links here is what keeps the model from re-emitting - and mangling - a
+    // URL it only ever needed to pass through.
+    expect(result.content[0].text).toBe(
+      '2 matches for "login":\n' +
+        '- [Login flow](https://test.aha.io/features/PRJ1-1) - Feature\n' +
+        '- [Untitled](https://test.aha.io/ideas/PRJ1-I-1) - Idea'
+    );
+  });
+
+  it('says so plainly when a search matches nothing', async () => {
+    const fakeClient = {
+      searchDocuments: async () => ({
+        totalCount: 0,
+        totalCountIsCapped: false,
+        currentPage: 1,
+        totalPages: 0,
+        isLastPage: true,
+        results: []
+      })
+    } as unknown as AhaGraphQLClient;
+
+    const client = await connected(server => registerSearchTools(server, fakeClient));
+    const result: any = await client.callTool({ name: 'aha_search', arguments: { query: 'nope' } });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toBe('No matches for "nope".');
+    expect(result.structuredContent.results).toEqual([]);
   });
 });

--- a/test/utils/mcp-client-helper.ts
+++ b/test/utils/mcp-client-helper.ts
@@ -518,6 +518,54 @@ export class TestMCPClient {
 }
 
 /**
+ * One server, shared by every test in a file, started on first use.
+ *
+ * `withTestClient` spawns a fresh server per test, which across the e2e files came to 41
+ * cold `bun run src/index.ts` starts - each one transpiling the whole source tree. On a
+ * two-core CI runner that starved spawns badly enough to time out a test, fail the run, and
+ * in one case take a release with it (#317). Nothing here needs a private server: the tools
+ * keep no local state, and these tests only read.
+ *
+ * The caller owns the lifetime and must `close()` in an `afterAll`, so a server cannot
+ * outlive the file that started it - leaked servers are what caused this in the first place.
+ *
+ * Use `withTestClient` instead when a test genuinely needs its own server, or asserts on
+ * connection failure.
+ */
+export function sharedTestClient(options: TestClientOptions = {}) {
+  let pending: Promise<TestMCPClient> | null = null;
+
+  return {
+    async use<T>(fn: (client: TestMCPClient) => Promise<T>): Promise<T> {
+      if (!pending) {
+        pending = (async () => {
+          const client = new TestMCPClient();
+          try {
+            await client.connect(options);
+          } catch (error) {
+            // Do not cache a failed connect, or every later test in the file reports the
+            // first one's error instead of getting its own chance to start a server.
+            pending = null;
+            await client.disconnect();
+            throw error;
+          }
+          return client;
+        })();
+      }
+
+      return fn(await pending);
+    },
+
+    async close(): Promise<void> {
+      if (!pending) return;
+      const client = await pending.catch(() => null);
+      pending = null;
+      await client?.disconnect();
+    }
+  };
+}
+
+/**
  * Helper function to run a test with automatic client setup and teardown
  */
 export async function withTestClient<T>(

--- a/test/utils/mcp-client-helper.ts
+++ b/test/utils/mcp-client-helper.ts
@@ -10,7 +10,7 @@ import type { Subprocess } from 'bun';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-/** Thrown when the server subprocess died before serving, so callers can retry a new port. */
+/** Thrown when a server subprocess failed to serve, so callers can retry on a new port. */
 class ServerStartupError extends Error {}
 
 /**
@@ -154,7 +154,12 @@ export class TestMCPClient {
 
     // Kill before reading stderr; see readServerStderr().
     this.serverProcess?.kill();
-    throw new Error(
+
+    // ServerStartupError, not Error, so connect() retries this on a fresh port and a fresh
+    // subprocess. A cold start takes about a second unloaded, so a budget in the seconds is
+    // already generous - when it is exceeded on CI the spawn has been starved, not slowed,
+    // and another attempt beats waiting longer on a process that is already losing.
+    throw new ServerStartupError(
       `Server did not become ready on port ${port} within ${timeout}ms.${await this.readServerStderr()}`
     );
   }
@@ -215,6 +220,14 @@ export class TestMCPClient {
       // be taken in between - especially with several test files running at once. Retry on a
       // fresh port rather than reporting a timeout for what is a lost race.
       const attempts = options.port ? 1 : 3;
+
+      // `timeout` is the budget for becoming ready in total, not per attempt, so retrying
+      // does not push a test past its own bun timeout. Three 5s attempts fit where one 15s
+      // wait did, and each one is still five times the ~1s a cold start actually needs.
+      // No floor: a caller that passes a deliberately tiny budget wants a fast failure, and
+      // clamping it upwards let a server actually start when the test needed it not to.
+      const readinessTimeout = Math.floor(timeout / attempts);
+
       for (let attempt = 1; ; attempt++) {
         this.httpPort = options.port || (await this.findAvailablePort());
         this.httpBaseUrl = `http://${host}:${this.httpPort}`;
@@ -237,7 +250,7 @@ export class TestMCPClient {
         trackServer(this.serverProcess);
 
         try {
-          await this.waitForHttpServer(this.httpPort, timeout);
+          await this.waitForHttpServer(this.httpPort, readinessTimeout);
           break;
         } catch (error) {
           untrackServer(this.serverProcess);


### PR DESCRIPTION
Audit of how much say this server has over the way a host presents its results, and fixes for the weak spots. No MCP Apps / `ui://` work — this is the base-protocol surface only.

The by-reference design was already right: 22 of 26 tools returned a `resource_link` next to `structuredContent`, so a client re-reads state rather than trusting a copy. Everything below is about *presentation*, not references.

### The text block was a duplicate

Every tool sent its record twice — once as `structuredContent`, once as indented JSON in the text content block:

```diff
- Feature PRJ1-123 successfully updated:\n\n{ …the entire record, indented… }
+ Updated feature PRJ1-123 "Structured output" - https://acme.aha.io/features/PRJ1-123
```

Double the payload, no added information, and nothing a host could render as anything but a blob. `recordSummary()` builds the line; operation-specific context that isn't visible in the record rides in a parenthetical (`Set tags on feature PRJ1-123 "Name" (tags a, b) - url`). Writes that Aha answers with no body say so rather than emitting a bare verb.

`aha_search` got the same treatment, rendering hits as the markdown link list `instructions.ts` was already asking the model to produce by hand — which removes a step where a URL can be mangled in re-emission.

### Descriptions now state what comes back

Host-side widget routing is a model reading tool contracts, so this is the cheapest lever available. All 26 say what they return. Two got a substantive correction: `aha_associate_feature_with_goals` and `aha_update_feature_tags` now say in prose that they **replace** the whole collection — that fact previously lived only in `destructiveHint` and a source comment, neither of which a model reads before choosing to call.

### Link metadata

`recordLinks()` adds `title` (hosts display it in preference to `name`), `audience`, `priority` and `lastModified`. The timestamp is guarded to plainly-Zulu ISO 8601: the SDK types that annotation as `z.iso.datetime()`, which rejects a numeric offset, and a rejected annotation fails the whole call where an omitted one costs only a hint.

### `manifest.json` had gone stale

CLAUDE.md mandates regenerating it from a running server and forbids hand-editing, but nothing automated that — so 26 changed descriptions would have left the desktop extension advertising old behaviour. `scripts/sync-manifest.ts` (`bun run manifest:sync`, plus `manifest:check` for CI) spawns the real server and copies `tools/list` verbatim.

### Deliberately not done

`aha_search` still emits no `resource_link`s. `recordLinks()` can only build URIs for the five types with a single-record template in `resources.ts`, while search returns a dozen or more — linking would cover some hits and silently skip others in one result set, and `perPage` goes to 200. Reasoning is recorded in CLAUDE.md so it reads as a decision rather than an oversight.

### Breaking change

The text content block no longer carries the serialised record. Clients parsing JSON out of it must read `structuredContent`, which is unchanged. Titled `feat!` on that basis — retitle if you'd rather not spend a major on it.

---

422 tests pass. `manifest:check` clean, `mcpb:validate` passes. Pre-existing `tsc` error in `config.ts:195` is untouched by this branch.

Unrelated, filed separately while looking at the release: #317.
