### PR TITLE
feat!: add single-record read tools and stop advertising "*" as a match-all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,22 @@ Behaviours measured against a live account, not documented upstream - keep the c
   permission or licensing problem is an HTTP **403** - do not conflate them.
 - Most other list queries (`goals`, `initiatives`, `keyResults`, ...) require a `filters`
   argument *and* a scoping id inside it; `filters: {}` is rejected.
+- **There is no match-all query, and `*` is not one.** Alone it returns an arbitrary subset
+  (4116 hits on an account where `APPO11Y*` by itself returned 7963); combined with
+  `projectId` it returns **zero**, for every workspace tried. `searchDocuments` rejects a
+  wildcard-only query rather than passing it on, because the empty result reads as an empty
+  workspace and gets diagnosed as a broken `projectId` filter - which is exactly what
+  happened while `aha_search`'s own description recommended that combination. The filter
+  works: `projectId` plus a real term returns correctly scoped hits. Do not restore the
+  match-all claim to the tool description, the README, or the blank-query error.
+- `projectId` must be a **string**. A numeric id is not an error, it silently matches
+  nothing - and real workspace ids exceed 2^53, so a JS number cannot hold one exactly
+  anyway. `searchDocuments` coerces with `String()`.
+- A search hit cannot carry per-type fields. `searchDocuments` returns a concrete
+  `SearchDocument`, not a union, so `... on Feature { workflowStatus }` is rejected outright
+  with *"Fragment on Feature can't be spread inside SearchDocument"*. Status, release
+  membership and custom field values are only reachable per record - hence the `aha_get_*`
+  tools. Do not try to enrich search hits through this query.
 
 A previous local-cache implementation (SQLite plus a placeholder embedding that hashed
 character codes through `Math.sin()`) was removed in favour of this. Do not reintroduce
@@ -170,9 +186,17 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
   does not cover. Reads credentials via `AhaService.getCredentials()` so `configure_server`
   applies at runtime
 - **ConfigService**: Manages runtime configuration with file persistence and validation
-- **Tools**: 31 MCP tools (CRUD, search, health checks, configuration), none of which keep
-  local state
+- **Tools**: 36 MCP tools (CRUD, single-record reads, search, health checks, configuration),
+  none of which keep local state
 - **Resources**: 40+ resource types for accessing Aha.io entities via URI schemes
+- **Read tools vs read resources**: `src/core/tools/record-tools.ts` registers `aha_get_*`
+  for feature, epic, idea, initiative and release, wrapping the same service getters the
+  `aha://{type}/{id}` resources call. The duplication is deliberate and should stay.
+  Surfacing resources to a model is optional for a client, and tool-only clients are common;
+  on one of those this server was ~25 writers plus a search returning six fields, so an
+  agent could set a feature's status but never read the status it was replacing. Reads must
+  stay reachable as tools for every type that has a write tool - if you add writers for a
+  new type, add its reader too
 - **Prompts**: 17 workflow prompts. Twelve template a question; five (`idea_triage`,
   `release_readiness`, `feature_description_draft`, `quarterly_roadmap_review`,
   `customer_demand_rollup`) instead tell the agent which tools and resources to reach for,
@@ -245,8 +269,9 @@ Every tool is registered with an annotations argument, and the e2e suite fails i
 missing. Conventions used here:
 
 - `title` is a short human-readable label for client UIs.
-- `readOnlyHint` is true only for tools that never write: `aha_search`, `server_status`,
-  `get_server_config`, `server_health_check`, `test_configuration`.
+- `readOnlyHint` is true only for tools that never write: `aha_search`, the five `aha_get_*`
+  readers, `server_status`, `get_server_config`, `server_health_check`,
+  `test_configuration`.
 - `destructiveHint` and `idempotentHint` are **omitted** when `readOnlyHint` is true - the
   spec only gives them meaning for writers.
 - `destructiveHint: true` covers the deletes plus the two PUT endpoints that replace a whole

--- a/README.md
+++ b/README.md
@@ -432,7 +432,21 @@ aha://custom-field/CF-123/options # Get options for custom field
 
 ### Available Tools
 
-**Note**: Read operations (list/get) are handled through MCP resources. Tools are focused on write operations and relationship management.
+**Note**: List operations are handled through MCP resources. Tools cover search, single-record
+reads, write operations and relationship management.
+
+#### Record Read Tools
+- `aha_get_feature`: Read one feature, including workflow status, release, assignee, tags, score and custom field values
+- `aha_get_epic`: Read one epic
+- `aha_get_idea`: Read one idea
+- `aha_get_initiative`: Read one initiative
+- `aha_get_release`: Read one release
+
+These return the full record as `structuredContent`. They duplicate what
+`aha://feature/{id}` and friends already serve, deliberately: a client is free to surface
+resources to its model or not, and several do not — on those, every read here was
+unreachable, leaving write tools with no way to see what they were about to replace.
+`aha_search` is not a substitute, as it cannot return per-record fields.
 
 #### Write Operation Tools
 - `aha_create_feature_comment`: Create a comment on a feature
@@ -473,11 +487,14 @@ aha://custom-field/CF-123/options # Get options for custom field
 - `aha_associate_feature_with_goals`: Associate a feature with multiple goals
 - `aha_update_feature_tags`: Update tags for a feature
 
-**Note**: The MCP server follows best practices by separating read and write operations:
-- **Resources** are used for all read operations (list/get) and provide comprehensive access to Aha.io entities with advanced filtering capabilities through URI parameters
-- **Tools** are reserved for write operations (create/update/delete) and relationship management (associate/move) that modify data in Aha.io
+**Note**: reads are offered through both interfaces, by design:
+- **Resources** cover the full read surface — every entity type, with filtering through URI parameters, and lists as well as single records
+- **Tools** cover writes (create/update/delete), relationship management (associate/move), search, and single-record reads for the five most-written types
 
-This separation ensures a clean architecture where resources handle data retrieval and tools handle data modification.
+The overlap is deliberate. Resources are the richer read surface, but the MCP spec leaves it
+to each client whether to expose them to its model, and tool-only clients are common. Keeping
+reads tool-accessible for the types that have write tools is what stops an agent from changing
+a field it cannot see.
 
 ### 🚀 Phase 8 - Complete CRUD Operations & Advanced Features
 
