### PR TITLE
feat: read and write comments on every record type, including the ideas portal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,40 @@ A previous local-cache implementation (SQLite plus a placeholder embedding that 
 character codes through `Math.sin()`) was removed in favour of this. Do not reintroduce
 client-side "semantic" ranking without a real embedding model.
 
+### Comments
+
+Comments live in `src/core/tools/comment-tools.ts` (`aha_list_comments`, `aha_create_comment`,
+`aha_create_idea_portal_comment`) plus the `aha://comments/{type}/{id}` resources. Three
+things here are not guessable from Aha's docs:
+
+- **An idea has two comment streams, and they are disjoint.** `/ideas/{id}/comments` holds
+  internal comments; `/ideas/{id}/idea_comments` holds the ideas-portal conversation, served
+  by a different SDK class (`IdeaCommentsApi`). Measured on a live idea: one internal comment,
+  two portal comments, **no overlapping ids**. The portal side is where a customer's own words
+  are - on the idea probed, a portal user asking why their idea was rejected, and the reply.
+  Reading only `/comments` therefore looks complete while dropping the half that matters for
+  triage. `aha_list_comments` reads both for ideas and stamps each comment with `source`;
+  `aha://comments/idea/{id}` and `aha://idea-comments/{id}` stay separate URIs so neither
+  changes meaning. Do not merge them into one resource.
+- **`visibility` reads and writes in different vocabularies.** A response carries a phrase
+  ("Visible to all ideas portal users"); a create request takes `public` or
+  `employee_or_creator`. One cannot be fed back as the other, so nothing maps between them.
+- **`visibility` is a required argument on `aha_create_idea_portal_comment`.** Aha defaults it
+  to `public`, which means a caller that omits the field publishes to customers by accident.
+  Keep it required, and keep the portal write a separate tool from `aha_create_comment` so a
+  host can gate the customer-facing one on its own.
+
+Two smaller notes. `POST /ideas/{id}/comments` is documented as creating an *internal*
+comment, so `aha_create_comment` on an idea cannot reach the portal - that is why the tool
+says "internal" in its own output. And Aha's spec has GET but no POST for a workspace's
+comments, so `product` is readable but not writable; the `TARGETS` table in `comment-tools.ts`
+encodes that by having no `write` for it, rather than failing at call time.
+
+The SDK's `IdeacommentsPostRequest` model captured only `spam`, because aha-js 2.0.0 is
+generated from recorded test responses. `createIdeaPortalComment` casts the documented
+`{ idea_comment: { body, visibility } }` body onto it; if a regenerated SDK types that
+properly, drop the cast.
+
 ### Error handling
 
 Aha's REST failures are mapped by `src/core/services/aha-errors.ts` rather than surfaced
@@ -186,8 +220,8 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
   does not cover. Reads credentials via `AhaService.getCredentials()` so `configure_server`
   applies at runtime
 - **ConfigService**: Manages runtime configuration with file persistence and validation
