### PR TITLE
fix: advertise tool output schemas in JSON Schema 2020-12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,14 +428,49 @@ what it protects is Aha's API, which all sessions share. Default 120/minute, set
 
 #### Schema dialects
 
-Input and output schemas are advertised as draft-07, because `toJsonSchemaCompat` in the
-SDK converts Zod with a hardcoded `draft-7` target and never passes `target` for tools. The
-spec permits an explicit dialect and only *recommends* 2020-12, so this conforms; it changes
-when the SDK lets the target through, not before. Zero-argument tools use
-`z.strictObject({}).optional()` and emit no `$schema`, so they default to 2020-12 - and,
-unlike the raw `{}` shape they replaced, they accept a `tools/call` with `arguments` omitted
-entirely, which the spec allows. An e2e test pins the dialects so an SDK upgrade surfaces
-here rather than in a client.
+The SDK converts Zod with a hardcoded `draft-7` target and never passes `target` for tools
+(`toJsonSchemaCompat`), so everything it emits is labelled draft-07. The spec permits an
+explicit dialect and only *recommends* 2020-12 - but **"permitted" is not "accepted"**:
+Claude Code's validator implements the recommendation and nothing else, and refused *every
+tool on this server at once* with `invalid outputSchema: JSON Schema declares an unsupported
+dialect`. Reads, writes and the diagnostics tools all went with it, so there was no tool left
+to diagnose the server with. A dialect a client will not compile does not degrade a result, it
+removes the tool.
+
+So the two sides are advertised differently, and that asymmetry is deliberate:
+
+- **Output schemas are relabelled to 2020-12** by `installOutputSchemaDialect`
+  (`src/core/schema-dialect.ts`), installed in `startServer()` **before** any registration,
+  next to `installToolRateLimit` and for the same reason - it wraps `server.registerTool`, so
+  a tool registered ahead of it keeps the SDK default. It tags the registered schema with
+  Zod's `.meta({ $schema })`, which lands in the emitted document and overrides the target's
+  own `$schema`. That is what keeps this on the public registration API instead of patching
+  the SDK's private `tools/list` handler. `.meta()` clones rather than mutates, which is why
+  the tag belongs at registration and not beside each schema's definition: several output
+  schemas nest inside others (`keyResultOutputSchema` inside `keyResultsListOutputSchema`),
+  and a nested subschema carrying its own `$schema` is meaningless.
+- **Input schemas stay on draft-07.** Every client measured accepts them, and relabelling a
+  dialect nothing has rejected would be a change with no evidence behind it. An e2e assertion
+  pins both sides so they cannot drift silently.
+
+**The relabel is verified, not asserted.** `schema-dialect.test.ts` compares the advertised
+document for all 19 output schemas against `z.toJSONSchema(schema, { target: 'draft-2020-12',
+io: 'output' })` and requires them equal - today every body is byte-identical between the two
+targets, so the label is true rather than optimistic. If a future field makes them diverge
+(tuples emit `items` vs `prefixItems`, definitions `definitions` vs `$defs`) that test fails,
+and the fix at that point is converting at the right target, not loosening the comparison.
+Relabelling stays safe for the SDK's own client, which compiles the advertised schema with
+draft-07 Ajv at `validateSchema: false` and accepts a 2020-12 label - fixing one client by
+breaking another is not a fix, so a real call through a real client is part of that test file.
+
+An `outputSchema` given as a raw Zod shape has no `.meta()` to tag and keeps the draft-07
+label, with a warning: wrapping the shape here would change its `additionalProperties`
+semantics to fix a dialect. The e2e assertion over the real tool list is what stops that
+passing unnoticed.
+
+Zero-argument tools use `z.strictObject({}).optional()` and emit no `$schema`, so they default
+to 2020-12 - and, unlike the raw `{}` shape they replaced, they accept a `tools/call` with
+`arguments` omitted entirely, which the spec allows.
 
 ### Resources
 

