### PR TITLE
feat: enumerate a release's features as a tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,47 @@ Measured against a live account, not taken from `@cedricziel/aha-js`' fixture-de
   emits none. The difference is coverage: every record in this result is the same type and has
   a resource template, so linking is complete rather than partial.
 
+### Release membership
+
+`src/core/tools/release-tools.ts` holds `aha_list_release_features`, wrapping
+`GET /releases/{id}/features` - the same endpoint the `aha://release/{release_id}/features`
+resource has always read. It exists because **`aha_search` cannot enumerate**: it is
+relevance-ranked, it cannot be asked for every record in a scope, and a hit carries no
+per-type fields, so release membership is not visible on one at all. Reported from a real
+session, search surfaced 4 features of a release holding 16, and the only clue the list was
+short was a gap in the `position` values. A partial list that reads as complete is worse than
+an error, which is why this tool is not just a convenience over the resource.
+
+Measured against a live account, not taken from Aha's docs:
+
+- **The endpoint pages, and its default page size is 30.** A release with 59 features answers
+  with 30 and `pagination: { total_records: 59, total_pages: 2, current_page: 1 }`; the same
+  release with `per_page=500` returns all 59 in one page, so Aha's own ceiling was not
+  observable below 200. `per_page=5` on a 16-feature release gave 5 across 4 pages.
+  `AhaService.getReleaseFeatures()` therefore takes `page` and `perPage`, and the tool asks
+  for 200 by default: the common request is "list this release", and Aha's default would
+  answer it with a page that reads like a release.
+- **`pagination` is part of the contract here, not a pass-through extra.** It is described in
+  `releaseFeaturesListOutputSchema`, forwarded whenever Aha sends it, and the text block says
+  `30 of 59 features` plus which page to ask for next. Do not drop it to save tokens - it is
+  the only thing distinguishing 30-of-30 from 30-of-59.
+- **The endpoint returns identity fields only** (`created_at, id, name, product_id,
+  reference_num, resource, url`) - no `workflow_status`, no assignee. This is the same
+  measurement the tier-1 rendering of the matching resource rests on, so the tool's
+  description points at `aha_get_feature` for the state of any one feature rather than
+  implying it returns state.
+- This endpoint is reached with `fetch` rather than through `aha-js`, whose generated method
+  returns `void`, so the query string is hand-built and pinned by a test.
+
+`aha_list_release_features` emits one `resource_link` per feature: every record is a feature
+and features have a single-record template, so coverage is complete - the same test
+`aha_list_key_results` passes and `aha_search` fails. Block count is bounded by `perPage`,
+which the caller sets, rather than by a cap here that would drop links silently.
+
+The sibling gap is still open: `getReleaseEpics` has no tool, so a release organised around
+epics is enumerable only as a resource. Same shape, same argument - add it with a test rather
+than assuming this file's measurements transfer.
+
 ### Error handling
 
 Aha's REST failures are mapped by `src/core/services/aha-errors.ts` rather than surfaced
@@ -258,8 +299,8 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
   does not cover. Reads credentials via `AhaService.getCredentials()` so `configure_server`
   applies at runtime
 - **ConfigService**: Manages runtime configuration with file persistence and validation
-- **Tools**: 48 MCP tools (CRUD, single-record reads, comments, OKRs, search, health checks,
-  configuration), none of which keep local state
+- **Tools**: 49 MCP tools (CRUD, single-record reads, collection reads, comments, OKRs,
+  search, health checks, configuration), none of which keep local state
 - **Resources**: 40+ resource types for accessing Aha.io entities via URI schemes. Every
   registration carries `annotations` from `resourceAnnotations()`, and collection reads are
   rendered per a three-tier policy rather than uniform JSON - see "Resource output: rendering
@@ -345,8 +386,8 @@ missing. Conventions used here:
 
 - `title` is a short human-readable label for client UIs.
 - `readOnlyHint` is true only for tools that never write: `aha_search`, `aha_list_comments`,