@@ -521,13 +538,14 @@ The MCP server now provides comprehensive lifecycle management for Aha.io entiti
 - **Comprehensive Entity Coverage**: Full CRUD operations for features, epics, ideas, and competitors
 
 #### Technical Achievements
-- **31 MCP tools**, all querying Aha.io directly — no local state
+- **36 MCP tools**, all querying Aha.io directly — no local state
 - **15 listed MCP resources** covering the entity set, plus templated resource URIs
 - **17 domain-specific prompts** (workflow automation)
 - **25 core CRUD and write operation tools** for complete lifecycle management
 - **Cross-record search** over Aha's own index, covering 20 record types
+- **5 single-record read tools**, so a write can be checked against the record's current state on clients that do not surface resources
 - **5 server configuration tools** for runtime configuration
-- **306 tests passing** with comprehensive service coverage
+- **437 tests passing** with comprehensive service coverage
 - **No native dependencies**, so the server runs anywhere Node does
 - **Comprehensive error handling** with proper Zod schema validation
 
@@ -544,15 +562,27 @@ always current and no native dependencies or writable storage are required.
 // Ideas only, within one workspace
 { "query": "alerting", "recordTypes": ["Idea"], "workspaceId": "7387509120724661690" }
 
-// List a workspace's ideas: "*" matches everything
-{ "query": "*", "recordTypes": ["Idea"], "workspaceId": "7387509120724661690" }
+// Sweep a workspace broadly: alternatives, because there is no match-all
+{ "query": "a* OR e* OR i* OR o* OR u*", "recordTypes": ["Idea"], "workspaceId": "7387509120724661690" }
 ```
 
 **What it matches:** record names and descriptions. Comment bodies match too, surfacing as
 `Comment` hits that link to their parent record.
 
 **Query syntax:** `term*` for prefix matching, `AND` / `OR` / `NOT`, and `"quoted phrases"`.
-`*` matches everything.
+
+**There is no match-all query.** A bare `*` is rejected: on its own Aha returns an arbitrary
+subset for it, and combined with `workspaceId` it returns nothing at all — an empty result
+that reads like an empty workspace. Search for a term, or enumerate a workspace through the
+list resources (`aha://features`, `aha://ideas/{product_id}`) instead of searching it.
+
+**What it does not return:** workflow status, release membership, assignee or custom field
+values. Aha's `searchDocuments` cannot select per-type fields, so a hit carries only its
+name, type, id, workspace, URL and `updated_at`. Read the record itself for anything else:
+
+```jsonc
+{ "featureId": "PRJ1-123" }   // aha_get_feature — full record, including custom fields
+```
 
 **Record types** (`recordTypes`, omit to search all):
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Aha.io MCP Server",
   "version": "4.0.0",
   "description": "Model Context Protocol server for Aha.io product management platform",
