### PR TITLE
docs: list aha_list_comments among the read-only tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,8 +303,8 @@ Every tool is registered with an annotations argument, and the e2e suite fails i
 missing. Conventions used here:
 
 - `title` is a short human-readable label for client UIs.
-- `readOnlyHint` is true only for tools that never write: `aha_search`, the five `aha_get_*`
-  readers, `server_status`, `get_server_config`, `server_health_check`,
+- `readOnlyHint` is true only for tools that never write: `aha_search`, `aha_list_comments`,
+  the five `aha_get_*` readers, `server_status`, `get_server_config`, `server_health_check`,
   `test_configuration`.
 - `destructiveHint` and `idempotentHint` are **omitted** when `readOnlyHint` is true - the
   spec only gives them meaning for writers.


### PR DESCRIPTION
`CLAUDE.md`'s tool-annotation section enumerates which tools carry `readOnlyHint`, and `aha_list_comments` was missing from it — the code is annotated correctly, the list had just drifted. An enumerated list that drifts is worse than no list, since the next reader trusts it and concludes the annotation was forgotten.

Prompted by a question about whether the last two PRs annotated everything, so I audited all 39 registered tools against every convention the file states:

| convention | result |
|---|---|
| `annotations` present | ✅ 39/39 |
| `title` identical in both spec locations | ✅ 39/39 |
| `readOnlyHint` / `openWorldHint` boolean | ✅ 39/39 |
| `destructiveHint` + `idempotentHint` omitted when read-only | ✅ |
| both present when writing | ✅ |
| no `create_*` claiming idempotency | ✅ |
| `outputSchema` on every tool | ✅ |
| draft-07 input dialect where args exist | ✅ |

The eight tools added in #321 and #323:

```
aha_get_feature                  ro=true  dest=—     idem=—     ow=true
aha_get_epic                     ro=true  dest=—     idem=—     ow=true
aha_get_idea                     ro=true  dest=—     idem=—     ow=true
aha_get_initiative               ro=true  dest=—     idem=—     ow=true
aha_get_release                  ro=true  dest=—     idem=—     ow=true
aha_list_comments                ro=true  dest=—     idem=—     ow=true
aha_create_comment               ro=false dest=false idem=false ow=true
aha_create_idea_portal_comment   ro=false dest=false idem=false ow=true
```

No code changes. Resources are unannotated here, which matches every other resource in the file — the repo does not use resource-level annotations.