--- a/src/core/schema-dialect.ts
+++ b/src/core/schema-dialect.ts
@@ -1,0 +1,93 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { log } from "./logger.js";
+
+/**
+ * The JSON Schema dialect the tool **output** schemas are advertised in.
+ *
+ * The SDK converts Zod with a hardcoded `draft-7` target and never passes `target` for tools
+ * (`toJsonSchemaCompat` in `server/zod-json-schema-compat.js`), so every schema it emits is
+ * labelled `http://json-schema.org/draft-07/schema#`. The spec permits an explicit dialect
+ * and only *recommends* 2020-12, but a client whose validator implements the recommendation
+ * and nothing else rejects the tool outright - measured in Claude Code, which refused every
+ * tool on this server with *"invalid outputSchema: JSON Schema declares an unsupported
+ * dialect"*, diagnostics and reads included. A dialect a client will not compile is worse
+ * than none: it does not degrade the result, it removes the tool.
+ *
+ * Only the output schemas are relabelled. Input schemas stay on the SDK's draft-07 and are
+ * accepted as-is by the clients this was measured against, and rewriting a dialect nothing
+ * has complained about would be a change with no evidence behind it.
+ */
+export const OUTPUT_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
+
+/**
+ * Wrap `server.registerTool` so every tool registered afterwards advertises its output
+ * schema in {@link OUTPUT_SCHEMA_DIALECT}.
+ *
+ * The relabelling works through Zod's metadata registry rather than by editing the converted
+ * JSON Schema: `.meta({ $schema })` lands in the emitted document and overrides the target's
+ * own `$schema`, which is what lets this sit on the public registration API instead of
+ * reaching into the SDK's private `tools/list` handler to patch its output.
+ *
+ * The tag goes on a *clone* - `.meta()` does not mutate its receiver - which is why this
+ * belongs at registration rather than beside each schema's definition. Several output
+ * schemas are also nested inside others (`keyResultOutputSchema` inside
+ * `keyResultsListOutputSchema`), and a nested subschema carrying its own `$schema` is
+ * meaningless; tagging the registered root leaves those occurrences untouched.
+ *
+ * Patching the registrar rather than the 19 schema declarations is the same bargain
+ * `installToolRateLimit` makes: tools are registered from five modules, and something that
+ * has to be remembered at every declaration is something that will be missed at the next
+ * one.
+ *
+ * Call before registering any tools - a tool registered ahead of this keeps the SDK default.
+ */
+export function installOutputSchemaDialect(server: McpServer): void {
+  const originalRegisterTool = server.registerTool.bind(server);
+
+  (server as unknown as Record<string, unknown>).registerTool = (
+    name: string,
+    config: unknown,
+    ...rest: unknown[]
+  ) => {
+    return (originalRegisterTool as (...args: unknown[]) => unknown)(
+      name,
+      withOutputSchemaDialect(name, config),
+      ...rest
+    );
+  };
+}
+
+/**
+ * Return `config` with its `outputSchema` tagged, or unchanged when there is nothing to tag.
+ *
+ * A tool with no output schema is left alone: the spec makes `outputSchema` optional, and
+ * inventing one here would commit the tool to returning `structuredContent`.
+ */
+function withOutputSchemaDialect(name: string, config: unknown): unknown {
+  if (!config || typeof config !== "object") return config;
+
+  const outputSchema = (config as { outputSchema?: unknown }).outputSchema;
+  if (!outputSchema || typeof outputSchema !== "object") return config;
+
+  const meta = (outputSchema as { meta?: unknown }).meta;
+  if (typeof meta !== "function") {
+    // A raw Zod shape rather than a schema instance. The SDK accepts one and converts it to
+    // an object schema itself, so the tool still works - it just keeps the draft-07 label,
+    // and wrapping the shape here would change its `additionalProperties` semantics to fix a
+    // dialect. Logged rather than thrown, and asserted over the real tool list in
+    // schema-dialect.test.ts so it cannot pass unnoticed.
+    log.warn("Tool output schema left in the SDK's default dialect", {
+      tool: name,
+      reason: "outputSchema is not a Zod schema instance",
+      expected: OUTPUT_SCHEMA_DIALECT
+    });
+    return config;
+  }
+
+  return {
+    ...(config as object),
+    outputSchema: (meta as (metadata: Record<string, unknown>) => unknown).call(outputSchema, {
+      $schema: OUTPUT_SCHEMA_DIALECT
+    })
+  };
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,7 @@ import { buildServerInstructions } from "../core/instructions.js";
 import * as services from "../core/services/index.js";
 import { ConfigService } from "../core/config.js";
 import { installToolRateLimit } from "../core/rate-limit.js";
+import { installOutputSchemaDialect } from "../core/schema-dialect.js";
 import {
   configureServerOutputSchema,
   healthCheckOutputSchema,
@@ -135,9 +136,12 @@ async function startServer() {
       { instructions: buildServerInstructions(config.company) }
     );
 
-    // Before any registerTool call: the limiter works by wrapping the registrar, so tools
-    // registered ahead of this line would not be covered.
+    // Both of these work by wrapping the registrar, so they have to come before any
+    // registerTool call - a tool registered ahead of these lines is neither rate limited nor
+    // relabelled. Order between them does not matter: one wraps the handler, the other the
+    // config.
     installToolRateLimit(server);
+    installOutputSchemaDialect(server);
 
     // Add health check tool
     server.registerTool(

--- a/test/e2e-streamable-http.test.ts
+++ b/test/e2e-streamable-http.test.ts
@@ -252,6 +252,18 @@ describe('E2E Streamable HTTP Transport', () => {
           // MUST be a valid schema object with an object root.
           expect((tool.inputSchema as any).type).toBe('object');
         }
+
+        // Output schemas are relabelled to 2020-12 by installOutputSchemaDialect, because a
+        // validator implementing only the recommended dialect rejects the tool outright rather
+        // than degrading - which is what happened in Claude Code, to every tool at once. Run
+        // over the spawned server so the tools registered in server.ts (server_status and the
+        // configuration tools) are covered too, not just the ones registerTools adds.
+        const outputDialects = tools.map(t => ({
+          name: t.name,
+          dialect: (t.outputSchema as any)?.$schema
+        }));
+        expect(outputDialects.filter(t => t.dialect !== 'https://json-schema.org/draft/2020-12/schema'))
+          .toEqual([]);
       });
     }, 30000);
 