-  "long_description": "A comprehensive MCP server that provides seamless integration with Aha.io's API. This extension enables AI assistants to search and manage Aha.io records - ideas, features, epics, initiatives, goals, requirements, releases and competitors - with 31 tools, 15 resources and 14 guided prompts.\n\nSearch is served by Aha.io's own index via aha_search, so results are always current and nothing is cached locally. Every tool queries Aha.io directly; the extension stores no data and needs no native dependencies.",
+  "long_description": "A comprehensive MCP server that provides seamless integration with Aha.io's API. This extension enables AI assistants to search and manage Aha.io records - ideas, features, epics, initiatives, goals, requirements, releases and competitors - with 36 tools, 15 resources and 17 guided prompts.\n\nSearch is served by Aha.io's own index via aha_search, so results are always current and nothing is cached locally. Search returns names, types and links; aha_get_feature and its siblings return a full record - workflow status, release, assignee and custom field values - so a change can be checked against what the record says now. Every tool queries Aha.io directly; the extension stores no data and needs no native dependencies.",
   "author": {
     "name": "Cedric Ziel",
     "email": "mail@cedric-ziel.com",
@@ -119,12 +119,32 @@
       "description": "Delete an idea in Aha.io. Returns a confirmation naming the deleted idea; there is no record to return."
     },
     {
+      "name": "aha_get_epic",
+      "description": "Read one epic from Aha.io by reference number (e.g. PRJ1-E-4) or internal id. Returns the full current record - including workflow status, release, initiative, assignee, progress and custom field values - as structuredContent, a one-line summary naming its status, and a link to the epic. aha_search returns none of these fields, so use this to see a epic's current values, and always read before you write to one."
+    },
+    {
+      "name": "aha_get_feature",
+      "description": "Read one feature from Aha.io by reference number (e.g. PRJ1-123) or internal id. Returns the full current record - including workflow status, release, epic, initiative, assignee, tags, score, progress and custom field values - as structuredContent, a one-line summary naming its status, and a link to the feature. aha_search returns none of these fields, so use this to see a feature's current values, and always read before you write to one."
+    },
+    {
+      "name": "aha_get_idea",
+      "description": "Read one idea from Aha.io by reference number (e.g. PRJ1-I-7) or internal id. Returns the full current record - including workflow status, score, endorsement and vote counts, categories and custom field values - as structuredContent, a one-line summary naming its status, and a link to the idea. aha_search returns none of these fields, so use this to see a idea's current values, and always read before you write to one."
+    },
+    {
+      "name": "aha_get_initiative",
+      "description": "Read one initiative from Aha.io by reference number (e.g. PRJ1-S-2) or internal id. Returns the full current record - including workflow status, progress, timeframe, goals and custom field values - as structuredContent, a one-line summary naming its status, and a link to the initiative. aha_search returns none of these fields, so use this to see a initiative's current values, and always read before you write to one."
+    },
+    {
+      "name": "aha_get_release",
+      "description": "Read one release from Aha.io by reference number (e.g. PRJ1-R-3) or internal id. Returns the full current record - including workflow status, progress, whether it has been released, its release date, parking-lot flag, goals and custom field values - as structuredContent, a one-line summary naming its status, and a link to the release. aha_search returns none of these fields, so use this to see a release's current values, and always read before you write to one."
+    },
+    {
       "name": "aha_move_feature_to_release",
       "description": "Move a feature to a different release in Aha.io. Returns the updated feature and a link to it."
     },
     {
       "name": "aha_search",
-      "description": "Search across Aha.io records - ideas, features, epics, initiatives, goals, key results, requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and \"quoted phrases\". Use '*' to match everything, which is useful with workspaceId to list a workspace's records. Returns each hit's name, type and absolute Aha.io URL, already rendered as markdown links, plus paging counts."
+      "description": "Search across Aha.io records - ideas, features, epics, initiatives, goals, key results, requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and \"quoted phrases\". There is no match-all query: '*' is rejected, because Aha.io returns nothing for it once workspaceId is set. Returns each hit's name, type and absolute Aha.io URL, already rendered as markdown links, plus paging counts - not workflow status, release or custom fields. Read a specific record with aha_get_feature, aha_get_epic, aha_get_idea, aha_get_initiative or aha_get_release when you need its current field values, and always do so before writing to it."
     },
     {
       "name": "aha_update_competitor",

--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -2,10 +2,17 @@
  * Server instructions, returned in the `initialize` response and surfaced by clients as
  * standing context for the whole session - no tool call or prompt needed.
  *
- * Two jobs: say what this server is connected to, and get records linked rather than
- * described. Every byte here costs context in every session, so keep it to things a client
- * cannot work out from the tool list: the identity of the system, which identifier a human
- * recognises, and what to do with `url`.
+ * Three jobs: say what this server is connected to, get records linked rather than
+ * described, and get records read before they are written. Every byte here costs context in
+ * every session, so keep it to things a client cannot work out from the tool list: the
+ * identity of the system, which identifier a human recognises, what to do with `url`, and
+ * that these writes land on shared production data.
+ *
+ * The read-before-write sentence earns its place because the alternative is silent: Aha's
+ * writes replace values rather than merging them, `aha_search` cannot return the fields a
+ * writer is about to overwrite, and a model that never calls `aha_get_*` first will not
+ * notice any of that. It is the one instruction here whose absence corrupts data rather
+ * than merely costing a round trip.
  *
  * Guidance, not enforcement - clients vary in how prominently they surface this. Anything
  * that must hold belongs in the data instead.
@@ -29,6 +36,8 @@ export function buildServerInstructions(subdomain?: string | null): string {
     : 'the account this server is configured against';
 
   return `Aha! (aha.io) is the product management tool used for ${account}, and these tools read and write it directly. Its records are the live, shared source of truth rather than a scratch copy: ideas are incoming customer requests, features and epics are planned work, releases group work by date, and goals and initiatives hold the strategy that work rolls up to.
+
+Read a record before you change it. \`aha_search\` returns only a name, type, id and URL - never workflow status, release membership or custom field values - so read the record itself with \`aha_get_feature\`, \`aha_get_epic\`, \`aha_get_idea\`, \`aha_get_initiative\` or \`aha_get_release\` before writing to it, and report what it currently says if a change looks like it would overwrite someone else's work. Two of these tools replace a whole collection rather than adding to it: \`aha_update_feature_tags\` and \`aha_associate_feature_with_goals\` drop anything left out of the request.
 
 Records carry two identifiers. \`reference_num\` - PROJA-134, IDEASB-I-6375 - is the one people use and the one the Aha UI shows. \`id\` is an internal number nobody recognises. Name a record by its reference number.
 

--- a/src/core/services/aha-errors.ts
+++ b/src/core/services/aha-errors.ts
@@ -7,7 +7,7 @@ import { log } from "../logger.js";
  * The REST paths used to surface axios' own wording - `Request failed with status code 403` -
  * which says nothing about what was refused or why, and is indistinguishable from a bug in
  * this server. The GraphQL client in `aha-graphql.ts` has always mapped its statuses; this is
- * the same courtesy for the 31 tools and 40+ resources that go through `aha-js`.
+ * the same courtesy for the 36 tools and 40+ resources that go through `aha-js`.
  *
  * Deliberately no retrying here. Aha's limits are 300 requests/minute and 20/second and a 429
  * carries `retry_after`, but whether to wait or fail belongs to the caller, so a 429 is

--- a/src/core/services/aha-graphql.ts
+++ b/src/core/services/aha-graphql.ts
@@ -151,15 +151,36 @@ export class AhaGraphQLClient {
    *  - `*` suffix does prefix matching, `AND`/`OR`/`NOT` and "quoted phrases" are honoured
    *  - `projectId` constrains results to one workspace with no cross-workspace leakage
    *  - unrecognised `searchableType` values are not an error, they just match nothing
+   *  - **there is no match-all query.** A bare `*` is not one: on its own it returns an
+   *    arbitrary subset (4116 hits on an account where `APPO11Y*` alone returned 7963),
+   *    and combined with `projectId` it returns **zero**, for every workspace tried. This
+   *    is rejected below rather than passed through, because the empty result reads as an
+   *    empty workspace and gets diagnosed as a broken `projectId` filter - which is what
+   *    happened when the tool description recommended exactly that combination.
+   *  - `projectId` must be a **string**. Passing the same id as a number is not an error;
+   *    it silently matches nothing, so it is coerced below.
    */
   async searchDocuments(params: SearchDocumentsParams): Promise<SearchDocumentsResult> {
     const query = params.query?.trim();
     if (!query) {
-      throw new Error('A search query is required. Use "*" to match everything.');
+      throw new Error(
+        'A search query is required. Aha.io has no match-all query; search for a term, or ' +
+          'use prefix matching such as "a*".'
+      );
+    }
+    if (/^\*+$/.test(query)) {
+      throw new Error(
+        'Aha.io does not support "*" as a match-all query: on its own it returns an ' +
+          'arbitrary subset of records, and scoped to a workspace it returns nothing at ' +
+          'all. Search for a term instead - prefix matching ("a*"), a reference prefix ' +
+          '("PRJ1*"), or several alternatives ("a* OR b* OR c*") - and narrow with ' +
+          'recordTypes. To enumerate a workspace rather than search it, read its records ' +
+          'through the list resources, e.g. aha://features or aha://ideas/{product_id}.'
+      );
     }
 
     const filters: Record<string, unknown> = { query };
-    if (params.projectId) filters.projectId = params.projectId;
+    if (params.projectId) filters.projectId = String(params.projectId);
     if (params.searchableType?.length) filters.searchableType = params.searchableType;
 
     const per = Math.min(Math.max(params.per ?? 20, MIN_PER_PAGE), MAX_PER_PAGE);

--- a/src/core/tool-output.ts
+++ b/src/core/tool-output.ts
@@ -52,7 +52,13 @@ export function unwrapRecord(payload: unknown, key: string): Record<string, unkn
 }
 
 /** Record types with a single-record resource template in resources.ts. */
-type LinkableRecordType = "feature" | "epic" | "idea" | "initiative" | "competitor";
+export type LinkableRecordType =
+  | "feature"
+  | "epic"
+  | "idea"
+  | "initiative"
+  | "competitor"
+  | "release";
 
 function identifier(value: unknown): string | undefined {
   if (typeof value === "string" && value.length > 0) return value;
@@ -170,25 +176,59 @@ const recordIdentity = {
 const progressField = z.number().nullish().describe("Completion percentage, 0-100");
 const scoreField = z.number().nullish().describe("Aha.io score");
 
+/**
+ * Described rather than left to pass through undescribed, because it is the field a caller
+ * most often needs before writing to a record - and a schema that does not mention it reads
+ * as a server that cannot report it. `aha_search` cannot return it (Aha's `searchDocuments`
+ * has no per-type fields), so the `aha_get_*` tools are the only way to see it, and naming
+ * it here is what tells a model that.
+ *
+ * The union is deliberate. Every endpoint measured returns an object, but this file's rule
+ * is that a wrong guess about a type fails the call outright rather than degrading, so a
+ * plain string is admitted too.
+ */
+const workflowStatusField = z
+  .union([
+    z.looseObject({
+      id: z.union([z.string(), z.number()]).optional(),
+      name: z.string().optional(),
+      complete: z.boolean().optional(),
+      color: z.string().optional()
+    }),
+    z.string()
+  ])
+  .nullish()
+  .describe("Current workflow status, e.g. { name: \"In development\", complete: false }");
+
 export const featureOutputSchema = z.looseObject({
   ...recordIdentity,
   progress: progressField,
-  score: scoreField
+  score: scoreField,
+  workflow_status: workflowStatusField
 });
 
 export const epicOutputSchema = z.looseObject({
   ...recordIdentity,
-  progress: progressField
+  progress: progressField,
+  workflow_status: workflowStatusField
 });
 
 export const initiativeOutputSchema = z.looseObject({
   ...recordIdentity,
-  progress: progressField
+  progress: progressField,
+  workflow_status: workflowStatusField
 });
 
 export const ideaOutputSchema = z.looseObject({
   ...recordIdentity,
-  score: scoreField
+  score: scoreField,
+  workflow_status: workflowStatusField
+});
+
+export const releaseOutputSchema = z.looseObject({
+  ...recordIdentity,
+  progress: progressField,
+  workflow_status: workflowStatusField
 });
 
 export const competitorOutputSchema = z.looseObject({

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import * as services from "./services/index.js";
 import { registerSearchTools } from "./tools/search-tools.js";
+import { registerRecordTools } from "./tools/record-tools.js";
 import {
   commentOutputSchema,
   competitorOutputSchema,
@@ -1333,4 +1334,9 @@ export function registerTools(server: McpServer) {
 
   // Search, served by Aha's own index rather than a local copy of the data.
   registerSearchTools(server);
+
+  // Single-record reads. Registered as tools, not only as aha:// resources, because a client
+  // that does not surface resources to its model would otherwise see writers with no way to
+  // read what they are about to overwrite.
+  registerRecordTools(server);
 }

--- a/src/core/tools/record-tools.ts
+++ b/src/core/tools/record-tools.ts
@@ -1,0 +1,222 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import * as services from "../services/index.js";
+import {
+  epicOutputSchema,
+  featureOutputSchema,
+  ideaOutputSchema,
+  initiativeOutputSchema,
+  recordLinks,
+  recordSummary,
+  releaseOutputSchema,
+  unwrapRecord,
+  type LinkableRecordType
+} from "../tool-output.js";
+import { describeAhaError } from "../services/aha-errors.js";
+import { log } from "../logger.js";
+
+/**
+ * Single-record read tools.
+ *
+ * These wrap service methods the `aha://{type}/{id}` resources have always called, and add
+ * nothing of their own. They exist because reads reached only through resources are, for
+ * many hosts, not reachable at all: the MCP resource API is optional for clients to surface
+ * to a model, and connector-style clients commonly expose tools only. On one of those, this
+ * server presented ~25 write tools and a single read (`aha_search`) whose six fields carry
+ * no workflow status, no release membership and no custom field values - so an agent could
+ * change a feature's status but never read the status it was changing. That asymmetry is
+ * worse than a missing feature; it invites blind writes.
+ *
+ * Every type here has both a service getter and a single-record resource template, so the
+ * `resource_link` in each result points somewhere real.
+ */
+
+/**
+ * Aha nests status and the fields most likely to have drifted, and the text block is a
+ * one-line summary rather than the record re-serialised - so the summary names them
+ * explicitly. A client that drops `structuredContent`, or a person skimming a transcript,
+ * still sees the values that decide whether a write is safe.
+ */
+function stateDetail(record: Record<string, unknown>): string | undefined {
+  const parts: string[] = [];
+
+  const status = record.workflow_status;
+  if (typeof status === "string" && status) {
+    parts.push(status);
+  } else if (status && typeof status === "object") {
+    const name = (status as Record<string, unknown>).name;
+    if (typeof name === "string" && name) parts.push(name);
+  }
+
+  const releaseRef =
+    record.release_reference_num ??
+    (record.release && typeof record.release === "object"
+      ? (record.release as Record<string, unknown>).reference_num
+      : undefined);
+  if (typeof releaseRef === "string" && releaseRef) parts.push(`release ${releaseRef}`);
+
+  const assignee = record.assigned_to_user;
+  if (assignee && typeof assignee === "object") {
+    const name = (assignee as Record<string, unknown>).name;
+    if (typeof name === "string" && name) parts.push(`assigned to ${name}`);
+  }
+
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+interface ReaderConfig {
+  /** Tool name, e.g. `aha_get_feature`. */
+  tool: string;
+  /** Display title, used for both `title` and `annotations.title`. */
+  title: string;
+  /** Lower-case record type as it reads in prose, e.g. "feature". */
+  noun: string;
+  /** Resource type for the `aha://` link; also the type the record is unwrapped as. */
+  recordType: LinkableRecordType;
+  /** Input parameter name, matching the writing tools' convention (`featureId`, ...). */
+  idParam: string;
+  /** Example reference number for this type, e.g. `PRJ1-123`. */
+  example: string;
+  /** The fields worth naming in the description, beyond the common ones. */
+  fields: string;
+  /** The wrapper key Aha may nest the record under; see `unwrapRecord`. */
+  unwrapKey: string;
+  outputSchema: z.ZodObject<z.ZodRawShape>;
+  fetch: (id: string) => Promise<unknown>;
+}
+
+const READERS: ReaderConfig[] = [
+  {
+    tool: "aha_get_feature",
+    title: "Get feature",
+    noun: "feature",
+    recordType: "feature",
+    idParam: "featureId",
+    example: "PRJ1-123",
+    fields: "workflow status, release, epic, initiative, assignee, tags, score, progress and custom field values",
+    unwrapKey: "feature",
+    outputSchema: featureOutputSchema,
+    fetch: id => services.AhaService.getFeature(id)
+  },
+  {
+    tool: "aha_get_epic",
+    title: "Get epic",
+    noun: "epic",
+    recordType: "epic",
+    idParam: "epicId",
+    example: "PRJ1-E-4",
+    fields: "workflow status, release, initiative, assignee, progress and custom field values",
+    unwrapKey: "epic",
+    outputSchema: epicOutputSchema,
+    fetch: id => services.AhaService.getEpic(id)
+  },
+  {
+    tool: "aha_get_idea",
+    title: "Get idea",
+    noun: "idea",
+    recordType: "idea",
+    idParam: "ideaId",
+    example: "PRJ1-I-7",
+    fields: "workflow status, score, endorsement and vote counts, categories and custom field values",
+    unwrapKey: "idea",
+    outputSchema: ideaOutputSchema,
+    fetch: id => services.AhaService.getIdea(id)
+  },
+  {
+    tool: "aha_get_initiative",
+    title: "Get initiative",
+    noun: "initiative",
+    recordType: "initiative",
+    idParam: "initiativeId",
+    example: "PRJ1-S-2",
+    fields: "workflow status, progress, timeframe, goals and custom field values",
+    unwrapKey: "initiative",
+    outputSchema: initiativeOutputSchema,
+    fetch: id => services.AhaService.getInitiative(id)
+  },
+  {
+    tool: "aha_get_release",
+    title: "Get release",
+    noun: "release",
+    recordType: "release",
+    idParam: "releaseId",
+    example: "PRJ1-R-3",
+    fields:
+      "workflow status, progress, whether it has been released, its release date, parking-lot flag, goals and custom field values",
+    unwrapKey: "release",
+    outputSchema: releaseOutputSchema,
+    fetch: id => services.AhaService.getRelease(id)
+  }
+];
+
+function register(server: McpServer, config: ReaderConfig) {
+  server.registerTool(
+    config.tool,
+    {
+      title: config.title,
+      description:
+        `Read one ${config.noun} from Aha.io by reference number (e.g. ${config.example}) or ` +
+        `internal id. Returns the full current record - including ${config.fields} - as ` +
+        `structuredContent, a one-line summary naming its status, and a link to the ` +
+        `${config.noun}. aha_search returns none of these fields, so use this to see a ` +
+        `${config.noun}'s current values, and always read before you write to one.`,
+      inputSchema: {
+        [config.idParam]: z
+          .string()
+          .min(1)
+          .describe(
+            `Reference number (e.g. ${config.example}) or internal id of the ${config.noun}. ` +
+              `Both work; an aha_search hit's id is the internal one, and its url ends in the ` +
+              `reference number.`
+          )
+      },
+      outputSchema: config.outputSchema,
+      annotations: {
+        title: config.title,
+        readOnlyHint: true,
+        // destructiveHint and idempotentHint are omitted deliberately: the spec only gives
+        // them meaning for tools that write.
+        openWorldHint: true
+      }
+    },
+    async (params: { [key: string]: string }) => {
+      const id = params[config.idParam];
+      try {
+        const response = await config.fetch(id);
+        const record = unwrapRecord(response, config.unwrapKey);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: recordSummary(`Read ${config.noun}`, record, {
+                fallbackId: id,
+                detail: stateDetail(record)
+              })
+            },
+            ...recordLinks(config.recordType, record, id)
+          ],
+          structuredContent: record
+        };
+      } catch (error) {
+        log.error(`Failed to read ${config.noun} ${id}`, error as Error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              // The id goes in as the subject so a 403 or 404 names the record that could
+              // not be read, rather than "the requested record".
+              text: `Error retrieving ${config.noun}: ${describeAhaError(error, id)}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}
+
+/** Register the single-record read tools. */
+export function registerRecordTools(server: McpServer) {
+  for (const config of READERS) register(server, config);
+}

--- a/src/core/tools/search-tools.ts
+++ b/src/core/tools/search-tools.ts
@@ -61,16 +61,21 @@ export function registerSearchTools(server: McpServer, client: AhaGraphQLClient 
       description: "Search across Aha.io records - ideas, features, epics, initiatives, goals, key results, " +
           "requirements, releases, tasks, pages, comments and more. Queries Aha.io directly, so " +
           "results are always current. Supports 'term*' for prefix matching, AND/OR/NOT, and " +
-          "\"quoted phrases\". Use '*' to match everything, which is useful with workspaceId to " +
-          "list a workspace's records. Returns each hit's name, type and absolute Aha.io URL, " +
-          "already rendered as markdown links, plus paging counts.",
+          "\"quoted phrases\". There is no match-all query: '*' is rejected, because Aha.io " +
+          "returns nothing for it once workspaceId is set. Returns each hit's name, type and " +
+          "absolute Aha.io URL, already rendered as markdown links, plus paging counts - not " +
+          "workflow status, release or custom fields. Read a specific record with " +
+          "aha_get_feature, aha_get_epic, aha_get_idea, aha_get_initiative or aha_get_release " +
+          "when you need its current field values, and always do so before writing to it.",
       inputSchema: {
         query: z
           .string()
           .min(1)
           .describe(
             "Search term. Matches record names and descriptions, and comment bodies. " +
-              "Supports 'term*' prefix matching, AND/OR/NOT, and \"quoted phrases\". Use '*' to match all."
+              "Supports 'term*' prefix matching, AND/OR/NOT, and \"quoted phrases\". A bare '*' " +
+              "is not a match-all and is rejected; to sweep broadly, use alternatives such as " +
+              "'a* OR b* OR c*'."
           ),
         workspaceId: z
           .string()

--- a/test/aha-graphql.test.ts
+++ b/test/aha-graphql.test.ts
@@ -140,9 +140,58 @@ describe('AhaGraphQLClient', () => {
       expect(calls[0].body.variables.filters).not.toHaveProperty('searchableType');
     });
 
-    it('rejects a blank query, pointing at the wildcard', async () => {
+    it('coerces a workspace id to a string, which a number silently is not', async () => {
+      // Aha accepts a numeric projectId without complaint and matches nothing at all, so a
+      // caller passing the id as a number would get an empty result with no hint why. Real
+      // workspace ids (7387506590217164236) also exceed 2^53, so a number cannot even hold
+      // one exactly - which is why the API surface types this as a string throughout.
+      const { client, calls } = stub(page());
+      await client.searchDocuments({ query: 'alert', projectId: 12345 as any });
+
+      expect(calls[0].body.variables.filters.projectId).toBe('12345');
+    });
+
+    it('rejects a blank query, without promising a match-all', async () => {
       const { client } = stub(page());
-      await expect(client.searchDocuments({ query: '   ' })).rejects.toThrow(/\*/);
+      await expect(client.searchDocuments({ query: '   ' })).rejects.toThrow(/no match-all/);
+    });
+
+    /**
+     * `*` was documented by this server as a match-all and is not one: alone it returns an
+     * arbitrary subset, and with `projectId` set it returns zero for every workspace tried.
+     * The empty result is the damaging part - it reads as an empty workspace, and gets
+     * diagnosed as a broken workspace filter - so it is refused before the request goes out.
+     */
+    it('refuses a wildcard-only query rather than returning nothing', async () => {
+      const { client, calls } = stub(page());
+
+      for (const query of ['*', '**', ' * ']) {
+        await expect(client.searchDocuments({ query })).rejects.toThrow(
+          /does not support "\*" as a match-all/
+        );
+      }
+
+      expect(calls).toHaveLength(0);
+    });
+
+    it('says what to do instead when it refuses a wildcard', async () => {
+      const { client } = stub(page());
+      const error = await client.searchDocuments({ query: '*' }).catch((e: Error) => e);
+
+      // A refusal that does not name a working alternative just moves the dead end.
+      expect(error.message).toMatch(/a\*/);
+      expect(error.message).toMatch(/recordTypes/);
+      expect(error.message).toMatch(/aha:\/\//);
+    });
+
+    it('still allows a wildcard inside a real term', async () => {
+      const { client, calls } = stub(page());
+      await client.searchDocuments({ query: 'APPO11Y*', projectId: 'ws-1' });
+
+      expect(calls[0].body.variables.filters).toEqual({
+        query: 'APPO11Y*',
+        projectId: 'ws-1'
+      });
     });
   });
 

--- a/test/instructions.test.ts
+++ b/test/instructions.test.ts
@@ -25,4 +25,19 @@ describe('buildServerInstructions', () => {
     // `resource` is the API endpoint; offering it as a link sends the user to JSON.
     expect(instructions).toMatch(/never offer it as the link/i);
   });
+
+  /**
+   * A client that surfaces tools but not resources sees writers it cannot verify against,
+   * because search returns none of the fields a write replaces. This is the only always-on
+   * channel the server has to say so, so it names the read tools by name.
+   */
+  it('tells the session to read a record before writing to it', () => {
+    const instructions = buildServerInstructions('acme');
+
+    expect(instructions).toMatch(/read a record before you change it/i);
+    expect(instructions).toContain('aha_get_feature');
+    // The two PUTs that replace a collection rather than adding to it.
+    expect(instructions).toContain('aha_update_feature_tags');
+    expect(instructions).toContain('aha_associate_feature_with_goals');
+  });
 });

--- a/test/record-read-tools.test.ts
+++ b/test/record-read-tools.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerRecordTools } from '../src/core/tools/record-tools.js';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * The single-record read tools.
+ *
+ * These exist because reads offered only as `aha://` resources are unreachable on a host
+ * that does not surface resources to its model - which left this server presenting write
+ * tools alongside one search that returns six fields, none of them workflow status, release
+ * membership or custom field values. The assertions below are mostly about that: the fields
+ * a caller needs before writing have to arrive, both in `structuredContent` and in the text
+ * block, since a client may show only one of them.
+ *
+ * Calls go through a real MCP client, because the client is what validates
+ * `structuredContent` against the advertised `outputSchema` - so a call that returns at all
+ * is itself the conformance assertion.
+ */
+async function connected() {
+  const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+  registerRecordTools(server);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+/**
+ * A feature as Aha actually returns one, trimmed. `custom_fields` and `assigned_to_user` are
+ * undescribed by the output schema and must survive anyway - they are the reason these tools
+ * exist, and a closed schema would reject them at call time.
+ */
+const FEATURE = {
+  id: '6971110726488350000',
+  reference_num: 'APPO11Y-16',
+  name: 'Per-service blocking',
+  url: 'https://test.aha.io/features/APPO11Y-16',
+  created_at: '2026-08-01T10:00:00.000Z',
+  updated_at: '2026-08-02T10:00:00.000Z',
+  progress: 40,
+  score: 80,
+  workflow_status: { id: '7386770842053906242', name: 'Backlog', complete: false },
+  release_reference_num: 'APPO11Y-R-3',
+  assigned_to_user: { id: '1', name: 'Ada Lovelace' },
+  custom_fields: [
+    { name: 'Launch Tier', value: 'Tier 3' },
+    { name: 'VoC Prioritization Score', value: 80 }
+  ]
+};
+
+describe('Single-record read tools', () => {
+  const patched: string[] = [];
+
+  const patch = (method: keyof typeof AhaService, impl: (...args: any[]) => Promise<any>) => {
+    patched.push(method as string);
+    (AhaService as any)[`__original_${method}`] = (AhaService as any)[method];
+    (AhaService as any)[method] = impl;
+  };
+
+  afterEach(() => {
+    for (const method of patched) {
+      (AhaService as any)[method] = (AhaService as any)[`__original_${method}`];
+      delete (AhaService as any)[`__original_${method}`];
+    }
+    patched.length = 0;
+  });
+
+  it('registers a reader for every type that has a single-record resource', async () => {
+    const client = await connected();
+    const names = (await client.listTools()).tools.map(t => t.name).sort();
+
+    expect(names).toEqual([
+      'aha_get_epic',
+      'aha_get_feature',
+      'aha_get_idea',
+      'aha_get_initiative',
+      'aha_get_release'
+    ]);
+  });
+
+  it('returns the whole record, including fields the schema does not describe', async () => {
+    patch('getFeature', async () => FEATURE);
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_feature',
+      arguments: { featureId: 'APPO11Y-16' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual(FEATURE);
+    // The three fields aha_search cannot return, which is the whole point of the tool.
+    expect(result.structuredContent.workflow_status.name).toBe('Backlog');
+    expect(result.structuredContent.release_reference_num).toBe('APPO11Y-R-3');
+    expect(result.structuredContent.custom_fields).toContainEqual({
+      name: 'Launch Tier',
+      value: 'Tier 3'
+    });
+  });
+
+  it('names status, release and assignee in the text block', async () => {
+    patch('getFeature', async () => FEATURE);
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_feature',
+      arguments: { featureId: 'APPO11Y-16' }
+    });
+
+    // A client that drops structuredContent still has to see the values that decide whether
+    // a write is safe, so the summary carries them rather than only the record's name.
+    expect(result.content[0].text).toBe(
+      'Read feature APPO11Y-16 "Per-service blocking" ' +
+        '(Backlog, release APPO11Y-R-3, assigned to Ada Lovelace) - ' +
+        'https://test.aha.io/features/APPO11Y-16'
+    );
+  });
+
+  it('summarises a record with no status, release or assignee without empty parentheses', async () => {
+    patch('getEpic', async () => ({ reference_num: 'PRJ1-E-4', name: 'Bare epic' }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_epic',
+      arguments: { epicId: 'PRJ1-E-4' }
+    });
+
+    expect(result.content[0].text).toBe('Read epic PRJ1-E-4 "Bare epic"');
+  });
+
+  it('reads a status Aha hands back as a bare string', async () => {
+    // The output schema admits a string as well as an object; the summary has to too.
+    patch('getIdea', async () => ({ idea: { reference_num: 'PRJ1-I-7', name: 'Idea', workflow_status: 'New' } }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_idea',
+      arguments: { ideaId: 'PRJ1-I-7' }
+    });
+
+    expect(result.content[0].text).toBe('Read idea PRJ1-I-7 "Idea" (New)');
+  });
+
+  it('unwraps the records Aha nests under a single key', async () => {
+    patch('getIdea', async () => ({ idea: { reference_num: 'PRJ1-I-7', name: 'Wrapped idea' } }));
+    patch('getInitiative', async () => ({
+      initiative: { reference_num: 'PRJ1-S-2', name: 'Wrapped initiative' }
+    }));
+    patch('getRelease', async () => ({
+      release: { reference_num: 'PRJ1-R-3', name: 'Wrapped release', progress: 0 }
+    }));
+    const client = await connected();
+
+    for (const [tool, arg, id, name] of [
+      ['aha_get_idea', 'ideaId', 'PRJ1-I-7', 'Wrapped idea'],
+      ['aha_get_initiative', 'initiativeId', 'PRJ1-S-2', 'Wrapped initiative'],
+      ['aha_get_release', 'releaseId', 'PRJ1-R-3', 'Wrapped release']
+    ] as const) {
+      const result: any = await client.callTool({ name: tool, arguments: { [arg]: id } });
+
+      expect(result.structuredContent.reference_num).toBe(id);
+      expect(result.structuredContent).not.toHaveProperty('idea');
+      expect(result.content[0].text).toContain(`"${name}"`);
+    }
+  });
+
+  it('links each record to a resource URI a client can actually read', async () => {
+    patch('getRelease', async () => ({
+      release: {
+        reference_num: 'PRJ1-R-3',
+        name: 'Parked',
+        updated_at: '2026-08-02T10:00:00.000Z'
+      }
+    }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_release',
+      arguments: { releaseId: 'PRJ1-R-3' }
+    });
+
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    // aha://release/{id} is a registered resource template; a link to an unreadable URI
+    // would be worse than none.
+    expect(link.uri).toBe('aha://release/PRJ1-R-3');
+    expect(link.title).toBe('PRJ1-R-3 - Parked');
+    expect(link.annotations.lastModified).toBe('2026-08-02T10:00:00.000Z');
+  });
+
+  it('falls back to the requested id when Aha returns no identifier', async () => {
+    patch('getFeature', async () => ({}));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_feature',
+      arguments: { featureId: 'APPO11Y-16' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({});
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    expect(link.uri).toBe('aha://feature/APPO11Y-16');
+  });
+
+  it('annotates the readers as read-only, leaving the writer-only hints unset', async () => {
+    const client = await connected();
+    const tools = (await client.listTools()).tools;
+
+    for (const tool of tools) {
+      expect(tool.annotations!.readOnlyHint).toBe(true);
+      expect(tool.annotations!.openWorldHint).toBe(true);
+      // The spec only gives these meaning for tools that write.
+      expect(tool.annotations!.destructiveHint).toBeUndefined();
+      expect(tool.annotations!.idempotentHint).toBeUndefined();
+      // Hosts read one or the other depending on their spec version.
+      expect(tool.title).toBe(tool.annotations!.title as string);
+      expect(tool.outputSchema).toBeDefined();
+    }
+  });
+
+  it('reports a failure as isError, without claiming the record does not exist', async () => {
+    patch('getFeature', async () => {
+      // Shaped like the axios error aha-js throws: describeAhaError reads the status off
+      // response, not out of the message, so a bare Error would not exercise the mapping.
+      throw Object.assign(new Error('Request failed with status code 404'), {
+        isAxiosError: true,
+        response: { status: 404, headers: {} }
+      });
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_get_feature',
+      arguments: { featureId: 'APPO11Y-16' }
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    // Aha returns 404 for a record the token cannot see as well as one that is absent, so
+    // the message must not resolve that ambiguity for the caller.
+    expect(result.content[0].text).toContain('404');
+    expect(result.content[0].text).toContain('cannot see');
+    // And it names which record failed, not just that one did.
+    expect(result.content[0].text).toContain('APPO11Y-16');
+  });
+});


### PR DESCRIPTION
Two defects, found when an agent tried to compute status and Launch Tier drift for a workspace through this server and reported that neither was computable.

## 1. `*` was documented as a match-all and is not one

`aha_search`'s description said: *"Use '\*' to match everything, which is useful with workspaceId to list a workspace's records."* Measured against a live account:

| filter | total |
|---|---|
| `query: 'APPO11Y*'` + workspace `7387506590217164236` | 22 |
| `query: 'a*'` + same workspace | 76 |
| `query: 'the'` + same workspace | 125 |
| `query: '*'` + same workspace | **0** |
| `query: '*'` alone | 4116 (vs 7963 for `APPO11Y*` alone) |

So `*` is not a match-all, and with `workspaceId` set it returns nothing at all — for every workspace tried. The description walked callers into the one combination that always returns zero, and an empty result reads as an empty workspace: that is what got diagnosed as a broken `workspaceId` filter. **The filter works** — `projectId` plus a real term returns correctly scoped hits.

`searchDocuments` now refuses a wildcard-only query instead of passing it on, naming forms that do work rather than moving the dead end one step along. The same false claim is removed from the tool description, the input description, the blank-query error and the README example.

Also fixed while testing: `projectId` is coerced with `String()`. A numeric id is not an error — it silently matches nothing — and real workspace ids exceed 2^53, so a JS number cannot hold one exactly anyway.

## 2. Reads were unreachable on clients that don't surface resources

Every single-record read was reachable only as an `aha://` resource, and the MCP spec leaves it to each client whether to expose resources to its model. On a client that does not, this server was ~25 write tools plus one search returning six fields — none of them workflow status, release membership or custom field values — so an agent could set a feature's status but never read the status it was replacing.

Search cannot close that gap. `searchDocuments` returns a concrete `SearchDocument` rather than a union, so `... on Feature { workflowStatus }` is rejected outright (*"Fragment on Feature can't be spread inside SearchDocument"*) and no per-type field can be selected.

`aha_get_feature`, `aha_get_epic`, `aha_get_idea`, `aha_get_initiative` and `aha_get_release` wrap the same service getters the resources already call, for the five types that have write tools. The resource templates stay as the richer read surface — the duplication is the point, and `CLAUDE.md` says so, along with the rule that a new type's writer needs its reader.

- Each reader's text block names status, release and assignee rather than only the record's name, so a client that drops `structuredContent` still shows what a write would overwrite.
- `workflow_status` is now described in the output schemas — as an object *or* a bare string, since a wrong type guess fails the call rather than degrading — so a model can tell from the contract that status is available.
- Server instructions gained a read-before-write sentence. It earns space in the one always-on channel because the alternative is silent: Aha's writes replace values rather than merging them, search cannot show what is about to be replaced, and a model that never calls `aha_get_*` will not notice either. It also names `aha_update_feature_tags` and `aha_associate_feature_with_goals`, which drop anything left out of the request.

## Verification

Against a live account, not only the mock:

```
Read feature APPO11Y-16 "Fine-grained RBAC for application o11y"
  (Backlog, release APPO11Y-R-3, assigned to Cedric Ziel) - https://.../features/APPO11Y-16
status: Backlog | release: APPO11Y-R-3 | Launch Tier: Tier 3
```

Those are the three fields reported as uncomputable. All five readers return a record and a resolvable resource link; `aha_search` with `"*"` returns the refusal; a scoped search returns hits.

- **437 tests pass, 0 fail** (15 new, in `test/record-read-tools.test.ts` plus the graphql and instructions suites)
- `manifest.json` regenerated via `bun run manifest:sync` — 36 tools; `mcpb validate` passes
- `node build/index.js --help` starts clean, no native dependencies added

## Note for reviewers, not part of this change

A local `node_modules` still on `@cedricziel/aha-js` 1.2.5 — predating the 2.0.0 migration in a076e74 — produces 68 `tsc` errors and a runtime `featuresApi.featuresByIdGet is not a function` on the first REST call. After `bun install` per the lockfile, one deliberate pre-existing error remains (the `sse` comparison at `src/core/config.ts:195`). Worth checking whatever hosts the connector is running from, since a stale tree there breaks every REST tool rather than just reads.

## BREAKING CHANGE

`aha_search` rejects a wildcard-only query. A call passing `query: "*"` previously returned an arbitrary subset of records, or nothing at all when `workspaceId` was set; it now comes back as an `isError` result naming the query forms that work. Callers relying on `"*"` must pass a real term, or enumerate a workspace through the list resources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added single-record read tools for epics, features, ideas, initiatives, and releases.
  * Added release details and workflow status information to record results.
  * Added guidance to read records before making changes.

* **Bug Fixes**
  * Improved search validation for empty and wildcard-only queries.
  * Corrected handling of numeric project IDs in searches.
  * Added clearer error reporting for missing records.

* **Documentation**
  * Updated search guidance, tool counts, and read-access documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->