-  the five `aha_get_*` readers, `server_status`, `get_server_config`, `server_health_check`,
-  `test_configuration`.
+  `aha_list_release_features`, `aha_list_key_results`, the `aha_get_*` readers,
+  `server_status`, `get_server_config`, `server_health_check`, `test_configuration`.
 - `destructiveHint` and `idempotentHint` are **omitted** when `readOnlyHint` is true - the
   spec only gives them meaning for writers.
 - `destructiveHint: true` covers the deletes plus the two PUT endpoints that replace a whole

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download `aha-mcp-v<version>.mcpb` from the [latest release](https://github.com/
 and open it with Claude Desktop, which will prompt you for your Aha.io subdomain and API
 token. No Node.js or Docker setup and no manual JSON editing required.
 
-The extension exposes 48 tools that query Aha.io directly, so results are always current and
+The extension exposes 49 tools that query Aha.io directly, so results are always current and
 nothing is stored locally. Cross-record search is served by Aha.io's own index — see
 [Search](#-search).
 
@@ -466,6 +466,19 @@ resources to its model or not, and several do not — on those, every read here 
 unreachable, leaving write tools with no way to see what they were about to replace.
 `aha_search` is not a substitute, as it cannot return per-record fields.
 
+#### Collection Read Tools
+- `aha_list_release_features`: List the features assigned to a release, with a link per feature and Aha's total for the release
+- `aha_list_key_results`: List a goal's key results, with status, progress and metrics
+- `aha_list_comments`: List the comments on a record, both streams for an idea
+
+`aha_list_release_features` is the only way to enumerate a release. `aha_search` is
+relevance-ranked, returns no release membership on a hit and cannot be asked for every record
+in a scope, so a release list assembled from search results is partial — and nothing in it says
+so. The tool asks for 200 features per page (Aha's own default is 30) and always returns Aha's
+pagination block, so a caller can tell a complete list from the front of a longer one. Aha
+returns identity fields only on this endpoint, so use `aha_get_feature` for the state of any
+one feature.
+
 #### Write Operation Tools
 - `aha_create_feature_comment`: Create a comment on a feature
 - `aha_create_initiative_in_product`: Create an initiative within a specific product
@@ -576,7 +589,7 @@ The MCP server now provides comprehensive lifecycle management for Aha.io entiti
 - **Comprehensive Entity Coverage**: Full CRUD operations for features, epics, ideas, and competitors
 
 #### Technical Achievements
-- **48 MCP tools**, all querying Aha.io directly — no local state
+- **49 MCP tools**, all querying Aha.io directly — no local state
 - **17 listed MCP resources** covering the entity set, plus templated resource URIs
 - **17 domain-specific prompts** (workflow automation)
 - **32 core CRUD and write operation tools** for complete lifecycle management, including OKRs (goals and key results)

--- a/manifest.json
+++ b/manifest.json
@@ -179,6 +179,10 @@
       "description": "List the key results belonging to a goal in Aha.io. This is how you get the id of a key result before updating it: aha_search cannot return a key result's metrics or status, and the abbreviated copies inside a goal are not the full records. Returns each key result with its status, progress and metrics, plus a link per key result."
     },
     {
+      "name": "aha_list_release_features",
+      "description": "List the features assigned to a release in Aha.io. This is the only way to enumerate a release: aha_search is relevance-ranked, returns no release membership on a hit, and cannot be asked for every record in a scope, so a search-built list of a release is partial without saying so. Requests 200 features per page by default (Aha's own default is 30); returns each feature with a link to it, plus Aha's pagination block naming the total on the release so a caller can tell a complete list from the front of a longer one. Aha returns identity fields only here - no workflow status - so follow up with aha_get_feature for the state of one."
+    },
+    {
       "name": "aha_move_feature_to_release",
       "description": "Move a feature to a different release in Aha.io. Returns the updated feature and a link to it."
     },

--- a/src/core/services/aha-service.interface.ts
+++ b/src/core/services/aha-service.interface.ts
@@ -246,7 +246,7 @@ export interface IAhaService {
 
   // Relationships
   getGoalEpics(goalId: string): Promise<GoalEpicsResponse>;
-  getReleaseFeatures(releaseId: string): Promise<ReleaseFeaturesResponse>;
+  getReleaseFeatures(releaseId: string, page?: number, perPage?: number): Promise<ReleaseFeaturesResponse>;
   getReleaseEpics(releaseId: string): Promise<EpicsListResponse>;
   getInitiativeEpics(initiativeId: string): Promise<EpicsListResponse>;
 

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -596,7 +596,11 @@ export class MockAhaService implements IAhaService {
     return { epics: [] } as GoalEpicsResponse;
   }
 
-  async getReleaseFeatures(_releaseId: string): Promise<ReleaseFeaturesResponse> {
+  async getReleaseFeatures(
+    _releaseId: string,
+    _page?: number,
+    _perPage?: number
+  ): Promise<ReleaseFeaturesResponse> {
     return { features: [] } as ReleaseFeaturesResponse;
   }
 

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1484,14 +1484,31 @@ export class AhaService {
 
   /**
    * Get features associated with a specific release
+   *
+   * Paged, and deliberately so. Measured against a live account, `/releases/{id}/features`
+   * returns **30 records** when asked for no page size, alongside a `pagination` block naming
+   * the real total - so a caller that took the first response for the whole release silently
+   * lost everything past the 30th feature. `per_page` is honoured (5 gave 5 of 16 across 4
+   * pages; 500 gave all 59 of a 59-feature release, so Aha's own ceiling was not observable
+   * below 200), and `page` walks the rest.
+   *
    * @param releaseId The ID of the release
-   * @returns A list of features associated with the release
+   * @param page 1-based page number (optional; Aha defaults to 1)
+   * @param perPage Number of items per page (optional; Aha defaults to 30)
+   * @returns The features on the release, with Aha's pagination block
    */
-  public static async getReleaseFeatures(releaseId: string): Promise<ReleaseFeaturesResponse> {
+  public static async getReleaseFeatures(
+    releaseId: string,
+    page?: number,
+    perPage?: number
+  ): Promise<ReleaseFeaturesResponse> {
     try {
       // Use direct API call since SDK method returns void
       const basePath = `https://${this.subdomain}.aha.io/api/v1`;
-      const url = `${basePath}/releases/${releaseId}/features`;
+      const query = new URLSearchParams();
+      if (page !== undefined) query.set('page', String(page));
+      if (perPage !== undefined) query.set('per_page', String(perPage));
+      const url = `${basePath}/releases/${releaseId}/features${query.size > 0 ? `?${query}` : ''}`;
 
       const response = await fetch(url, {
         headers: {

--- a/src/core/tool-output.ts
+++ b/src/core/tool-output.ts
@@ -317,6 +317,28 @@ export const keyResultsListOutputSchema = z.object({
     .describe("Aha's pagination block, when the response carried one")
 });
 
+/**
+ * `aha_list_release_features` builds this itself, so the wrapper is closed; the features
+ * inside are Aha records and are not.
+ *
+ * `pagination` is described rather than left to pass through, and the tool always sends it
+ * when Aha does. This is the field that says whether the list is the release or just the
+ * front of it: `/releases/{id}/features` answers with 30 features when asked for no page
+ * size, so a caller reading only the array cannot tell 30-of-30 from 30-of-59.
+ */
+export const releaseFeaturesListOutputSchema = z.object({
+  release_id: z.string().describe("Release whose features these are, as it was requested"),
+  features: z.array(featureOutputSchema).describe("Features on the release, for the page requested"),
+  pagination: z
+    .looseObject({
+      total_records: z.number().optional().describe("Features on the release in total, across all pages"),
+      total_pages: z.number().optional().describe("Pages at the page size used"),
+      current_page: z.number().optional().describe("Page this result came from")
+    })
+    .optional()
+    .describe("Aha's pagination block, when the response carried one. Compare total_records with the length of `features` before treating this as the whole release.")
+});
+
 export const commentOutputSchema = z.looseObject({
   id: z.union([z.string(), z.number()]).optional().describe("Comment id"),
   created_at: z.string().optional().describe("ISO 8601 creation timestamp"),

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -5,6 +5,7 @@ import { registerSearchTools } from "./tools/search-tools.js";
 import { registerRecordTools } from "./tools/record-tools.js";
 import { registerCommentTools } from "./tools/comment-tools.js";
 import { registerGoalTools } from "./tools/goal-tools.js";
+import { registerReleaseTools } from "./tools/release-tools.js";
 import {
   commentOutputSchema,
   competitorOutputSchema,
@@ -1350,6 +1351,10 @@ export function registerTools(server: McpServer) {
 
   // Comments, including the ideas-portal stream that aha://comments/idea/{id} does not carry.
   registerCommentTools(server);
+
+  // Release membership. Enumeration, which search cannot do: it is relevance-ranked and a hit
+  // carries no release, so a release's contents were only reachable as a resource.
+  registerReleaseTools(server);
 
   // Goals and key results - Aha's model of an OKR. Kept in their own file because the routes
   // are shaped differently from the rest: goal creation and deletion are workspace-scoped,

--- a/src/core/tools/release-tools.ts
+++ b/src/core/tools/release-tools.ts
@@ -1,0 +1,146 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import * as services from "../services/index.js";
+import { recordLinks, releaseFeaturesListOutputSchema } from "../tool-output.js";
+import { describeAhaError } from "../services/aha-errors.js";
+
+/**
+ * Release membership reads.
+ *
+ * `aha_search` cannot answer "what is in this release". It is relevance-ranked rather than
+ * enumerable: it returns the hits it considers best for a query string, with no way to ask for
+ * *all* records matching a scope - and a hit carries no per-type fields, so release membership
+ * is not even visible on one (see the search notes in CLAUDE.md). Reported from a real
+ * session: search surfaced 4 features of a release that holds 16, and the caller could tell
+ * the list was short only by noticing gaps in the position values. A partial list that looks
+ * whole is worse than an error, because nothing in the result says it is partial.
+ *
+ * Aha has the endpoint - `GET /releases/{id}/features` - and this server has always wrapped it
+ * as the `aha://release/{release_id}/features` resource. That is unreachable on a tool-only
+ * client, which is the same asymmetry `record-tools.ts` exists to fix: every read a client
+ * needs has to be reachable as a tool.
+ */
+
+/** Aha's own page size for this endpoint, measured; used in the description, not as a default. */
+const AHA_DEFAULT_PER_PAGE = 30;
+
+/** What this tool asks for unless told otherwise, so one call enumerates most releases whole. */
+const DEFAULT_PER_PAGE = 200;
+
+export function registerReleaseTools(server: McpServer) {
+  server.registerTool(
+    "aha_list_release_features",
+    {
+      title: "List features in a release",
+      description:
+        "List the features assigned to a release in Aha.io. This is the only way to enumerate " +
+        "a release: aha_search is relevance-ranked, returns no release membership on a hit, and " +
+        "cannot be asked for every record in a scope, so a search-built list of a release is " +
+        `partial without saying so. Requests ${DEFAULT_PER_PAGE} features per page by default ` +
+        `(Aha's own default is ${AHA_DEFAULT_PER_PAGE}); returns each feature with a link to it, ` +
+        "plus Aha's pagination block naming the total on the release so a caller can tell a " +
+        "complete list from the front of a longer one. Aha returns identity fields only here - " +
+        "no workflow status - so follow up with aha_get_feature for the state of one.",
+      inputSchema: {
+        releaseId: z
+          .string()
+          .describe("Reference number (e.g. PRJ1-R-18) or internal id of the release"),
+        page: z.number().min(1).optional().describe("1-based page number"),
+        perPage: z
+          .number()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe(`Features per page, up to 200. Defaults to ${DEFAULT_PER_PAGE}`)
+      },
+      outputSchema: releaseFeaturesListOutputSchema,
+      annotations: {
+        title: "List features in a release",
+        readOnlyHint: true,
+        // destructiveHint and idempotentHint are omitted deliberately: the spec only gives
+        // them meaning for tools that write.
+        openWorldHint: true
+      }
+    },
+    async (params: { releaseId: string; page?: number; perPage?: number }) => {
+      try {
+        const perPage = params.perPage ?? DEFAULT_PER_PAGE;
+        const response = await services.AhaService.getReleaseFeatures(
+          params.releaseId,
+          params.page,
+          perPage
+        );
+        const features = Array.isArray(response?.features) ? response.features : [];
+        const pagination = response?.pagination as Record<string, unknown> | undefined;
+
+        const lines = features.map(feature => {
+          const record = feature as Record<string, unknown>;
+          return `- ${record.reference_num ?? record.id} "${record.name ?? "(unnamed)"}"`;
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              // The count line states coverage rather than leaving it to be inferred, and names
+              // the next page when there is one: the failure this tool exists to prevent is a
+              // caller treating a page as the release.
+              text:
+                features.length === 0
+                  ? `Release ${params.releaseId} has no features on this page`
+                  : `${coverage(features.length, pagination)} in release ${params.releaseId}:\n${lines.join("\n")}${nextPageHint(pagination)}`
+            },
+            // One link per feature. Coverage is complete - every record here is a feature, and
+            // features have a single-record resource template - which is the same test
+            // aha_list_key_results passes and aha_search fails. The block count is bounded by
+            // perPage, so it is the caller's to control rather than a silent cap here.
+            ...features.flatMap(feature => recordLinks("feature", feature as Record<string, unknown>))
+          ],
+          structuredContent: {
+            release_id: params.releaseId,
+            features: features as Record<string, unknown>[],
+            ...(pagination ? { pagination } : {})
+          }
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error listing release features: ${describeAhaError(error, params.releaseId)}`
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  );
+}
+
+/**
+ * "16 features" when the page is the release, "30 of 59 features" when it is not.
+ *
+ * Only claims a total when Aha sent one and it disagrees with what arrived; a total that
+ * matches the page is not worth the words, and inventing one would be the very thing this
+ * tool is here to stop.
+ */
+function coverage(returned: number, pagination: Record<string, unknown> | undefined): string {
+  const total = pagination?.total_records;
+  const plural = (n: number) => `${n} feature${n === 1 ? "" : "s"}`;
+
+  if (typeof total === "number" && total !== returned) {
+    return `${returned} of ${plural(total)}`;
+  }
+  return plural(returned);
+}
+
+/** Name the next page, when Aha's pagination says there is one. */
+function nextPageHint(pagination: Record<string, unknown> | undefined): string {
+  const current = pagination?.current_page;
+  const totalPages = pagination?.total_pages;
+
+  if (typeof current === "number" && typeof totalPages === "number" && current < totalPages) {
+    return `\n\nPage ${current} of ${totalPages}. Call again with page: ${current + 1} for the rest.`;
+  }
+  return "";
+}

--- a/test/release-tools.test.ts
+++ b/test/release-tools.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { registerReleaseTools } from '../src/core/tools/release-tools.js';
+import { AhaService } from '../src/core/services/aha-service.js';
+
+/**
+ * Release membership reads.
+ *
+ * Calls go through a real MCP client, because the client validates `structuredContent`
+ * against the advertised `outputSchema` - a call that returns at all is itself the
+ * conformance assertion. The fixtures carry exactly the fields a live
+ * `/releases/{id}/features` returns: identity only, no `workflow_status`.
+ */
+async function connected() {
+  const server = new McpServer({ name: 'aha-test', version: '1.0.0' });
+  registerReleaseTools(server);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+/** A feature as this endpoint returns one - measured: seven identity fields, nothing else. */
+const feature = (n: number) => ({
+  id: `697111072648835000${n}`,
+  reference_num: `APPO11Y-${n}`,
+  name: `Feature ${n}`,
+  product_id: '7386671125809128444',
+  reference_prefix: undefined,
+  resource: `https://test.aha.io/api/v1/features/APPO11Y-${n}`,
+  url: `https://test.aha.io/features/APPO11Y-${n}`,
+  created_at: '2026-08-01T10:00:00.000Z'
+});
+
+describe('Release feature listing', () => {
+  const patched: string[] = [];
+
+  const patch = (method: keyof typeof AhaService, impl: (...args: any[]) => Promise<any>) => {
+    patched.push(method as string);
+    (AhaService as any)[`__original_${method}`] = (AhaService as any)[method];
+    (AhaService as any)[method] = impl;
+  };
+
+  afterEach(() => {
+    for (const method of patched) {
+      (AhaService as any)[method] = (AhaService as any)[`__original_${method}`];
+      delete (AhaService as any)[`__original_${method}`];
+    }
+    patched.length = 0;
+  });
+
+  it('enumerates a release and links every feature it returns', async () => {
+    patch('getReleaseFeatures', async () => ({
+      features: [feature(1), feature(2)],
+      pagination: { total_records: 2, total_pages: 1, current_page: 1 }
+    }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_release_features',
+      arguments: { releaseId: 'APPO11Y-R-18' }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent.release_id).toBe('APPO11Y-R-18');
+    expect(result.structuredContent.features).toHaveLength(2);
+    expect(result.content[0].text).toBe(
+      '2 features in release APPO11Y-R-18:\n- APPO11Y-1 "Feature 1"\n- APPO11Y-2 "Feature 2"'
+    );
+
+    // One link per feature: coverage is complete here, unlike aha_search, so linking cannot
+    // silently skip part of the result set.
+    const links = result.content.filter((c: any) => c.type === 'resource_link');
+    expect(links.map((l: any) => l.uri)).toEqual([
+      'aha://feature/APPO11Y-1',
+      'aha://feature/APPO11Y-2'
+    ]);
+  });
+
+  it('says how much of the release it is showing, and which page holds the rest', async () => {
+    // The failure this tool exists to prevent: Aha answers with 30 features for a release that
+    // holds 59, and a caller reading only the array cannot tell that from a complete list.
+    patch('getReleaseFeatures', async () => ({
+      features: [feature(1)],
+      pagination: { total_records: 59, total_pages: 2, current_page: 1 }
+    }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_release_features',
+      arguments: { releaseId: 'APPO11Y-R-3', perPage: 1 }
+    });
+
+    expect(result.content[0].text).toContain('1 of 59 features in release APPO11Y-R-3');
+    expect(result.content[0].text).toContain('Page 1 of 2. Call again with page: 2 for the rest.');
+    // Pagination reaches the client structurally too, not only as prose.
+    expect(result.structuredContent.pagination).toEqual({
+      total_records: 59,
+      total_pages: 2,
+      current_page: 1
+    });
+  });
+
+  it('asks Aha for 200 per page unless told otherwise', async () => {
+    // Aha's own default is 30. Taking it would make the common case - "list this release" -
+    // return a page while reading like a release.
+    const calls: any[] = [];
+    patch('getReleaseFeatures', async (releaseId: string, page?: number, perPage?: number) => {
+      calls.push({ releaseId, page, perPage });
+      return { features: [], pagination: { total_records: 0, total_pages: 0, current_page: 1 } };
+    });
+    const client = await connected();
+
+    await client.callTool({ name: 'aha_list_release_features', arguments: { releaseId: 'PRJ1-R-1' } });
+    await client.callTool({
+      name: 'aha_list_release_features',
+      arguments: { releaseId: 'PRJ1-R-1', page: 3, perPage: 25 }
+    });
+
+    expect(calls[0]).toEqual({ releaseId: 'PRJ1-R-1', page: undefined, perPage: 200 });
+    expect(calls[1]).toEqual({ releaseId: 'PRJ1-R-1', page: 3, perPage: 25 });
+  });
+
+  it('reports an empty page without claiming the release is empty', async () => {
+    patch('getReleaseFeatures', async () => ({ features: [] }));
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_release_features',
+      arguments: { releaseId: 'PRJ1-R-9', page: 4 }
+    });
+
+    expect(result.isError).toBeFalsy();
+    // "on this page", because page 4 of a 2-page release is empty while the release is not.
+    expect(result.content[0].text).toBe('Release PRJ1-R-9 has no features on this page');
+    expect(result.structuredContent.features).toEqual([]);
+    expect(result.structuredContent).not.toHaveProperty('pagination');
+  });
+
+  it('reports a failure as a tool error rather than an empty release', async () => {
+    patch('getReleaseFeatures', async () => {
+      throw new Error('Request failed with status code 404');
+    });
+    const client = await connected();
+
+    const result: any = await client.callTool({
+      name: 'aha_list_release_features',
+      arguments: { releaseId: 'PRJ1-R-404' }
+    });
+
+    // An empty success would read as "this release has no features", which is the same
+    // silent-partial-list failure in its worst form.
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Error listing release features');
+  });
+
+  it('sends page and per_page to Aha, and neither when neither was asked for', async () => {
+    // This endpoint is reached with `fetch` rather than through aha-js, so the query string is
+    // hand-built and worth pinning: a dropped `per_page` would silently reinstate Aha's 30.
+    const urls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any) => {
+      urls.push(String(url));
+      return new Response(JSON.stringify({ features: [], pagination: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }) as typeof fetch;
+
+    try {
+      AhaService.initialize('test-token', 'test');
+      await AhaService.getReleaseFeatures('APPO11Y-R-18', 2, 200);
+      await AhaService.getReleaseFeatures('APPO11Y-R-18');
+
+      expect(urls[0]).toBe(
+        'https://test.aha.io/api/v1/releases/APPO11Y-R-18/features?page=2&per_page=200'
+      );
+      expect(urls[1]).toBe('https://test.aha.io/api/v1/releases/APPO11Y-R-18/features');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('is declared read-only, reaches Aha, and describes its output', async () => {
+    const client = await connected();
+    const tool = (await client.listTools()).tools.find(t => t.name === 'aha_list_release_features')!;
+
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(tool.annotations?.openWorldHint).toBe(true);
+    // Meaningless for a reader, per the spec, so they must stay absent.
+    expect(tool.annotations?.destructiveHint).toBeUndefined();
+    expect(tool.annotations?.idempotentHint).toBeUndefined();
+    // Titles live in both spec locations and must agree.
+    expect(tool.title).toBe(tool.annotations?.title);
+    expect(tool.outputSchema).toBeDefined();
+  });
+});


### PR DESCRIPTION
## The gap

`aha_search` cannot answer "what is in this release". It is relevance-ranked rather than
enumerable, cannot be asked for every record in a scope, and a hit carries no per-type fields —
so release membership is not visible on one at all. From a real session: search surfaced **4
features of a release that holds 16**, and the only clue the list was short was a gap in the
`position` values. A partial list that reads as complete is worse than an error.

Aha has the endpoint, and this server already wrapped it as the
`aha://release/{release_id}/features` resource — unreachable on a tool-only client, which is the
same asymmetry `record-tools.ts` exists to fix.

## Measured, not assumed

| behaviour | measurement |
| --- | --- |
| Default page size | **30** — a 59-feature release answers with 30 and `total_pages: 2` |
| `per_page` honoured | `per_page=5` on a 16-feature release → 5 across 4 pages |
| Aha's own ceiling | not observable below 200 — `per_page=500` returned all 59 in one page |
| Fields returned | identity only: `created_at, id, name, product_id, reference_num, resource, url` |

So `AhaService.getReleaseFeatures()` now takes `page`/`perPage`, and `aha_list_release_features`
asks for **200** by default: the common request is "list this release", and Aha's default answers
it with a page that reads like a release.

`pagination` is part of the contract, not a pass-through extra — described in
`releaseFeaturesListOutputSchema`, forwarded whenever Aha sends it, and restated in the text block
as `30 of 59 features` with the next page named. It is the only thing separating 30-of-30 from
30-of-59. Because the endpoint returns no `workflow_status`, the description points at
`aha_get_feature` for the state of one feature rather than implying it returns state.

One `resource_link` per feature: coverage is complete — every record is a feature and features have
a single-record template, the test `aha_list_key_results` passes and `aha_search` fails. Block
count is bounded by `perPage`, which the caller sets, rather than by a silent cap here.

## Verified against a live account

```
16 features in release APPO11Y-R-18:       → 16 links, pagination 16/1/1
25 of 59 features in release APPO11Y-R-3:  → "Page 1 of 3. Call again with page: 2 for the rest."
```

7 new tests in `test/release-tools.test.ts`, including the query-string pin (this endpoint is
reached with `fetch`, because aha-js types the generated method as returning `void`, so a dropped
`per_page` would silently reinstate Aha's 30). Full suite: 512 pass, 0 fail. `manifest.json`
regenerated with `bun run manifest:sync` (49 tools); README and CLAUDE.md counts updated.

## Left out

`getReleaseEpics` still has no tool, so a release organised around epics is enumerable only as a
resource. Same shape and same argument — noted in CLAUDE.md rather than guessed at here. Say the
word and it is a small follow-up.