--- a/test/schema-dialect.test.ts
+++ b/test/schema-dialect.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import * as z from 'zod/v4';
+import { registerTools } from '../src/core/tools.js';
+import * as toolOutput from '../src/core/tool-output.js';
+import { OUTPUT_SCHEMA_DIALECT, installOutputSchemaDialect } from '../src/core/schema-dialect.js';
+
+/**
+ * The dialect a tool advertises decides whether a client will compile its schema at all -
+ * Claude Code refused every tool on this server while the output schemas carried the SDK's
+ * draft-07 label. So these assertions run over what `tools/list` actually puts on the wire,
+ * not over the Zod schemas, and the honesty check below compares the advertised document
+ * against a genuine 2020-12 conversion rather than trusting the relabel.
+ */
+
+const SDK_DEFAULT_DIALECT = 'http://json-schema.org/draft-07/schema#';
+
+async function listTools(register: (server: McpServer) => void) {
+  const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+  installOutputSchemaDialect(server);
+  register(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  return { client, tools: (await client.listTools()).tools };
+}
+
+/** Every output schema this server declares, by export name. */
+const OUTPUT_SCHEMAS = Object.entries(toolOutput).filter(([name]) =>
+  name.endsWith('OutputSchema')
+) as [string, z.ZodType][];
+
+describe('installOutputSchemaDialect', () => {
+  it('advertises every registered tool output schema in 2020-12', async () => {
+    const { tools } = await listTools(registerTools);
+
+    // Guards the premise: a tool with no output schema would pass the loop below vacuously.
+    expect(tools.length).toBeGreaterThan(30);
+    expect(tools.filter(t => !t.outputSchema).map(t => t.name)).toEqual([]);
+
+    const wrong = tools
+      .map(t => ({ name: t.name, dialect: (t.outputSchema as Record<string, unknown>).$schema }))
+      .filter(t => t.dialect !== OUTPUT_SCHEMA_DIALECT);
+    expect(wrong).toEqual([]);
+  });
+
+  it('leaves input schemas in the dialect the SDK emits', async () => {
+    const { tools } = await listTools(registerTools);
+
+    // Not an oversight. Input schemas are accepted as draft-07 by the clients this was
+    // measured against, and relabelling a dialect nothing has rejected would be a change with
+    // no evidence behind it. Pinned so the two sides cannot drift silently.
+    for (const tool of tools) {
+      const dialect = (tool.inputSchema as Record<string, unknown>).$schema;
+      // Zero-argument tools emit no $schema and so default to 2020-12, per the spec.
+      expect([SDK_DEFAULT_DIALECT, undefined]).toContain(dialect);
+    }
+  });
+
+  it('advertises exactly what a 2020-12 conversion of the same schema would', async () => {
+    // The relabel would be a lie if the draft-07 target emitted a document the newer dialect
+    // reads differently - tuples (`items` vs `prefixItems`) and `$defs` are the usual
+    // divergences. Comparing per schema means a future field that does diverge fails here
+    // rather than in a client, and the fix at that point is converting at the right target
+    // instead of relabelling.
+    const { tools } = await listTools(server => {
+      for (const [name, schema] of OUTPUT_SCHEMAS) {
+        server.registerTool(
+          name,
+          {
+            title: name,
+            description: `Probe for ${name}`,
+            inputSchema: z.strictObject({}).optional(),
+            outputSchema: schema,
+            annotations: { title: name, readOnlyHint: true, openWorldHint: false }
+          },
+          async () => ({ content: [], structuredContent: {} })
+        );
+      }
+    });
+
+    expect(tools.length).toBe(OUTPUT_SCHEMAS.length);
+
+    for (const [name, schema] of OUTPUT_SCHEMAS) {
+      const advertised = tools.find(t => t.name === name)!.outputSchema;
+      const native = z.toJSONSchema(schema, { target: 'draft-2020-12', io: 'output' });
+      expect(advertised).toEqual(native as unknown as typeof advertised);
+    }
+  });
+
+  it('does not give an output schema to a tool that declared none', async () => {
+    const { tools } = await listTools(server => {
+      server.registerTool(
+        'no_output',
+        {
+          title: 'No output',
+          description: 'Declares no output schema',
+          inputSchema: z.strictObject({}).optional(),
+          annotations: { title: 'No output', readOnlyHint: true, openWorldHint: false }
+        },
+        async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })
+      );
+    });
+
+    // `outputSchema` is optional in the spec, and inventing one would commit the tool to
+    // returning structuredContent it does not produce.
+    expect(tools[0].outputSchema).toBeUndefined();
+  });
+
+  it('leaves a raw shape alone rather than changing what it means', async () => {
+    const { tools } = await listTools(server => {
+      server.registerTool(
+        'raw_shape_output',
+        {
+          title: 'Raw shape output',
+          description: 'Declares its output as a raw Zod shape',
+          inputSchema: z.strictObject({}).optional(),
+          // A shape, not a schema instance: there is no `.meta()` to tag, and wrapping it
+          // would change its additionalProperties semantics to fix a dialect. It keeps the
+          // SDK default and the registrar logs a warning; the first assertion in this file is
+          // what stops a real tool from being registered this way unnoticed.
+          outputSchema: { value: z.string() },
+          annotations: { title: 'Raw shape output', readOnlyHint: true, openWorldHint: false }
+        },
+        async () => ({
+          content: [{ type: 'text' as const, text: 'ok' }],
+          structuredContent: { value: 'ok' }
+        })
+      );
+    });
+
+    expect((tools[0].outputSchema as Record<string, unknown>).$schema).toBe(SDK_DEFAULT_DIALECT);
+  });
+
+  it('still validates a real record client-side under the relabelled schema', async () => {
+    // The SDK client compiles the advertised schema with draft-07 Ajv, so the relabel has to
+    // remain compilable there too - fixing one client by breaking another is not a fix. The
+    // client throws on a schema it cannot compile or a payload it rejects, so a call that
+    // returns is the assertion.
+    const { client } = await listTools(server => {
+      server.registerTool(
+        'probe_feature',
+        {
+          title: 'Probe feature',
+          description: 'Returns a feature-shaped record',
+          inputSchema: z.strictObject({}).optional(),
+          outputSchema: toolOutput.featureOutputSchema,
+          annotations: { title: 'Probe feature', readOnlyHint: true, openWorldHint: false }
+        },
+        async () => {
+          const feature = {
+            id: '6971110726488350000',
+            reference_num: 'PRJ1-123',
+            name: 'Structured output',
+            url: 'https://test.aha.io/features/PRJ1-123',
+            progress: 40,
+            workflow_status: { id: '1', name: 'In development', complete: false },
+            // Undescribed by the schema, and has to survive: Aha returns far more than is
+            // typed, so the advertised schema must stay open after the relabel.
+            custom_fields: [{ key: 'team', value: 'platform' }]
+          };
+          return {
+            content: [{ type: 'text' as const, text: feature.reference_num }],
+            structuredContent: feature
+          };
+        }
+      );
+    });
+
+    const result: any = await client.callTool({ name: 'probe_feature', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent.reference_num).toBe('PRJ1-123');
+    expect(result.structuredContent.custom_fields).toEqual([{ key: 'team', value: 'platform' }]);
+  });
+});