-- **Tools**: 36 MCP tools (CRUD, single-record reads, search, health checks, configuration),
-  none of which keep local state
+- **Tools**: 39 MCP tools (CRUD, single-record reads, comments, search, health checks,
+  configuration), none of which keep local state
 - **Resources**: 40+ resource types for accessing Aha.io entities via URI schemes
 - **Read tools vs read resources**: `src/core/tools/record-tools.ts` registers `aha_get_*`
   for feature, epic, idea, initiative and release, wrapping the same service getters the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download `aha-mcp-v<version>.mcpb` from the [latest release](https://github.com/
 and open it with Claude Desktop, which will prompt you for your Aha.io subdomain and API
 token. No Node.js or Docker setup and no manual JSON editing required.
 
-The extension exposes 31 tools that query Aha.io directly, so results are always current and
+The extension exposes 39 tools that query Aha.io directly, so results are always current and
 nothing is stored locally. Cross-record search is served by Aha.io's own index — see
 [Search](#-search).
 
@@ -349,8 +349,10 @@ aha_embedding_status --jobId embed-xyz789
 - `aha_initiative_epics`: List epics for an initiative using `aha://initiative/{initiative_id}/epics`
 
 #### Comment Resources
+- `aha_feature_comments`: Access comments for a feature using `aha://comments/feature/{feature_id}`
 - `aha_epic_comments`: Access comments for an epic using `aha://comments/epic/{epic_id}`
-- `aha_idea_comments`: Access comments for an idea using `aha://comments/idea/{idea_id}`
+- `aha_idea_comments`: Access an idea's **internal** comments using `aha://comments/idea/{idea_id}`
+- `aha_idea_portal_comments`: Access an idea's **ideas-portal** comments using `aha://idea-comments/{idea_id}` — different records from the above, including anything a customer wrote
 - `aha_initiative_comments`: Access comments for an initiative using `aha://comments/initiative/{initiative_id}`
 - `aha_product_comments`: Access comments for a product using `aha://comments/product/{product_id}`
 - `aha_goal_comments`: Access comments for a goal using `aha://comments/goal/{goal_id}`
@@ -402,8 +404,10 @@ aha://releases/PROJ-001?query=mobile&status=shipped # List releases for product
 aha://initiative/INIT-123/epics   # List epics for initiative
 
 # Comment Resources
+aha://comments/feature/PRJ1-123   # Get comments for feature
 aha://comments/epic/EPIC-123      # Get comments for epic
-aha://comments/idea/IDEA-456      # Get comments for idea
+aha://comments/idea/IDEA-456      # Get an idea's internal comments
+aha://idea-comments/IDEA-456      # Get an idea's ideas-portal comments
 aha://comments/initiative/INIT-789 # Get comments for initiative
 aha://comments/product/PROD-001   # Get comments for product
 aha://comments/goal/GOAL-555      # Get comments for goal
@@ -538,14 +542,15 @@ The MCP server now provides comprehensive lifecycle management for Aha.io entiti
 - **Comprehensive Entity Coverage**: Full CRUD operations for features, epics, ideas, and competitors
 
 #### Technical Achievements
-- **36 MCP tools**, all querying Aha.io directly — no local state
-- **15 listed MCP resources** covering the entity set, plus templated resource URIs
+- **39 MCP tools**, all querying Aha.io directly — no local state
+- **17 listed MCP resources** covering the entity set, plus templated resource URIs
 - **17 domain-specific prompts** (workflow automation)
 - **25 core CRUD and write operation tools** for complete lifecycle management
 - **Cross-record search** over Aha's own index, covering 20 record types
 - **5 single-record read tools**, so a write can be checked against the record's current state on clients that do not surface resources
+- **Comment reads and writes** on every record type Aha supports, with an idea's ideas-portal conversation handled as its own stream
 - **5 server configuration tools** for runtime configuration
-- **437 tests passing** with comprehensive service coverage
+- **457 tests passing** with comprehensive service coverage
 - **No native dependencies**, so the server runs anywhere Node does
 - **Comprehensive error handling** with proper Zod schema validation
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "Aha.io MCP Server",
   "version": "4.0.0",
   "description": "Model Context Protocol server for Aha.io product management platform",
-  "long_description": "A comprehensive MCP server that provides seamless integration with Aha.io's API. This extension enables AI assistants to search and manage Aha.io records - ideas, features, epics, initiatives, goals, requirements, releases and competitors - with 36 tools, 15 resources and 17 guided prompts.\n\nSearch is served by Aha.io's own index via aha_search, so results are always current and nothing is cached locally. Search returns names, types and links; aha_get_feature and its siblings return a full record - workflow status, release, assignee and custom field values - so a change can be checked against what the record says now. Every tool queries Aha.io directly; the extension stores no data and needs no native dependencies.",
+  "long_description": "A comprehensive MCP server that provides seamless integration with Aha.io's API. This extension enables AI assistants to search and manage Aha.io records - ideas, features, epics, initiatives, goals, requirements, releases and competitors - with 39 tools, 17 resources and 17 guided prompts.\n\nSearch is served by Aha.io's own index via aha_search, so results are always current and nothing is cached locally. Search returns names, types and links; aha_get_feature and its siblings return a full record - workflow status, release, assignee and custom field values - so a change can be checked against what the record says now. Comments are readable and writable on every record type that supports them, and an idea's ideas-portal conversation is handled as its own stream - so a customer's own words are visible, and a reply can be aimed at portal users or kept to employees. Every tool queries Aha.io directly; the extension stores no data and needs no native dependencies.",
   "author": {
     "name": "Cedric Ziel",
     "email": "mail@cedric-ziel.com",
@@ -59,6 +59,10 @@
       "description": "Associate a feature with multiple goals in Aha.io. Replaces the feature's whole goal set, so goals left out are unlinked. Returns the updated feature and a link to it."
     },
     {
+      "name": "aha_create_comment",
+      "description": "Add a comment to an Aha.io record - feature, idea, epic, initiative, goal, release, release phase, requirement or todo. The comment is internal: visible to Aha.io users and never shown in an ideas portal, including on an idea. To reply to a customer in the ideas portal, use aha_create_idea_portal_comment instead. Returns the created comment and a link to the record it was added to."
+    },
+    {
       "name": "aha_create_competitor",
       "description": "Create a competitor in a product in Aha.io. Returns the created competitor and a link to it."
     },
@@ -76,7 +80,7 @@
     },
     {
       "name": "aha_create_feature_comment",
-      "description": "Create a comment on a feature in Aha.io. Returns the created comment."
+      "description": "Create a comment on a feature in Aha.io. Returns the created comment. aha_create_comment does the same for features and every other record type, and aha_list_comments reads them back - prefer those unless you specifically want this one."
     },
     {
       "name": "aha_create_idea",
@@ -85,6 +89,10 @@
     {
       "name": "aha_create_idea_by_portal_user",
       "description": "Create an idea in a product in Aha.io, attributed to an ideas-portal user rather than to the API token's owner. Returns the created idea and a link to it."
+    },
+    {
+      "name": "aha_create_idea_portal_comment",
+      "description": "Comment on an idea in a way that can be seen outside Aha.io, in the ideas portal - this is how you reply to a customer who submitted or commented on an idea. visibility is required and decides the audience: 'public' shows the comment to every portal user, 'employee_or_creator' restricts it to employees and the idea's creator. Aha.io itself defaults to 'public', so nothing here is optional by design. For a note that must stay inside Aha.io, use aha_create_comment. Returns the created comment and a link to the idea."
     },
     {
       "name": "aha_create_idea_with_category",
@@ -120,23 +128,27 @@
     },
     {
       "name": "aha_get_epic",
-      "description": "Read one epic from Aha.io by reference number (e.g. PRJ1-E-4) or internal id. Returns the full current record - including workflow status, release, initiative, assignee, progress and custom field values - as structuredContent, a one-line summary naming its status, and a link to the epic. aha_search returns none of these fields, so use this to see a epic's current values, and always read before you write to one."
+      "description": "Read one epic from Aha.io by reference number (e.g. PRJ1-E-4) or internal id. Returns the full current record - including workflow status, release, initiative, assignee, progress and custom field values - as structuredContent, a one-line summary naming its status, and a link to the epic. aha_search returns none of these fields, so use this to see an epic's current values, and always read before you write to one. aha_list_comments reads its comment thread."
     },
     {
       "name": "aha_get_feature",
-      "description": "Read one feature from Aha.io by reference number (e.g. PRJ1-123) or internal id. Returns the full current record - including workflow status, release, epic, initiative, assignee, tags, score, progress and custom field values - as structuredContent, a one-line summary naming its status, and a link to the feature. aha_search returns none of these fields, so use this to see a feature's current values, and always read before you write to one."
+      "description": "Read one feature from Aha.io by reference number (e.g. PRJ1-123) or internal id. Returns the full current record - including workflow status, release, epic, initiative, assignee, tags, score, progress and custom field values - as structuredContent, a one-line summary naming its status, and a link to the feature. aha_search returns none of these fields, so use this to see a feature's current values, and always read before you write to one. aha_list_comments reads its comment thread."
     },
     {
       "name": "aha_get_idea",
-      "description": "Read one idea from Aha.io by reference number (e.g. PRJ1-I-7) or internal id. Returns the full current record - including workflow status, score, endorsement and vote counts, categories and custom field values - as structuredContent, a one-line summary naming its status, and a link to the idea. aha_search returns none of these fields, so use this to see a idea's current values, and always read before you write to one."
+      "description": "Read one idea from Aha.io by reference number (e.g. PRJ1-I-7) or internal id. Returns the full current record - including workflow status, score, endorsement and vote counts, categories and custom field values - as structuredContent, a one-line summary naming its status, and a link to the idea. aha_search returns none of these fields, so use this to see an idea's current values, and always read before you write to one. aha_list_comments reads its comment thread."
     },
     {
       "name": "aha_get_initiative",
-      "description": "Read one initiative from Aha.io by reference number (e.g. PRJ1-S-2) or internal id. Returns the full current record - including workflow status, progress, timeframe, goals and custom field values - as structuredContent, a one-line summary naming its status, and a link to the initiative. aha_search returns none of these fields, so use this to see a initiative's current values, and always read before you write to one."
+      "description": "Read one initiative from Aha.io by reference number (e.g. PRJ1-S-2) or internal id. Returns the full current record - including workflow status, progress, timeframe, goals and custom field values - as structuredContent, a one-line summary naming its status, and a link to the initiative. aha_search returns none of these fields, so use this to see an initiative's current values, and always read before you write to one. aha_list_comments reads its comment thread."
     },
     {
       "name": "aha_get_release",
-      "description": "Read one release from Aha.io by reference number (e.g. PRJ1-R-3) or internal id. Returns the full current record - including workflow status, progress, whether it has been released, its release date, parking-lot flag, goals and custom field values - as structuredContent, a one-line summary naming its status, and a link to the release. aha_search returns none of these fields, so use this to see a release's current values, and always read before you write to one."
+      "description": "Read one release from Aha.io by reference number (e.g. PRJ1-R-3) or internal id. Returns the full current record - including workflow status, progress, whether it has been released, its release date, parking-lot flag, goals and custom field values - as structuredContent, a one-line summary naming its status, and a link to the release. aha_search returns none of these fields, so use this to see a release's current values, and always read before you write to one. aha_list_comments reads its comment thread."
+    },
+    {
+      "name": "aha_list_comments",
+      "description": "Read the comments on an Aha.io record - feature, idea, epic, initiative, goal, release, release phase, requirement, todo or product. For an idea this returns both streams: internal comments and the ideas-portal conversation, which are separate records in Aha, so a customer's own words arrive alongside internal discussion. Every comment is labelled with its source ('internal' or 'portal') and, for portal comments, its visibility. Returns the comments oldest first as structuredContent, a summary listing author and an excerpt of each, and a link to the parent record."
     },
     {
       "name": "aha_move_feature_to_release",

--- a/src/core/resources.ts
+++ b/src/core/resources.ts
@@ -681,6 +681,98 @@ export function registerResources(server: McpServer) {
     }
   );
 
+  // Aha feature comments resource
+  server.registerResource(
+    "aha_feature_comments",
+    new ResourceTemplate(
+      "aha://comments/feature/{feature_id}",
+      {
+        list: undefined,
+        complete: {
+          feature_id: async () => []
+        }
+      }
+    ),
+    {
+      title: "Aha Feature Comments",
+      description: "Get comments for a specific feature",
+      mimeType: "application/json"
+    },
+    async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
+      const pathParts = uri.pathname.split('/');
+      const featureId = normalizeVar(variables.feature_id) || pathParts[pathParts.length - 1];
+
+      if (!featureId) {
+        throw new Error('Invalid feature ID: Feature ID is missing from URI');
+      }
+
+      try {
+        const comments = await getAhaService().getFeatureComments(featureId);
+
+        return {
+          contents: [{
+            uri: uri.toString(),
+            text: JSON.stringify(comments, null, 2),
+            mimeType: "application/json"
+          }]
+        };
+      } catch (error) {
+        console.error(`Error retrieving comments for feature ${featureId}:`, error);
+        throw toMcpError(error, uri.toString());
+      }
+    }
+  );
+
+  /**
+   * An idea's *portal* comments, which `aha://comments/idea/{id}` does not return - the two
+   * endpoints hold disjoint records, and the portal side is where a customer's own words are.
+   * Kept as a separate URI rather than merged into the other resource so that neither one
+   * silently changes meaning; the `aha_list_comments` tool is what merges them for a caller
+   * who wants the whole conversation.
+   */
+  server.registerResource(
+    "aha_idea_portal_comments",
+    new ResourceTemplate(
+      "aha://idea-comments/{idea_id}",
+      {
+        list: undefined,
+        complete: {
+          idea_id: async () => []
+        }
+      }
+    ),
+    {
+      title: "Aha Idea Portal Comments",
+      description:
+        "Get an idea's ideas-portal comments, including anything a customer wrote. These are " +
+        "different records from aha://comments/idea/{idea_id}, which holds internal comments only.",
+      mimeType: "application/json"
+    },
+    async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
+      const pathParts = uri.pathname.split('/');
+      const ideaId = normalizeVar(variables.idea_id) || pathParts[pathParts.length - 1];
+
+      if (!ideaId) {
+        throw new Error('Invalid idea ID: Idea ID is missing from URI');
+      }
+
+      try {
+        const comments = await getAhaService().getIdeaPortalComments(ideaId);
+
+        return {
+          contents: [{
+            uri: uri.toString(),
+            text: JSON.stringify(comments, null, 2),
+            mimeType: "application/json"
+          }]
+        };
+      } catch (error) {
+        console.error(`Error retrieving portal comments for idea ${ideaId}:`, error);
+        throw toMcpError(error, uri.toString());
+      }
+    }
+  );
+
   // Aha idea comments resource
   server.registerResource(
     "aha_idea_comments",
@@ -695,7 +787,9 @@ export function registerResources(server: McpServer) {
     ),
     {
       title: "Aha Idea Comments",
-      description: "Get comments for a specific idea",
+      description:
+        "Get internal comments for a specific idea. This does not include the ideas-portal " +
+        "conversation - read aha://idea-comments/{idea_id} for that.",
       mimeType: "application/json"
     },
     async (uri: URL, variables: Variables, _extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {

--- a/src/core/services/aha-service.interface.ts
+++ b/src/core/services/aha-service.interface.ts
@@ -23,6 +23,9 @@ import type {
   ProductsListResponse,
   Comment,
   CommentsListResponse,
+  IdeaComment,
+  IdeaCommentsListResponse,
+  IdeaCommentVisibility,
   GoalGetResponse,
   GoalsListResponse,
   GoalEpicsResponse,
@@ -168,6 +171,7 @@ export interface IAhaService {
 
   // Comments
   createFeatureComment(featureId: string, body: string): Promise<Comment>;
+  getFeatureComments(featureId: string): Promise<CommentsListResponse>;
   getEpicComments(epicId: string): Promise<CommentsListResponse>;
   getIdeaComments(ideaId: string): Promise<CommentsListResponse>;
   getInitiativeComments(initiativeId: string): Promise<CommentsListResponse>;
@@ -177,6 +181,31 @@ export interface IAhaService {
   getReleasePhaseComments(releasePhaseId: string): Promise<CommentsListResponse>;
   getRequirementComments(requirementId: string): Promise<CommentsListResponse>;
   getTodoComments(todoId: string): Promise<CommentsListResponse>;
+
+  createEpicComment(epicId: string, body: string): Promise<Comment>;
+  createIdeaComment(ideaId: string, body: string): Promise<Comment>;
+  createInitiativeComment(initiativeId: string, body: string): Promise<Comment>;
+  createGoalComment(goalId: string, body: string): Promise<Comment>;
+  createReleaseComment(releaseId: string, body: string): Promise<Comment>;
+  createReleasePhaseComment(releasePhaseId: string, body: string): Promise<Comment>;
+  createRequirementComment(requirementId: string, body: string): Promise<Comment>;
+  createTodoComment(todoId: string, body: string): Promise<Comment>;
+
+  /**
+   * An idea's portal comments, which `getIdeaComments` does not return - the two endpoints
+   * hold disjoint sets. See `IdeaComment`.
+   */
+  getIdeaPortalComments(ideaId: string): Promise<IdeaCommentsListResponse>;
+  /**
+   * Comment on an idea in a way that can reach the ideas portal. `visibility` is required
+   * rather than defaulted: Aha's default is `public`, and publishing to customers is not a
+   * thing to do by omission.
+   */
+  createIdeaPortalComment(
+    ideaId: string,
+    body: string,
+    visibility: IdeaCommentVisibility
+  ): Promise<IdeaComment>;
 
   // Additional list methods
   listIdeasByProduct(

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -17,6 +17,9 @@ import type {
   ProductsListResponse,
   Comment,
   CommentsListResponse,
+  IdeaComment,
+  IdeaCommentsListResponse,
+  IdeaCommentVisibility,
   GoalGetResponse,
   GoalsListResponse,
   GoalEpicsResponse,
@@ -381,6 +384,77 @@ export class MockAhaService implements IAhaService {
       body,
       created_at: new Date().toISOString()
     } as Comment;
+  }
+
+  async getFeatureComments(_featureId: string): Promise<CommentsListResponse> {
+    return { comments: [] } as CommentsListResponse;
+  }
+
+  async createEpicComment(_epicId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createIdeaComment(_ideaId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createInitiativeComment(_initiativeId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createGoalComment(_goalId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createReleaseComment(_releaseId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createReleasePhaseComment(_releasePhaseId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createRequirementComment(_requirementId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  async createTodoComment(_todoId: string, body: string): Promise<Comment> {
+    return { id: '1', body, created_at: new Date().toISOString() } as Comment;
+  }
+
+  /**
+   * Portal comments are a separate endpoint from `getIdeaComments`, so the mock keeps them
+   * separate too - a mock that returned the same list for both would hide the very split
+   * these methods exist to expose.
+   */
+  async getIdeaPortalComments(ideaId: string): Promise<IdeaCommentsListResponse> {
+    return {
+      idea_comments: [
+        {
+          id: 'IC-1',
+          idea_id: ideaId,
+          body: '<p>Why was this rejected?</p>',
+          visibility: 'Visible to all ideas portal users',
+          idea_commenter_portal_user: { email: 'customer@example.com' }
+        }
+      ]
+    } as IdeaCommentsListResponse;
+  }
+
+  async createIdeaPortalComment(
+    ideaId: string,
+    body: string,
+    visibility: IdeaCommentVisibility
+  ): Promise<IdeaComment> {
+    return {
+      id: 'IC-2',
+      idea_id: ideaId,
+      body,
+      // Echoed back as given rather than as Aha's human-readable phrase; the mock is not the
+      // place to invent a mapping between the two vocabularies.
+      visibility,
+      created_at: new Date().toISOString()
+    } as IdeaComment;
   }
 
   async getEpicComments(_epicId: string): Promise<CommentsListResponse> {

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -7,6 +7,7 @@ import {
   ProductsApi,
   InitiativesApi,
   CommentsApi,
+  IdeaCommentsApi,
   GoalsApi,
   ToDosApi,
   CompetitorsApi,
@@ -19,6 +20,7 @@ import {
   IdeaVotesApi,
   CustomFieldsApi
 } from '@cedricziel/aha-js';
+import type { IdeacommentsPostRequest } from '@cedricziel/aha-js';
 
 import {
   Feature,
@@ -34,6 +36,9 @@ import {
   ProductsListResponse,
   Comment,
   CommentsListResponse,
+  IdeaComment,
+  IdeaCommentsListResponse,
+  IdeaCommentVisibility,
   GoalGetResponse,
   GoalsListResponse,
   GoalEpicsResponse,
@@ -81,6 +86,7 @@ export class AhaService {
   private static productsApi: ProductsApi | null = null;
   private static initiativesApi: InitiativesApi | null = null;
   private static commentsApi: CommentsApi | null = null;
+  private static ideaCommentsApi: IdeaCommentsApi | null = null;
   private static goalsApi: GoalsApi | null = null;
   private static todosApi: ToDosApi | null = null;
   private static competitorsApi: CompetitorsApi | null = null;
@@ -234,6 +240,7 @@ export class AhaService {
       this.productsApi = new ProductsApi(this.configuration);
       this.initiativesApi = new InitiativesApi(this.configuration);
       this.commentsApi = new CommentsApi(this.configuration);
+      this.ideaCommentsApi = new IdeaCommentsApi(this.configuration);
       this.goalsApi = new GoalsApi(this.configuration);
       this.todosApi = new ToDosApi(this.configuration);
       this.competitorsApi = new CompetitorsApi(this.configuration);
@@ -327,6 +334,17 @@ export class AhaService {
       this.initializeClient();
     }
     return this.commentsApi!;
+  }
+
+  /**
+   * `IdeaCommentsApi` covers `/ideas/{id}/idea_comments`, which is a different endpoint from
+   * the `/ideas/{id}/comments` that `CommentsApi` serves - see the `IdeaComment` type.
+   */
+  private static getIdeaCommentsApi(): IdeaCommentsApi {
+    if (!this.ideaCommentsApi) {
+      this.initializeClient();
+    }
+    return this.ideaCommentsApi!;
   }
 
   /**
@@ -963,6 +981,170 @@ export class AhaService {
       return response.data as unknown as CommentsListResponse;
     } catch (error) {
       log.error('Error getting comments for todo', error as Error, { operation: 'getTodoComments', todo_id: todoId });
+      throw error;
+    }
+  }
+
+  /**
+   * Get comments for a specific feature
+   * @param featureId The ID of the feature
+   * @returns A list of comments for the feature
+   */
+  public static async getFeatureComments(featureId: string): Promise<CommentsListResponse> {
+    const commentsApi = this.getCommentsApi();
+
+    try {
+      const response = await commentsApi.featuresByFeatureCommentsGet({ featureId });
+      return response.data as unknown as CommentsListResponse;
+    } catch (error) {
+      log.error('Error getting comments for feature', error as Error, { operation: 'getFeatureComments', feature_id: featureId });
+      throw error;
+    }
+  }
+
+  /**
+   * Every `POST .../comments` endpoint takes the same body and answers with `{ comment }`,
+   * so the per-type creators differ only in which SDK method they call. One helper keeps
+   * that from becoming nine copies of the same five lines.
+   */
+  private static async postComment(
+    operation: string,
+    context: Record<string, unknown>,
+    body: string,
+    call: (
+      api: CommentsApi,
+      request: { comment: { body: string } }
+    ) => Promise<{ data: unknown }>
+  ): Promise<Comment> {
+    const commentsApi = this.getCommentsApi();
+
+    try {
+      const response = await call(commentsApi, { comment: { body } });
+      const data = response.data as { comment?: Comment };
+      return data.comment as Comment;
+    } catch (error) {
+      log.error('Error creating comment', error as Error, { operation, ...context });
+      throw error;
+    }
+  }
+
+  public static async createEpicComment(epicId: string, body: string): Promise<Comment> {
+    return this.postComment('createEpicComment', { epic_id: epicId }, body, (api, request) =>
+      api.epicsByEpicCommentsPost({ epicId, commentsPostRequest: request })
+    );
+  }
+
+  /**
+   * Comment on an idea *internally*. Aha documents `POST /ideas/{id}/comments` as creating an
+   * internal comment; it cannot reach the ideas portal, and the record it creates will not
+   * appear in `getIdeaPortalComments`. Use `createIdeaPortalComment` to reply to a customer.
+   */
+  public static async createIdeaComment(ideaId: string, body: string): Promise<Comment> {
+    return this.postComment('createIdeaComment', { idea_id: ideaId }, body, (api, request) =>
+      api.ideasByIdeaCommentsPost({ ideaId, commentsPostRequest: request })
+    );
+  }
+
+  public static async createInitiativeComment(initiativeId: string, body: string): Promise<Comment> {
+    return this.postComment(
+      'createInitiativeComment',
+      { initiative_id: initiativeId },
+      body,
+      (api, request) => api.initiativesByInitiativeCommentsPost({ initiativeId, commentsPostRequest: request })
+    );
+  }
+
+  public static async createGoalComment(goalId: string, body: string): Promise<Comment> {
+    return this.postComment('createGoalComment', { goal_id: goalId }, body, (api, request) =>
+      api.goalsByGoalCommentsPost({ goalId, commentsPostRequest: request })
+    );
+  }
+
+  public static async createReleaseComment(releaseId: string, body: string): Promise<Comment> {
+    return this.postComment('createReleaseComment', { release_id: releaseId }, body, (api, request) =>
+      api.releasesByReleaseCommentsPost({ releaseId, commentsPostRequest: request })
+    );
+  }
+
+  public static async createReleasePhaseComment(releasePhaseId: string, body: string): Promise<Comment> {
+    return this.postComment(
+      'createReleasePhaseComment',
+      { release_phase_id: releasePhaseId },
+      body,
+      (api, request) => api.releasePhasesByReleasePhaseCommentsPost({ releasePhaseId, commentsPostRequest: request })
+    );
+  }
+
+  public static async createRequirementComment(requirementId: string, body: string): Promise<Comment> {
+    return this.postComment(
+      'createRequirementComment',
+      { requirement_id: requirementId },
+      body,
+      (api, request) => api.requirementsByRequirementCommentsPost({ requirementId, commentsPostRequest: request })
+    );
+  }
+
+  /** Todos are `/tasks` in Aha's API; see the aha-js 2.0.0 migration notes. */
+  public static async createTodoComment(todoId: string, body: string): Promise<Comment> {
+    return this.postComment('createTodoComment', { todo_id: todoId }, body, (api, request) =>
+      api.tasksByTaskCommentsPost({ taskId: todoId, commentsPostRequest: request })
+    );
+  }
+
+  /**
+   * An idea's portal comments - a different endpoint from `getIdeaComments`, over records
+   * that endpoint never returns. See the `IdeaComment` type for what the split is and why
+   * reading only one side is misleading.
+   */
+  public static async getIdeaPortalComments(ideaId: string): Promise<IdeaCommentsListResponse> {
+    const ideaCommentsApi = this.getIdeaCommentsApi();
+
+    try {
+      const response = await ideaCommentsApi.ideasByIdeaIdeaCommentsGet({ ideaId });
+      return response.data as unknown as IdeaCommentsListResponse;
+    } catch (error) {
+      log.error('Error getting portal comments for idea', error as Error, {
+        operation: 'getIdeaPortalComments',
+        idea_id: ideaId
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Create a comment on an idea that can reach the ideas portal.
+   *
+   * `visibility` is a required argument on purpose. Aha defaults it to `public`, so an
+   * omitted value publishes to customers - not a thing that should happen because a caller
+   * left a field out.
+   *
+   * The cast is needed because this SDK is generated from recorded test responses, and the
+   * only field its `IdeacommentsPostRequest` model captured is `spam`. Aha documents the
+   * body as `{ idea_comment: { body, visibility } }`, which is what goes on the wire; the
+   * cast admits it without hand-rolling the request the way `competitorRequest` has to.
+   */
+  public static async createIdeaPortalComment(
+    ideaId: string,
+    body: string,
+    visibility: IdeaCommentVisibility
+  ): Promise<IdeaComment> {
+    const ideaCommentsApi = this.getIdeaCommentsApi();
+
+    try {
+      const response = await ideaCommentsApi.ideasByIdeaIdeaCommentsPost({
+        ideaId,
+        ideacommentsPostRequest: {
+          idea_comment: { body, visibility }
+        } as unknown as IdeacommentsPostRequest
+      });
+      const data = response.data as unknown as { idea_comment?: IdeaComment };
+      return (data.idea_comment ?? (data as IdeaComment)) as IdeaComment;
+    } catch (error) {
+      log.error('Error creating portal comment on idea', error as Error, {
+        operation: 'createIdeaPortalComment',
+        idea_id: ideaId,
+        visibility
+      });
       throw error;
     }
   }

--- a/src/core/tool-output.ts
+++ b/src/core/tool-output.ts
@@ -51,14 +51,25 @@ export function unwrapRecord(payload: unknown, key: string): Record<string, unkn
   return {};
 }
 
-/** Record types with a single-record resource template in resources.ts. */
+/**
+ * Record types with a single-record resource template in resources.ts.
+ *
+ * Spelled as the URI segment, so `release-phase` rather than `release_phase` - a link built
+ * from the wrong spelling points at a template that does not match, which is worse than
+ * omitting the link.
+ */
 export type LinkableRecordType =
   | "feature"
   | "epic"
   | "idea"
   | "initiative"
   | "competitor"
-  | "release";
+  | "release"
+  | "release-phase"
+  | "goal"
+  | "requirement"
+  | "todo"
+  | "product";
 
 function identifier(value: unknown): string | undefined {
   if (typeof value === "string" && value.length > 0) return value;
@@ -242,6 +253,25 @@ export const commentOutputSchema = z.looseObject({
 });
 
 /**
+ * An idea portal comment, which carries a `visibility` the generic comment does not.
+ *
+ * The value here is Aha's read vocabulary - a human-readable phrase such as "Visible to all
+ * ideas portal users" - not the `public` / `employee_or_creator` a create request takes. A
+ * caller cannot round-trip one into the other.
+ */
+export const ideaCommentOutputSchema = z.looseObject({
+  id: z.union([z.string(), z.number()]).optional().describe("Idea comment id"),
+  idea_id: z.union([z.string(), z.number()]).optional().describe("Idea the comment belongs to"),
+  body: z.string().nullish().describe("Comment body, as HTML"),
+  visibility: z
+    .string()
+    .nullish()
+    .describe('How visible the comment is, as a phrase, e.g. "Visible to all ideas portal users"'),
+  created_at: z.string().optional().describe("ISO 8601 creation timestamp"),
+  updated_at: z.string().optional().describe("ISO 8601 last-modified timestamp")
+});
+
+/**
  * Aha's DELETE endpoints answer with an empty body, so there is no record to hand back -
  * only a restatement of what went away, which the caller can use to confirm the right
  * record was targeted.
@@ -252,6 +282,56 @@ export const deletionOutputSchema = z.object({
     .enum(["feature", "epic", "idea", "competitor"])
     .describe("Type of record that was deleted"),
   id: z.string().describe("Id or reference number the deletion was requested for")
+});
+
+/**
+ * Comment types a record can carry. `internal` is Aha's own comment stream, reachable on
+ * every record type; `portal` exists only on ideas and is the conversation that can appear in
+ * an ideas portal. They come from different endpoints over disjoint records, so a caller has
+ * to be able to tell which one it is holding - hence the field rather than one flat list.
+ */
+export const COMMENT_SOURCES = ["internal", "portal"] as const;
+
+/**
+ * One comment as `aha_list_comments` reports it. Loose, because the body is Aha's record
+ * with `source` added, and Aha returns far more fields than are worth describing.
+ */
+const listedCommentSchema = z.looseObject({
+  id: z.union([z.string(), z.number()]).optional().describe("Comment id"),
+  source: z
+    .enum(COMMENT_SOURCES)
+    .describe(
+      'Which stream this came from. "internal" is visible to Aha users only; "portal" can ' +
+        "be visible in the ideas portal - check `visibility`."
+    ),
+  body: z.string().nullish().describe("Comment body, as HTML"),
+  visibility: z
+    .string()
+    .nullish()
+    .describe(
+      'Portal comments only, as a human-readable phrase, e.g. "Visible to all ideas portal ' +
+        'users". Absent on internal comments, which are never portal-visible.'
+    ),
+  created_at: z.string().nullish().describe("ISO 8601 creation timestamp"),
+  updated_at: z.string().nullish().describe("ISO 8601 last-modified timestamp")
+});
+
+/** Built by `aha_list_comments`: the wrapper is this server's, the comments are Aha's. */
+export const commentListOutputSchema = z.object({
+  record_type: z.string().describe("Record type the comments belong to, e.g. feature"),
+  record_id: z.string().describe("Id or reference number the comments were read for"),
+  comment_count: z.number().describe("Number of comments returned"),
+  /**
+   * Named explicitly so a zero here cannot be mistaken for "no portal conversation exists".
+   * Only ideas have a portal stream, and only ideas are asked for one.
+   */
+  includes_portal_comments: z
+    .boolean()
+    .describe(
+      "True when the ideas-portal stream was read as well as the internal one. Only ideas " +
+        "have a portal stream, so this is false for every other record type."
+    ),
+  comments: z.array(listedCommentSchema).describe("Comments, oldest first")
 });
 
 /** Built by `aha_search` from the GraphQL response, so every field is known. */

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -3,6 +3,7 @@ import * as z from "zod/v4";
 import * as services from "./services/index.js";
 import { registerSearchTools } from "./tools/search-tools.js";
 import { registerRecordTools } from "./tools/record-tools.js";
+import { registerCommentTools } from "./tools/comment-tools.js";
 import {
   commentOutputSchema,
   competitorOutputSchema,
@@ -30,7 +31,13 @@ export function registerTools(server: McpServer) {
     "aha_create_feature_comment",
     {
       title: "Create feature comment",
-      description: "Create a comment on a feature in Aha.io. Returns the created comment.",
+      // Kept as-is now that aha_create_comment covers every commentable type: removing it
+      // would break callers for no gain. The description says which to prefer so a model is
+      // not left choosing between two tools that look identical for features.
+      description:
+        "Create a comment on a feature in Aha.io. Returns the created comment. " +
+        "aha_create_comment does the same for features and every other record type, and " +
+        "aha_list_comments reads them back - prefer those unless you specifically want this one.",
       inputSchema: {
         featureId: z.string().describe("ID of the feature"),
         body: z.string().describe("Comment body")
@@ -1339,4 +1346,7 @@ export function registerTools(server: McpServer) {
   // that does not surface resources to its model would otherwise see writers with no way to
   // read what they are about to overwrite.
   registerRecordTools(server);
+
+  // Comments, including the ideas-portal stream that aha://comments/idea/{id} does not carry.
+  registerCommentTools(server);
 }

--- a/src/core/tools/comment-tools.ts
+++ b/src/core/tools/comment-tools.ts
@@ -1,0 +1,404 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import * as services from "../services/index.js";
+import {
+  commentListOutputSchema,
+  commentOutputSchema,
+  ideaCommentOutputSchema,
+  recordLinks,
+  type LinkableRecordType
+} from "../tool-output.js";
+import { describeAhaError } from "../services/aha-errors.js";
+import { log } from "../logger.js";
+import type { Comment, IdeaComment } from "../types/aha-types.js";
+
+/**
+ * Comment tools.
+ *
+ * Two things shaped these beyond "wrap the endpoints":
+ *
+ * 1. **Ideas have two comment streams, not one.** `/ideas/{id}/comments` holds internal
+ *    comments; `/ideas/{id}/idea_comments` holds the conversation that can reach the ideas
+ *    portal. They are disjoint - measured on a live idea: one internal comment, two portal
+ *    comments, no shared ids - and the portal side is where a customer's own words are. A
+ *    reader that returns only the first looks complete while omitting the half that usually
+ *    matters for triage, so `aha_list_comments` reads both for ideas and labels every comment
+ *    with its `source`.
+ * 2. **Publishing to customers must be deliberate.** Aha defaults an idea comment's
+ *    visibility to `public`, so a caller that omits the field is talking to customers by
+ *    accident. `aha_create_idea_portal_comment` therefore takes `visibility` as a required
+ *    argument and is a separate tool from `aha_create_comment`, which only ever writes
+ *    internally. Two tools rather than one flag means a host that gates writes can gate the
+ *    customer-facing one on its own.
+ */
+
+/** How each record type reaches its comments, and what to link to afterwards. */
+interface CommentTarget {
+  /** Value of the `recordType` argument. */
+  key: string;
+  /** URI segment for the parent record's resource, when it has one. */
+  link: LinkableRecordType;
+  read: (id: string) => Promise<{ comments?: Comment[] }>;
+  /** Absent for types Aha exposes no comment-create endpoint for. */
+  write?: (id: string, body: string) => Promise<Comment>;
+}
+
+const TARGETS: CommentTarget[] = [
+  {
+    key: "feature",
+    link: "feature",
+    read: id => services.AhaService.getFeatureComments(id),
+    write: (id, body) => services.AhaService.createFeatureComment(id, body)
+  },
+  {
+    key: "idea",
+    link: "idea",
+    read: id => services.AhaService.getIdeaComments(id),
+    write: (id, body) => services.AhaService.createIdeaComment(id, body)
+  },
+  {
+    key: "epic",
+    link: "epic",
+    read: id => services.AhaService.getEpicComments(id),
+    write: (id, body) => services.AhaService.createEpicComment(id, body)
+  },
+  {
+    key: "initiative",
+    link: "initiative",
+    read: id => services.AhaService.getInitiativeComments(id),
+    write: (id, body) => services.AhaService.createInitiativeComment(id, body)
+  },
+  {
+    key: "goal",
+    link: "goal",
+    read: id => services.AhaService.getGoalComments(id),
+    write: (id, body) => services.AhaService.createGoalComment(id, body)
+  },
+  {
+    key: "release",
+    link: "release",
+    read: id => services.AhaService.getReleaseComments(id),
+    write: (id, body) => services.AhaService.createReleaseComment(id, body)
+  },
+  {
+    key: "release_phase",
+    link: "release-phase",
+    read: id => services.AhaService.getReleasePhaseComments(id),
+    write: (id, body) => services.AhaService.createReleasePhaseComment(id, body)
+  },
+  {
+    key: "requirement",
+    link: "requirement",
+    read: id => services.AhaService.getRequirementComments(id),
+    write: (id, body) => services.AhaService.createRequirementComment(id, body)
+  },
+  {
+    key: "todo",
+    link: "todo",
+    read: id => services.AhaService.getTodoComments(id),
+    write: (id, body) => services.AhaService.createTodoComment(id, body)
+  },
+  {
+    // Aha's OpenAPI document has GET but no POST for a workspace's comments, so this one is
+    // read-only rather than omitted - reading it is still useful.
+    key: "product",
+    link: "product",
+    read: id => services.AhaService.getProductComments(id)
+  }
+];
+
+const READABLE = TARGETS.map(t => t.key) as [string, ...string[]];
+const WRITABLE = TARGETS.filter(t => t.write).map(t => t.key) as [string, ...string[]];
+
+function target(key: string): CommentTarget {
+  const found = TARGETS.find(t => t.key === key);
+  // Unreachable through the tool - the enum rejects anything else before the handler runs.
+  if (!found) throw new Error(`Unsupported record type: ${key}`);
+  return found;
+}
+
+/** Aha comment bodies are HTML; a one-line preview is for a person skimming, not for parsing. */
+function preview(body: unknown, limit = 100): string {
+  if (typeof body !== "string") return "(no body)";
+  const text = body
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text.length > limit ? `${text.slice(0, limit - 1)}…` : text || "(empty)";
+}
+
+function authorOf(comment: Record<string, unknown>): string {
+  const named = (value: unknown): string | undefined => {
+    if (!value || typeof value !== "object") return undefined;
+    const record = value as Record<string, unknown>;
+    const name = record.name ?? record.email;
+    return typeof name === "string" && name ? name : undefined;
+  };
+
+  return (
+    named(comment.user) ??
+    named(comment.idea_commenter_portal_user) ??
+    named(comment.idea_commenter_idea_user) ??
+    "unknown"
+  );
+}
+
+/** Oldest first, so a conversation reads top to bottom. Undated comments sort last. */
+function byCreatedAt(a: Record<string, unknown>, b: Record<string, unknown>): number {
+  const at = typeof a.created_at === "string" ? Date.parse(a.created_at) : NaN;
+  const bt = typeof b.created_at === "string" ? Date.parse(b.created_at) : NaN;
+  if (Number.isNaN(at) && Number.isNaN(bt)) return 0;
+  if (Number.isNaN(at)) return 1;
+  if (Number.isNaN(bt)) return -1;
+  return at - bt;
+}
+
+export function registerCommentTools(server: McpServer) {
+  server.registerTool(
+    "aha_list_comments",
+    {
+      title: "List comments",
+      description:
+        "Read the comments on an Aha.io record - feature, idea, epic, initiative, goal, " +
+        "release, release phase, requirement, todo or product. For an idea this returns both " +
+        "streams: internal comments and the ideas-portal conversation, which are separate " +
+        "records in Aha, so a customer's own words arrive alongside internal discussion. " +
+        "Every comment is labelled with its source ('internal' or 'portal') and, for portal " +
+        "comments, its visibility. Returns the comments oldest first as structuredContent, a " +
+        "summary listing author and an excerpt of each, and a link to the parent record.",
+      inputSchema: {
+        recordType: z
+          .enum(READABLE)
+          .describe(
+            "Type of record to read comments from. Only 'idea' has a portal comment stream."
+          ),
+        recordId: z
+          .string()
+          .min(1)
+          .describe("Reference number (e.g. PRJ1-123) or internal id of the record."),
+        includePortalComments: z
+          .boolean()
+          .optional()
+          .describe(
+            "Ideas only, default true. When true the ideas-portal conversation is read as " +
+              "well as the internal comments. Set false to see internal comments alone - but " +
+              "note that a portal reply from a customer will then be missing with no sign of it."
+          )
+      },
+      outputSchema: commentListOutputSchema,
+      annotations: {
+        title: "List comments",
+        readOnlyHint: true,
+        openWorldHint: true
+      }
+    },
+    async ({ recordType, recordId, includePortalComments }) => {
+      const config = target(recordType);
+      const wantsPortal = recordType === "idea" && includePortalComments !== false;
+
+      try {
+        const internal = await config.read(recordId);
+        const comments: Record<string, unknown>[] = (internal.comments ?? []).map(comment => ({
+          ...(comment as Record<string, unknown>),
+          source: "internal" as const
+        }));
+
+        if (wantsPortal) {
+          const portal = await services.AhaService.getIdeaPortalComments(recordId);
+          for (const comment of portal.idea_comments ?? []) {
+            comments.push({ ...(comment as Record<string, unknown>), source: "portal" as const });
+          }
+        }
+
+        comments.sort(byCreatedAt);
+
+        const payload = {
+          record_type: recordType,
+          record_id: recordId,
+          comment_count: comments.length,
+          includes_portal_comments: wantsPortal,
+          comments
+        };
+
+        const lines = comments.map(comment => {
+          const visibility =
+            comment.source === "portal" && typeof comment.visibility === "string"
+              ? ` [${comment.visibility}]`
+              : "";
+          return `- ${comment.source}${visibility} - ${authorOf(comment)}: ${preview(comment.body)}`;
+        });
+
+        const heading =
+          comments.length === 0
+            ? `No comments on ${recordType} ${recordId}` +
+              (wantsPortal ? " (internal or ideas portal)." : ".")
+            : `${comments.length} comment${comments.length === 1 ? "" : "s"} on ${recordType} ` +
+              `${recordId}${wantsPortal ? ", internal and ideas portal" : ""}:`;
+
+        return {
+          content: [
+            { type: "text" as const, text: [heading, ...lines].join("\n") },
+            ...recordLinks(config.link, {}, recordId)
+          ],
+          structuredContent: payload
+        };
+      } catch (error) {
+        log.error(`Failed to list comments for ${recordType} ${recordId}`, error as Error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error listing comments: ${describeAhaError(error, `${recordType} ${recordId}`)}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "aha_create_comment",
+    {
+      title: "Add comment",
+      description:
+        "Add a comment to an Aha.io record - feature, idea, epic, initiative, goal, release, " +
+        "release phase, requirement or todo. The comment is internal: visible to Aha.io users " +
+        "and never shown in an ideas portal, including on an idea. To reply to a customer in " +
+        "the ideas portal, use aha_create_idea_portal_comment instead. Returns the created " +
+        "comment and a link to the record it was added to.",
+      inputSchema: {
+        recordType: z.enum(WRITABLE).describe("Type of record to comment on."),
+        recordId: z
+          .string()
+          .min(1)
+          .describe("Reference number (e.g. PRJ1-123) or internal id of the record."),
+        body: z
+          .string()
+          .min(1)
+          .describe("Comment body. HTML is accepted, e.g. <p>text</p>; plain text also works.")
+      },
+      outputSchema: commentOutputSchema,
+      annotations: {
+        title: "Add comment",
+        readOnlyHint: false,
+        destructiveHint: false,
+        // A repeated call adds another comment rather than updating the first.
+        idempotentHint: false,
+        openWorldHint: true
+      }
+    },
+    async ({ recordType, recordId, body }) => {
+      const config = target(recordType);
+
+      try {
+        const comment = (await config.write!(recordId, body)) ?? {};
+        const record = comment as unknown as Record<string, unknown>;
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `Added internal comment to ${recordType} ${recordId}: ${preview(record.body ?? body)}`
+            },
+            ...recordLinks(config.link, {}, recordId)
+          ],
+          structuredContent: record
+        };
+      } catch (error) {
+        log.error(`Failed to comment on ${recordType} ${recordId}`, error as Error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error adding comment: ${describeAhaError(error, `${recordType} ${recordId}`)}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "aha_create_idea_portal_comment",
+    {
+      title: "Reply in ideas portal",
+      description:
+        "Comment on an idea in a way that can be seen outside Aha.io, in the ideas portal - " +
+        "this is how you reply to a customer who submitted or commented on an idea. " +
+        "visibility is required and decides the audience: 'public' shows the comment to every " +
+        "portal user, 'employee_or_creator' restricts it to employees and the idea's creator. " +
+        "Aha.io itself defaults to 'public', so nothing here is optional by design. For a note " +
+        "that must stay inside Aha.io, use aha_create_comment. Returns the created comment and " +
+        "a link to the idea.",
+      inputSchema: {
+        ideaId: z
+          .string()
+          .min(1)
+          .describe("Reference number (e.g. PRJ1-I-7) or internal id of the idea."),
+        body: z
+          .string()
+          .min(1)
+          .describe("Comment body. HTML is accepted, e.g. <p>text</p>; plain text also works."),
+        visibility: z
+          .enum(["public", "employee_or_creator"])
+          .describe(
+            "Who can see this. 'public' means every ideas-portal user, i.e. customers. " +
+              "'employee_or_creator' limits it to employees and whoever created the idea. " +
+              "Required - do not guess which one the user meant."
+          )
+      },
+      outputSchema: ideaCommentOutputSchema,
+      annotations: {
+        title: "Reply in ideas portal",
+        readOnlyHint: false,
+        // Not destructive - it adds a record and removes nothing - but it is the one write
+        // here that a person outside the account can read.
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true
+      }
+    },
+    async ({ ideaId, body, visibility }) => {
+      try {
+        const comment: IdeaComment =
+          (await services.AhaService.createIdeaPortalComment(ideaId, body, visibility)) ?? {};
+        const record = comment as unknown as Record<string, unknown>;
+
+        const audience =
+          visibility === "public"
+            ? "visible to all ideas portal users"
+            : "visible to employees and the idea's creator";
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Added portal comment to idea ${ideaId} (${audience}): ${preview(record.body ?? body)}`
+            },
+            ...recordLinks("idea", {}, ideaId)
+          ],
+          structuredContent: record
+        };
+      } catch (error) {
+        log.error(`Failed to add portal comment to idea ${ideaId}`, error as Error);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error adding portal comment: ${describeAhaError(error, `idea ${ideaId}`)}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}

--- a/src/core/tools/record-tools.ts
+++ b/src/core/tools/record-tools.ts
@@ -149,6 +149,11 @@ const READERS: ReaderConfig[] = [
   }
 ];
 
+/** "an epic", not "a epic" - these strings are read by people as well as models. */
+function article(noun: string): string {
+  return /^[aeiou]/i.test(noun) ? "an" : "a";
+}
+
 function register(server: McpServer, config: ReaderConfig) {
   server.registerTool(
     config.tool,
@@ -158,8 +163,9 @@ function register(server: McpServer, config: ReaderConfig) {
         `Read one ${config.noun} from Aha.io by reference number (e.g. ${config.example}) or ` +
         `internal id. Returns the full current record - including ${config.fields} - as ` +
         `structuredContent, a one-line summary naming its status, and a link to the ` +
-        `${config.noun}. aha_search returns none of these fields, so use this to see a ` +
-        `${config.noun}'s current values, and always read before you write to one.`,
+        `${config.noun}. aha_search returns none of these fields, so use this to see ` +
+        `${article(config.noun)} ${config.noun}'s current values, and always read before you ` +
+        `write to one. aha_list_comments reads its comment thread.`,
       inputSchema: {
         [config.idParam]: z
           .string()

--- a/src/core/types/aha-types.ts
+++ b/src/core/types/aha-types.ts
@@ -563,6 +563,45 @@ export interface CommentsListResponse {
 }
 
 /**
+ * An idea's *portal* comment, from `GET /ideas/{id}/idea_comments`.
+ *
+ * Not the same records as `Comment` on an idea, and not a superset either - the two
+ * endpoints return disjoint sets. `/ideas/{id}/comments` holds internal comments, which Aha
+ * documents as such; `/ideas/{id}/idea_comments` holds the conversation that can reach the
+ * ideas portal, including anything a customer wrote. Measured on one live idea: one internal
+ * comment, two portal comments, no overlapping ids. Reading only the first silently drops
+ * the customer-facing half, which for idea triage is usually the half that matters.
+ *
+ * `visibility` is the field that distinguishes them, and it reads differently depending on
+ * direction: a response carries a human-readable phrase ("Visible to all ideas portal
+ * users"), while a create request takes `public` or `employee_or_creator`. Do not assume one
+ * vocabulary can be fed back into the other.
+ */
+export interface IdeaComment {
+  id?: string;
+  idea_id?: string;
+  body?: string;
+  /** Human-readable phrase on read, e.g. "Visible to all ideas portal users". */
+  visibility?: string;
+  created_at?: string;
+  updated_at?: string;
+  parent_idea_comment_id?: string | null;
+  /** Set when the author commented through the ideas portal rather than in Aha. */
+  idea_commenter_portal_user?: Record<string, unknown> | null;
+  idea_commenter_idea_user?: Record<string, unknown> | null;
+  attachments?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface IdeaCommentsListResponse {
+  idea_comments?: IdeaComment[];
+  pagination?: Pagination;
+}
+
+/** Visibility a new idea portal comment can be created with, per Aha's documented values. */
+export type IdeaCommentVisibility = 'public' | 'employee_or_creator';
+
+/**
  * Competitor entity.
  */
 export interface Competitor {

--- a/test/comment-tools.test.ts
+++ b/test/comment-tools.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerCommentTools } from '../src/core/tools/comment-tools.js';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * Comment tools.
+ *
+ * The load-bearing assertion in here is that an idea's two comment streams both arrive and
+ * stay distinguishable. Aha keeps internal comments at /ideas/{id}/comments and the
+ * ideas-portal conversation at /ideas/{id}/idea_comments; the sets are disjoint, and reading
+ * only the first looks complete while dropping whatever a customer wrote. The rest is about
+ * not publishing to customers by accident.
+ *
+ * Calls go through a real MCP client, which validates structuredContent against the
+ * advertised outputSchema - so a call that returns at all is the conformance assertion.
+ */
+async function connected() {
+  const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+  registerCommentTools(server);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+const INTERNAL = {
+  comments: [
+    {
+      id: '7469723628198768234',
+      body: '<p>Given we are going to merge App O11y with asserts, this is next quarter.</p>',
+      created_at: '2026-02-02T10:00:00.000Z',
+      user: { id: '1', name: 'Cedric Ziel' },
+      commentable: { id: '2', type: 'Idea' }
+    }
+  ]
+};
+
+const PORTAL = {
+  idea_comments: [
+    {
+      id: '7667211158746962968',
+      idea_id: 'PRJ1-I-7',
+      body: '<p>Why are we rejecting this idea? Isn&#x27;t Grafana meant to be open?</p>',
+      visibility: 'Visible to all ideas portal users',
+      created_at: '2026-01-01T10:00:00.000Z',
+      idea_commenter_portal_user: { email: 'customer@example.com' }
+    }
+  ]
+};
+
+describe('Comment tools', () => {
+  const patched: string[] = [];
+
+  const patch = (method: keyof typeof AhaService, impl: (...args: any[]) => Promise<any>) => {
+    patched.push(method as string);
+    (AhaService as any)[`__original_${method}`] = (AhaService as any)[method];
+    (AhaService as any)[method] = impl;
+  };
+
+  afterEach(() => {
+    for (const method of patched) {
+      (AhaService as any)[method] = (AhaService as any)[`__original_${method}`];
+      delete (AhaService as any)[`__original_${method}`];
+    }
+    patched.length = 0;
+  });
+
+  it('registers a reader, an internal writer and a portal writer', async () => {
+    const client = await connected();
+    const names = (await client.listTools()).tools.map(t => t.name).sort();
+
+    expect(names).toEqual(['aha_create_comment', 'aha_create_idea_portal_comment', 'aha_list_comments']);
+  });
+
+  it('reads both of an idea\'s comment streams and labels each one', async () => {
+    patch('getIdeaComments', async () => INTERNAL);
+    patch('getIdeaPortalComments', async () => PORTAL);
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'idea', recordId: 'PRJ1-I-7' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent.comment_count).toBe(2);
+    expect(result.structuredContent.includes_portal_comments).toBe(true);
+    expect(result.structuredContent.comments.map((c: any) => c.source)).toEqual([
+      // Oldest first: the customer's portal question precedes the internal reply.
+      'portal',
+      'internal'
+    ]);
+    expect(result.structuredContent.comments[0].visibility).toBe('Visible to all ideas portal users');
+  });
+
+  it('renders each comment with source, visibility, author and an excerpt', async () => {
+    patch('getIdeaComments', async () => INTERNAL);
+    patch('getIdeaPortalComments', async () => PORTAL);
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'idea', recordId: 'PRJ1-I-7' }
+    });
+
+    const text = result.content[0].text;
+    expect(text).toContain('2 comments on idea PRJ1-I-7, internal and ideas portal');
+    expect(text).toContain('- portal [Visible to all ideas portal users] - customer@example.com:');
+    expect(text).toContain('- internal - Cedric Ziel:');
+    // Bodies are HTML; the summary is for reading, so tags and entities are resolved.
+    expect(text).toContain("Isn't Grafana meant to be open?");
+    expect(text).not.toContain('<p>');
+  });
+
+  it('reads the internal stream alone when portal comments are declined', async () => {
+    patch('getIdeaComments', async () => INTERNAL);
+    patch('getIdeaPortalComments', async () => {
+      throw new Error('portal stream must not be read when includePortalComments is false');
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'idea', recordId: 'PRJ1-I-7', includePortalComments: false }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent.comment_count).toBe(1);
+    expect(result.structuredContent.includes_portal_comments).toBe(false);
+  });
+
+  /**
+   * Only ideas have a portal stream. Reporting `includes_portal_comments: false` on the other
+   * types keeps a zero from being read as "there is no portal conversation here".
+   */
+  it('never claims a portal read for record types that have no portal', async () => {
+    patch('getFeatureComments', async () => INTERNAL);
+    patch('getIdeaPortalComments', async () => {
+      throw new Error('a feature has no portal comment stream');
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'feature', recordId: 'PRJ1-123' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent.includes_portal_comments).toBe(false);
+    expect(result.structuredContent.comments[0].source).toBe('internal');
+  });
+
+  it('reads comments for every record type it advertises', async () => {
+    const calls: string[] = [];
+    for (const method of [
+      'getFeatureComments',
+      'getIdeaComments',
+      'getEpicComments',
+      'getInitiativeComments',
+      'getGoalComments',
+      'getReleaseComments',
+      'getReleasePhaseComments',
+      'getRequirementComments',
+      'getTodoComments',
+      'getProductComments'
+    ] as const) {
+      patch(method, async () => {
+        calls.push(method);
+        return { comments: [] };
+      });
+    }
+    patch('getIdeaPortalComments', async () => ({ idea_comments: [] }));
+    const client = await connected();
+
+    const types = ['feature', 'idea', 'epic', 'initiative', 'goal', 'release', 'release_phase', 'requirement', 'todo', 'product'];
+    for (const recordType of types) {
+      const result: any = await client.callTool({
+        name: 'aha_list_comments',
+        arguments: { recordType, recordId: 'X-1' }
+      });
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent.record_type).toBe(recordType);
+    }
+
+    expect(calls).toHaveLength(types.length);
+  });
+
+  it('links the parent record with the URI segment its resource template uses', async () => {
+    patch('getReleasePhaseComments', async () => ({ comments: [] }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'release_phase', recordId: 'PRJ1-RP-2' }
+    });
+
+    // The argument is release_phase; the resource is aha://release-phase/{id}. A link built
+    // from the argument spelling would point at a template that does not match.
+    const link = result.content.find((c: any) => c.type === 'resource_link');
+    expect(link.uri).toBe('aha://release-phase/PRJ1-RP-2');
+  });
+
+  it('adds an internal comment and says that is what it did', async () => {
+    let received: unknown;
+    patch('createEpicComment', async (_id: string, body: string) => {
+      received = body;
+      return { id: 'C-1', body, created_at: '2026-08-12T10:00:00.000Z' };
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_create_comment',
+      arguments: { recordType: 'epic', recordId: 'PRJ1-E-4', body: '<p>Scoped for Q3.</p>' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(received).toBe('<p>Scoped for Q3.</p>');
+    expect(result.structuredContent.id).toBe('C-1');
+    // "internal" is stated rather than implied: the whole point is that this is not the
+    // customer-facing write.
+    expect(result.content[0].text).toBe('Added internal comment to epic PRJ1-E-4: Scoped for Q3.');
+  });
+
+  it('offers no internal write for product comments, which Aha has no endpoint for', async () => {
+    const client = await connected();
+    const tool = (await client.listTools()).tools.find(t => t.name === 'aha_create_comment')!;
+    const recordType = (tool.inputSchema as any).properties.recordType;
+
+    expect(recordType.enum).not.toContain('product');
+    expect(recordType.enum).toContain('feature');
+  });
+
+  it('requires visibility on a portal comment rather than defaulting it', async () => {
+    patch('createIdeaPortalComment', async () => ({ id: 'IC-1' }));
+    const client = await connected();
+
+    // Aha defaults visibility to public, i.e. to customers. Omitting it here has to fail
+    // rather than quietly publish.
+    const result: any = await client.callTool({
+      name: 'aha_create_idea_portal_comment',
+      arguments: { ideaId: 'PRJ1-I-7', body: '<p>Thanks!</p>' }
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('passes visibility through and names the audience it just wrote to', async () => {
+    const seen: string[] = [];
+    patch('createIdeaPortalComment', async (_id: string, body: string, visibility: string) => {
+      seen.push(visibility);
+      return { id: 'IC-2', idea_id: 'PRJ1-I-7', body, visibility };
+    });
+    const client = await connected();
+
+    const pub: any = await client.callTool({
+      name: 'aha_create_idea_portal_comment',
+      arguments: { ideaId: 'PRJ1-I-7', body: '<p>We reconsidered.</p>', visibility: 'public' }
+    });
+    const limited: any = await client.callTool({
+      name: 'aha_create_idea_portal_comment',
+      arguments: { ideaId: 'PRJ1-I-7', body: '<p>Internal-ish.</p>', visibility: 'employee_or_creator' }
+    });
+
+    expect(seen).toEqual(['public', 'employee_or_creator']);
+    expect(pub.content[0].text).toContain('visible to all ideas portal users');
+    expect(limited.content[0].text).toContain("visible to employees and the idea's creator");
+    expect(pub.content.find((c: any) => c.type === 'resource_link').uri).toBe('aha://idea/PRJ1-I-7');
+  });
+
+  it('rejects a visibility value Aha does not accept', async () => {
+    patch('createIdeaPortalComment', async () => ({ id: 'IC-3' }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_create_idea_portal_comment',
+      arguments: { ideaId: 'PRJ1-I-7', body: '<p>x</p>', visibility: 'internal' }
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('annotates the reader read-only and both writers as non-idempotent writes', async () => {
+    const client = await connected();
+    const tools = (await client.listTools()).tools;
+
+    const reader = tools.find(t => t.name === 'aha_list_comments')!;
+    expect(reader.annotations!.readOnlyHint).toBe(true);
+    expect(reader.annotations!.destructiveHint).toBeUndefined();
+    expect(reader.annotations!.idempotentHint).toBeUndefined();
+
+    for (const name of ['aha_create_comment', 'aha_create_idea_portal_comment']) {
+      const writer = tools.find(t => t.name === name)!;
+      expect(writer.annotations!.readOnlyHint).toBe(false);
+      // A repeated call adds another comment; it does not replace the first.
+      expect(writer.annotations!.idempotentHint).toBe(false);
+      expect(writer.annotations!.destructiveHint).toBe(false);
+    }
+
+    for (const tool of tools) {
+      expect(tool.title).toBe(tool.annotations!.title as string);
+      expect(tool.outputSchema).toBeDefined();
+      expect(tool.annotations!.openWorldHint).toBe(true);
+    }
+  });
+
+  it('reports a failed read as isError, naming the record', async () => {
+    patch('getFeatureComments', async () => {
+      throw Object.assign(new Error('Request failed with status code 404'), {
+        isAxiosError: true,
+        response: { status: 404, headers: {} }
+      });
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'feature', recordId: 'PRJ1-123' }
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content[0].text).toContain('feature PRJ1-123');
+    // Aha 404s both for absent records and for ones the token cannot see.
+    expect(result.content[0].text).toContain('cannot see');
+  });
+
+  it('reports a failed portal write as isError without claiming it published', async () => {
+    patch('createIdeaPortalComment', async () => {
+      throw Object.assign(new Error('Request failed with status code 403'), {
+        isAxiosError: true,
+        response: { status: 403, headers: {} }
+      });
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_create_idea_portal_comment',
+      arguments: { ideaId: 'PRJ1-I-7', body: '<p>x</p>', visibility: 'public' }
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('403');
+    expect(result.content[0].text).not.toContain('Added portal comment');
+  });
+
+  it('says so plainly when a record has no comments at all', async () => {
+    patch('getIdeaComments', async () => ({ comments: [] }));
+    patch('getIdeaPortalComments', async () => ({ idea_comments: [] }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_comments',
+      arguments: { recordType: 'idea', recordId: 'PRJ1-I-9' }
+    });
+
+    // Naming both streams matters: "no comments" alone would leave a caller unsure whether
+    // the portal side was even looked at.
+    expect(result.content[0].text).toBe(
+      'No comments on idea PRJ1-I-9 (internal or ideas portal).'
+    );
+    expect(result.structuredContent.comments).toEqual([]);
+  });
+});

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -26,6 +26,8 @@ const mockAhaService = {
   getReleasePhaseComments: mock(() => Promise.resolve({ comments: [{ id: 'COMMENT-7', body: 'Test release phase comment' }] })),
   getRequirementComments: mock(() => Promise.resolve({ comments: [{ id: 'COMMENT-8', body: 'Test requirement comment' }] })),
   getTodoComments: mock(() => Promise.resolve({ comments: [{ id: 'COMMENT-9', body: 'Test todo comment' }] })),
+  getFeatureComments: mock(() => Promise.resolve({ comments: [{ id: 'COMMENT-10', body: 'Test feature comment' }] })),
+  getIdeaPortalComments: mock(() => Promise.resolve({ idea_comments: [{ id: 'IC-1', body: 'Test portal comment', visibility: 'Visible to all ideas portal users' }] })),
   getGoal: mock(() => Promise.resolve({ id: 'GOAL-123', name: 'Test Goal' })),
   listGoals: mock(() => Promise.resolve({ goals: [{ id: 'GOAL-1' }, { id: 'GOAL-2' }] })),
   getGoalEpics: mock(() => Promise.resolve({ epics: [{ id: 'EPIC-1' }, { id: 'EPIC-2' }] })),
@@ -67,6 +69,8 @@ describe('Resources', () => {
       getReleasePhaseComments: AhaService.getReleasePhaseComments,
       getRequirementComments: AhaService.getRequirementComments,
       getTodoComments: AhaService.getTodoComments,
+      getFeatureComments: AhaService.getFeatureComments,
+      getIdeaPortalComments: AhaService.getIdeaPortalComments,
       getGoal: AhaService.getGoal,
       listGoals: AhaService.listGoals,
       getGoalEpics: AhaService.getGoalEpics,
@@ -104,6 +108,8 @@ describe('Resources', () => {
     (AhaService as any).getReleasePhaseComments = mockAhaService.getReleasePhaseComments;
     (AhaService as any).getRequirementComments = mockAhaService.getRequirementComments;
     (AhaService as any).getTodoComments = mockAhaService.getTodoComments;
+    (AhaService as any).getFeatureComments = mockAhaService.getFeatureComments;
+    (AhaService as any).getIdeaPortalComments = mockAhaService.getIdeaPortalComments;
     (AhaService as any).getGoal = mockAhaService.getGoal;
     (AhaService as any).listGoals = mockAhaService.listGoals;
     (AhaService as any).getGoalEpics = mockAhaService.getGoalEpics;
@@ -169,6 +175,8 @@ describe('Resources', () => {
     (AhaService as any).getReleasePhaseComments = originalMethods.getReleasePhaseComments;
     (AhaService as any).getRequirementComments = originalMethods.getRequirementComments;
     (AhaService as any).getTodoComments = originalMethods.getTodoComments;
+    (AhaService as any).getFeatureComments = originalMethods.getFeatureComments;
+    (AhaService as any).getIdeaPortalComments = originalMethods.getIdeaPortalComments;
     (AhaService as any).getGoal = originalMethods.getGoal;
     (AhaService as any).listGoals = originalMethods.listGoals;
     (AhaService as any).getGoalEpics = originalMethods.getGoalEpics;
@@ -476,6 +484,50 @@ describe('Resources', () => {
   });
 
   describe('Comment Resources', () => {
+    describe('aha_feature_comments resource', () => {
+      it('should retrieve comments for feature', async () => {
+        // A feature could be commented on but not read back: aha_create_feature_comment
+        // existed with no matching read resource.
+        const handler = resourceHandlers.get('aha_feature_comments');
+        expect(handler).toBeDefined();
+
+        const uri = new URL('aha://comments/feature/FEAT-123');
+        const result = await handler!(uri, {}, {} as any);
+
+        expect(mockAhaService.getFeatureComments).toHaveBeenCalledWith('FEAT-123');
+        expect(result.contents[0].text).toContain('Test feature comment');
+      });
+
+      it('should throw error for missing feature ID', async () => {
+        const handler = resourceHandlers.get('aha_feature_comments');
+        const uri = new URL('aha://comments/feature/');
+
+        await expect(handler!(uri, {}, {} as any)).rejects.toThrow('Invalid feature ID: Feature ID is missing from URI');
+      });
+    });
+
+    describe('aha_idea_portal_comments resource', () => {
+      it('should retrieve the portal stream, which aha_idea_comments does not return', async () => {
+        const handler = resourceHandlers.get('aha_idea_portal_comments');
+        expect(handler).toBeDefined();
+
+        const uri = new URL('aha://idea-comments/IDEA-123');
+        const result = await handler!(uri, {}, {} as any);
+
+        expect(mockAhaService.getIdeaPortalComments).toHaveBeenCalledWith('IDEA-123');
+        // Kept a separate URI so neither resource silently changes meaning; the visibility
+        // is the field that distinguishes a portal comment from an internal one.
+        expect(result.contents[0].text).toContain('Visible to all ideas portal users');
+      });
+
+      it('should throw error for missing idea ID', async () => {
+        const handler = resourceHandlers.get('aha_idea_portal_comments');
+        const uri = new URL('aha://idea-comments/');
+
+        await expect(handler!(uri, {}, {} as any)).rejects.toThrow('Invalid idea ID: Idea ID is missing from URI');
+      });
+    });
+
     describe('aha_epic_comments resource', () => {
       it('should retrieve comments for epic', async () => {
         const handler = resourceHandlers.get('aha_epic_comments');


### PR DESCRIPTION
Follow-up to #321, from verifying what the comment surface could actually do. Gaps turned up in both directions, plus one silent omission that matters more than the rest.

## Reads and writes were inverted per record type

| | read | write |
|---|---|---|
| feature | ❌ no resource — but `GET /features/{id}/comments` works and the SDK has the method | ✅ `aha_create_feature_comment` |
| idea | ⚠️ internal only | ❌ |
| epic, initiative, goal, release, release phase, requirement, todo | ✅ | ❌ |

Comments were also resource-only, so on a client that does not surface resources to its model — the reason the `aha_get_*` readers exist — **no comment was readable at all**.

Now: `aha_list_comments` reads any commentable type, `aha_create_comment` writes to any type Aha has a create endpoint for. Workspaces stay read-only, because Aha's spec has GET but no POST for a workspace's comments — the `TARGETS` table has no `write` for `product` rather than failing at call time. `aha_create_feature_comment` stays (removing it would break callers for no gain) and now names which tool to prefer.

## An idea has two comment streams, and they are disjoint

`/ideas/{id}/comments` holds internal comments. `/ideas/{id}/idea_comments` holds the ideas-portal conversation, served by a different SDK class this server never used. On one live idea:

- `/comments` — 1 internal comment
- `/idea_comments` — 2 portal comments, `visibility: "Visible to all ideas portal users"`: a portal user asking *"Why are we rejecting this idea? Isn't Grafana meant to be the 'big tent'?"* and the reply explaining the rejection
- **zero overlapping ids**

Reading only the first looks complete while dropping the half that matters most for triage, and nothing in the payload hints the other half exists. `aha_list_comments` now reads both for ideas and stamps each comment with `source`, so an internal note is distinguishable from a customer-visible one:

```
3 comments on idea IDEASVOC-I-6938, internal and ideas portal:
- internal - Cedric Ziel: Given we are going to merge App O11y with asserts, this is not something…
- portal [Visible to all ideas portal users] - Matthew Fine: Why are we rejecting this idea? Isn't…
- portal [Visible to all ideas portal users] - unknown: Hi, Thanks for the question! - Back when…
```

The resources stay separate — `aha://comments/idea/{id}` for internal, `aha://idea-comments/{id}` for the portal — so neither URI quietly changes meaning.

## Publishing to customers is deliberate

`aha_create_idea_portal_comment` is its own tool with a **required** `visibility`. Aha defaults that field to `public`, so a caller omitting it publishes to customers by accident; requiring it turns a silent default into an explicit choice, and keeping the customer-facing write separate from `aha_create_comment` lets a host gate it on its own. Omitting it fails validation:

```
MCP error -32602: Invalid arguments for tool aha_create_idea_portal_comment:
  Invalid option: expected one of "public"|"employee_or_creator"
```

Note the field reads and writes in different vocabularies — responses carry a phrase, requests take `public` / `employee_or_creator` — so nothing maps between them. That, and the disjoint streams, are recorded in `CLAUDE.md` alongside the other measured-not-documented behaviours.

## Verification

Against a live account: the thread above is real output, feature comments read for the first time, and both new resources return their respective streams (1 comment / 2 portal comments).

**No comment was created anywhere.** The write paths were exercised against non-existent parents, which proves the route, the request shape, the token's authorisation and the error mapping without a side effect — each returns the mapped 404 rather than an SDK TypeError:

```
aha_create_comment epic FEO11Y-E-99999999      -> isError: epic … was not found (HTTP 404)
aha_create_comment goal APPO11Y-G-99999999     -> isError: goal … was not found (HTTP 404)
aha_create_idea_portal_comment IDEASVOC-I-99…  -> isError: idea … was not found (HTTP 404)
```

A successful create is the one thing not exercised live, since any real POST would notify watchers — say the word and I'll run one internal comment against a record you nominate.

- **457 tests pass, 0 fail** (20 new: `test/comment-tools.test.ts` plus the two resources)
- `manifest.json` regenerated — 39 tools; `mcpb validate` passes; `tsc` clean apart from the pre-existing `sse` comparison
- `node build/index.js --help` starts clean

Also fixed: the `aha_get_*` descriptions from #321 said "a epic" and "a idea".

## Not addressed

`README.md`'s intro still describes offline SQLite sync and vector embeddings, which were removed before I got here. I corrected the stale tool count next to it but left the architecture prose alone rather than widen this PR.