### PR DESCRIPTION
## What broke

Every tool on the server was rejected by Claude Code, reads and diagnostics included:

```
invalid outputSchema: JSON Schema declares an unsupported dialect
("$schema": "http://json-schema.org/draft-07/schema#").
The default validator supports JSON Schema 2020-12 only
```

No dialect string existed in `src/`. The label comes from the SDK: `toJsonSchemaCompat`
(`@modelcontextprotocol/sdk@1.30.0`) maps a missing `target` to `draft-7`, and `server/mcp.js`
never passes `target` when converting for `tools/list`. Adding `outputSchema` to all 48 tools
therefore put a draft-07 label on all 48 at once. The spec permits an explicit dialect and only
*recommends* 2020-12 — but a validator that implements the recommendation and nothing else does
not degrade the result, it removes the tool, and it took the tools needed to diagnose that with it.

## The fix

`installOutputSchemaDialect` (`src/core/schema-dialect.ts`) wraps `server.registerTool` and tags
each `outputSchema` with Zod's `.meta({ $schema: "https://json-schema.org/draft/2020-12/schema" })`,
which lands in the emitted document and overrides the target's own `$schema`. Installed in
`startServer()` alongside `installToolRateLimit`, before any registration.

- **Wrapping the registrar, not the 19 declarations** — the same bargain the rate limiter makes:
  tools are registered from five modules, and something to be remembered at every declaration
  gets missed at the next one.
- **Zod metadata, not a patched handler** — keeps this on the public registration API instead of
  reaching into the SDK's private `tools/list` handler.
- **`.meta()` clones rather than mutates** — which is why the tag belongs at registration and not
  at each definition: `keyResultOutputSchema` nests inside `keyResultsListOutputSchema`, and a
  nested subschema carrying its own `$schema` is meaningless.
- **Input schemas stay on draft-07.** Every client measured accepts them; relabelling a dialect
  nothing has rejected would be a change with no evidence behind it. An e2e assertion pins both
  sides so they cannot drift silently.

## Verification

Over a real spawned stdio server, all 48 tools:

```
 4 x  input: (none)                                  | output: .../draft/2020-12/schema
44 x  input: http://json-schema.org/draft-07/schema#  | output: .../draft/2020-12/schema
```

`test/schema-dialect.test.ts` makes the relabel checkable rather than asserted: for all 19 output
schemas the advertised document is compared against `z.toJSONSchema(schema, { target:
'draft-2020-12', io: 'output' })` and required to be equal — today every body is byte-identical
between the two targets, so the label is true. If a future field makes them diverge (`items` vs
`prefixItems`, `definitions` vs `$defs`) that test fails, and the fix then is converting at the
right target rather than loosening the comparison. A call through a real client is in that file
too: the SDK's own client compiles the advertised schema with draft-07 Ajv at
`validateSchema: false` and accepts a 2020-12 label, so this does not fix one client by breaking
another.

An `outputSchema` given as a raw Zod shape has no `.meta()` to tag and keeps the SDK default with
a logged warning — wrapping the shape would change its `additionalProperties` semantics to fix a
dialect. The assertion over the real tool list is what stops that passing unnoticed.

Full suite: 505 pass, 0 fail. `manifest:check` clean (the manifest carries no schemas).
`bun run build` + `node build/index.js --help` fine.

## Not covered

No write tool was called against a real Aha record. The dialect comes from the registrar rather
than per tool, and the assertion runs over the whole `tools/list`, writes included — what is
untested is a real mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool output schemas now advertise compatibility with JSON Schema 2020-12.
  * Input schemas continue using their existing schema format.
  * Tools without output schemas remain unchanged.
  * Output validation and compatibility are preserved for supported schema types.

* **Documentation**
  * Added guidance on schema formats, registration order, nested schemas, validation, and client compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->