### PR TITLE
feat: enumerate a release's epics as a tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,12 @@ Measured against a live account, not taken from `@cedricziel/aha-js`' fixture-de
 
 ### Release membership
 
-`src/core/tools/release-tools.ts` holds `aha_list_release_features`, wrapping
-`GET /releases/{id}/features` - the same endpoint the `aha://release/{release_id}/features`
-resource has always read. It exists because **`aha_search` cannot enumerate**: it is
+`src/core/tools/release-tools.ts` holds `aha_list_release_features` and
+`aha_list_release_epics`, wrapping `GET /releases/{id}/features` and `GET /releases/{id}/epics`
+- the same endpoints the `aha://release/{release_id}/features` and `.../epics` resources have
+always read. Both types are listed because a release is not organised the same way in every
+workspace: one planned in epics is as invisible through the features tool as it was through
+search. They exist because **`aha_search` cannot enumerate**: it is
 relevance-ranked, it cannot be asked for every record in a scope, and a hit carries no
 per-type fields, so release membership is not visible on one at all. Reported from a real
 session, search surfaced 4 features of a release holding 16, and the only clue the list was
@@ -165,33 +168,45 @@ an error, which is why this tool is not just a convenience over the resource.
 
 Measured against a live account, not taken from Aha's docs:
 
-- **The endpoint pages, and its default page size is 30.** A release with 59 features answers
-  with 30 and `pagination: { total_records: 59, total_pages: 2, current_page: 1 }`; the same
-  release with `per_page=500` returns all 59 in one page, so Aha's own ceiling was not
+- **The features endpoint pages, and its default page size is 30.** A release with 59 features
+  answers with 30 and `pagination: { total_records: 59, total_pages: 2, current_page: 1 }`; the
+  same release with `per_page=500` returns all 59 in one page, so Aha's own ceiling was not
   observable below 200. `per_page=5` on a 16-feature release gave 5 across 4 pages.
   `AhaService.getReleaseFeatures()` therefore takes `page` and `perPage`, and the tool asks
   for 200 by default: the common request is "list this release", and Aha's default would
   answer it with a page that reads like a release.
+- **The epics endpoint pages too, but its default page size is unmeasured** - and that gap is
+  deliberate rather than an oversight. `per_page=2` on a four-epic release returned 2 across 2
+  pages, so paging demonstrably works; the largest release reachable on the account probed
+  holds **4** epics, so the endpoint never had to page unasked and its default never showed
+  itself. **Do not copy the features endpoint's 30 across** - different route, unmeasured
+  number. `aha_list_release_epics` always sends an explicit `per_page`, so Aha's default does
+  not decide what a caller gets either way; that is what makes the unknown harmless rather
+  than something to guess at.
 - **`pagination` is part of the contract here, not a pass-through extra.** It is described in
-  `releaseFeaturesListOutputSchema`, forwarded whenever Aha sends it, and the text block says
-  `30 of 59 features` plus which page to ask for next. Do not drop it to save tokens - it is
-  the only thing distinguishing 30-of-30 from 30-of-59.
-- **The endpoint returns identity fields only** (`created_at, id, name, product_id,
-  reference_num, resource, url`) - no `workflow_status`, no assignee. This is the same
-  measurement the tier-1 rendering of the matching resource rests on, so the tool's
-  description points at `aha_get_feature` for the state of any one feature rather than
-  implying it returns state.
-- This endpoint is reached with `fetch` rather than through `aha-js`, whose generated method
-  returns `void`, so the query string is hand-built and pinned by a test.
+  `releaseFeaturesListOutputSchema` / `releaseEpicsListOutputSchema`, forwarded whenever Aha
+  sends it, and the text block says `30 of 59 features` plus which page to ask for next. Do
+  not drop it to save tokens - it is the only thing distinguishing 30-of-30 from 30-of-59.
+- **Both endpoints return identity fields only** - features give `created_at, id, name,
+  product_id, reference_num, resource, url`, epics the same minus `product_id` - with no
+  `workflow_status` and no assignee. This is the same measurement the tier-1 rendering of the
+  matching resources rests on, so each tool's description points at `aha_get_feature` /
+  `aha_get_epic` for the state of any one record rather than implying it returns state.
+- **The two reach Aha differently.** Features go through `fetch`, because aha-js types that
+  generated method as returning `void`, so the query string is hand-built and pinned by a
+  test. Epics go through aha-js, whose operation types `page` and `perPage` as **strings** -
+  hence `numParam()`.
 
-`aha_list_release_features` emits one `resource_link` per feature: every record is a feature
-and features have a single-record template, so coverage is complete - the same test
+Each tool emits one `resource_link` per record: every record in a result is the same type and
+that type has a single-record template, so coverage is complete - the test
 `aha_list_key_results` passes and `aha_search` fails. Block count is bounded by `perPage`,
 which the caller sets, rather than by a cap here that would drop links silently.
 
-The sibling gap is still open: `getReleaseEpics` has no tool, so a release organised around
-epics is enumerable only as a resource. Same shape, same argument - add it with a test rather
-than assuming this file's measurements transfer.
+The two schemas stay separate rather than one wrapper with two optional arrays: a caller
+reading `epics` should not have to work out whether `features` is missing because the release
+has none or because it called the other tool. The registrations share one `MEMBERSHIP` table
+and one handler, so the summary line, the pagination handling and the link rule cannot drift
+apart between the two.
 
 ### Error handling
 
@@ -299,7 +314,7 @@ This is a Model Context Protocol (MCP) server that provides integration with Aha
   does not cover. Reads credentials via `AhaService.getCredentials()` so `configure_server`
   applies at runtime
 - **ConfigService**: Manages runtime configuration with file persistence and validation
-- **Tools**: 49 MCP tools (CRUD, single-record reads, collection reads, comments, OKRs,
+- **Tools**: 50 MCP tools (CRUD, single-record reads, collection reads, comments, OKRs,
   search, health checks, configuration), none of which keep local state
 - **Resources**: 40+ resource types for accessing Aha.io entities via URI schemes. Every
   registration carries `annotations` from `resourceAnnotations()`, and collection reads are
@@ -386,8 +401,9 @@ missing. Conventions used here:
 
 - `title` is a short human-readable label for client UIs.
 - `readOnlyHint` is true only for tools that never write: `aha_search`, `aha_list_comments`,
-  `aha_list_release_features`, `aha_list_key_results`, the `aha_get_*` readers,
-  `server_status`, `get_server_config`, `server_health_check`, `test_configuration`.
+  `aha_list_release_features`, `aha_list_release_epics`, `aha_list_key_results`, the
+  `aha_get_*` readers, `server_status`, `get_server_config`, `server_health_check`,
+  `test_configuration`.
 - `destructiveHint` and `idempotentHint` are **omitted** when `readOnlyHint` is true - the
   spec only gives them meaning for writers.
 - `destructiveHint: true` covers the deletes plus the two PUT endpoints that replace a whole

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download `aha-mcp-v<version>.mcpb` from the [latest release](https://github.com/
 and open it with Claude Desktop, which will prompt you for your Aha.io subdomain and API
 token. No Node.js or Docker setup and no manual JSON editing required.
 
-The extension exposes 49 tools that query Aha.io directly, so results are always current and
+The extension exposes 50 tools that query Aha.io directly, so results are always current and
 nothing is stored locally. Cross-record search is served by Aha.io's own index — see
 [Search](#-search).
 
@@ -468,16 +468,20 @@ unreachable, leaving write tools with no way to see what they were about to repl
 
 #### Collection Read Tools
 - `aha_list_release_features`: List the features assigned to a release, with a link per feature and Aha's total for the release
+- `aha_list_release_epics`: List the epics assigned to a release, with a link per epic and Aha's total for the release
 - `aha_list_key_results`: List a goal's key results, with status, progress and metrics
 - `aha_list_comments`: List the comments on a record, both streams for an idea
 
-`aha_list_release_features` is the only way to enumerate a release. `aha_search` is
+The two release tools are the only way to enumerate a release. `aha_search` is
 relevance-ranked, returns no release membership on a hit and cannot be asked for every record
 in a scope, so a release list assembled from search results is partial — and nothing in it says
-so. The tool asks for 200 features per page (Aha's own default is 30) and always returns Aha's
-pagination block, so a caller can tell a complete list from the front of a longer one. Aha
-returns identity fields only on this endpoint, so use `aha_get_feature` for the state of any
-one feature.
+so. Both types are listed because a release is not organised the same way in every workspace: a
+release planned in epics is invisible to the features tool. Each asks for 200 records per page
+(Aha's own default is 30 for features; on the epics route it is unmeasured, which is why the
+tool never relies on it) and always returns Aha's pagination block, so a caller can tell a
+complete list from the front of a longer one. Aha
+returns identity fields only on these endpoints, so use `aha_get_feature` or `aha_get_epic` for
+the state of any one record.
 
 #### Write Operation Tools
 - `aha_create_feature_comment`: Create a comment on a feature
@@ -589,7 +593,7 @@ The MCP server now provides comprehensive lifecycle management for Aha.io entiti
 - **Comprehensive Entity Coverage**: Full CRUD operations for features, epics, ideas, and competitors
 
 #### Technical Achievements
-- **49 MCP tools**, all querying Aha.io directly — no local state
+- **50 MCP tools**, all querying Aha.io directly — no local state
 - **17 listed MCP resources** covering the entity set, plus templated resource URIs
 - **17 domain-specific prompts** (workflow automation)
 - **32 core CRUD and write operation tools** for complete lifecycle management, including OKRs (goals and key results)

--- a/manifest.json
+++ b/manifest.json
@@ -179,8 +179,12 @@
       "description": "List the key results belonging to a goal in Aha.io. This is how you get the id of a key result before updating it: aha_search cannot return a key result's metrics or status, and the abbreviated copies inside a goal are not the full records. Returns each key result with its status, progress and metrics, plus a link per key result."
     },
     {
+      "name": "aha_list_release_epics",
+      "description": "List the epics assigned to a release in Aha.io. This is the only way to enumerate a release's epics: aha_search is relevance-ranked, returns no release membership on a hit, and cannot be asked for every record in a scope, so a search-built list is partial without saying so. Requests 200 epics per page by default; returns each epic with a link to it, plus Aha's pagination block naming the total on the release so a caller can tell a complete list from the front of a longer one. Aha returns identity fields only here - no workflow status - so follow up with aha_get_epic for the state of one."
+    },
+    {
       "name": "aha_list_release_features",
-      "description": "List the features assigned to a release in Aha.io. This is the only way to enumerate a release: aha_search is relevance-ranked, returns no release membership on a hit, and cannot be asked for every record in a scope, so a search-built list of a release is partial without saying so. Requests 200 features per page by default (Aha's own default is 30); returns each feature with a link to it, plus Aha's pagination block naming the total on the release so a caller can tell a complete list from the front of a longer one. Aha returns identity fields only here - no workflow status - so follow up with aha_get_feature for the state of one."
+      "description": "List the features assigned to a release in Aha.io. This is the only way to enumerate a release's features: aha_search is relevance-ranked, returns no release membership on a hit, and cannot be asked for every record in a scope, so a search-built list is partial without saying so. Requests 200 features per page by default (Aha's own default is 30); returns each feature with a link to it, plus Aha's pagination block naming the total on the release so a caller can tell a complete list from the front of a longer one. Aha returns identity fields only here - no workflow status - so follow up with aha_get_feature for the state of one."
     },
     {
       "name": "aha_move_feature_to_release",

--- a/src/core/services/aha-service.interface.ts
+++ b/src/core/services/aha-service.interface.ts
@@ -247,7 +247,7 @@ export interface IAhaService {
   // Relationships
   getGoalEpics(goalId: string): Promise<GoalEpicsResponse>;
   getReleaseFeatures(releaseId: string, page?: number, perPage?: number): Promise<ReleaseFeaturesResponse>;
-  getReleaseEpics(releaseId: string): Promise<EpicsListResponse>;
+  getReleaseEpics(releaseId: string, page?: number, perPage?: number): Promise<EpicsListResponse>;
   getInitiativeEpics(initiativeId: string): Promise<EpicsListResponse>;
 
   // Me/Current User

--- a/src/core/services/aha-service.mock.ts
+++ b/src/core/services/aha-service.mock.ts
@@ -604,7 +604,11 @@ export class MockAhaService implements IAhaService {
     return { features: [] } as ReleaseFeaturesResponse;
   }
 
-  async getReleaseEpics(_releaseId: string): Promise<EpicsListResponse> {
+  async getReleaseEpics(
+    _releaseId: string,
+    _page?: number,
+    _perPage?: number
+  ): Promise<EpicsListResponse> {
     return { epics: [] } as EpicsListResponse;
   }
 

--- a/src/core/services/aha-service.ts
+++ b/src/core/services/aha-service.ts
@@ -1530,14 +1530,34 @@ export class AhaService {
 
   /**
    * Get epics associated with a specific release
+   *
+   * Paged, like the features sibling above - `per_page=2` on a four-epic release returned 2
+   * across 2 pages, with `pagination` naming the real total. Aha's *default* page size here is
+   * unmeasured: the largest release reachable on the account probed holds 4 epics, so the
+   * endpoint never had to page. Do not assume the features endpoint's 30 applies; ask for a
+   * page size rather than relying on the default.
+   *
+   * Unlike `getReleaseFeatures`, this route is reachable through aha-js, so `page` and
+   * `perPage` go through `numParam()` - the generated operation types them as strings.
+   *
    * @param releaseId The ID of the release
-   * @returns A list of epics associated with the release
+   * @param page 1-based page number (optional)
+   * @param perPage Number of items per page (optional)
+   * @returns The epics on the release, with Aha's pagination block
    */
-  public static async getReleaseEpics(releaseId: string): Promise<EpicsListResponse> {
+  public static async getReleaseEpics(
+    releaseId: string,
+    page?: number,
+    perPage?: number
+  ): Promise<EpicsListResponse> {
     const epicsApi = this.getEpicsApi();
 
     try {
-      const response = await epicsApi.releasesByReleaseEpicsGet({ releaseId });
+      const response = await epicsApi.releasesByReleaseEpicsGet({
+        releaseId,
+        page: this.numParam(page),
+        perPage: this.numParam(perPage)
+      });
       return response.data as unknown as EpicsListResponse;
     } catch (error) {
       log.error('Error getting epics for release', error as Error, { operation: 'getReleaseEpics', release_id: releaseId });

--- a/src/core/tool-output.ts
+++ b/src/core/tool-output.ts
@@ -326,17 +326,33 @@ export const keyResultsListOutputSchema = z.object({
  * front of it: `/releases/{id}/features` answers with 30 features when asked for no page
  * size, so a caller reading only the array cannot tell 30-of-30 from 30-of-59.
  */
+const releasePaginationField = z
+  .looseObject({
+    total_records: z.number().optional().describe("Records on the release in total, across all pages"),
+    total_pages: z.number().optional().describe("Pages at the page size used"),
+    current_page: z.number().optional().describe("Page this result came from")
+  })
+  .optional()
+  .describe(
+    "Aha's pagination block, when the response carried one. Compare total_records with the " +
+      "number of records returned before treating this as the whole release."
+  );
+
 export const releaseFeaturesListOutputSchema = z.object({
   release_id: z.string().describe("Release whose features these are, as it was requested"),
   features: z.array(featureOutputSchema).describe("Features on the release, for the page requested"),
-  pagination: z
-    .looseObject({
-      total_records: z.number().optional().describe("Features on the release in total, across all pages"),
-      total_pages: z.number().optional().describe("Pages at the page size used"),
-      current_page: z.number().optional().describe("Page this result came from")
-    })
-    .optional()
-    .describe("Aha's pagination block, when the response carried one. Compare total_records with the length of `features` before treating this as the whole release.")
+  pagination: releasePaginationField
+});
+
+/**
+ * The epic half of the same contract. Separate from the features schema rather than one
+ * schema with two optional arrays: a caller reading `epics` should not have to check whether
+ * `features` is absent because the release has none or because it asked the other tool.
+ */
+export const releaseEpicsListOutputSchema = z.object({
+  release_id: z.string().describe("Release whose epics these are, as it was requested"),
+  epics: z.array(epicOutputSchema).describe("Epics on the release, for the page requested"),
+  pagination: releasePaginationField
 });
 
 export const commentOutputSchema = z.looseObject({

--- a/src/core/tools/release-tools.ts
+++ b/src/core/tools/release-tools.ts
@@ -1,7 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import * as services from "../services/index.js";
-import { recordLinks, releaseFeaturesListOutputSchema } from "../tool-output.js";
+import {
+  recordLinks,
+  releaseEpicsListOutputSchema,
+  releaseFeaturesListOutputSchema,
+  type LinkableRecordType
+} from "../tool-output.js";
 import { describeAhaError } from "../services/aha-errors.js";
 
 /**
@@ -15,118 +20,186 @@ import { describeAhaError } from "../services/aha-errors.js";
  * the list was short only by noticing gaps in the position values. A partial list that looks
  * whole is worse than an error, because nothing in the result says it is partial.
  *
- * Aha has the endpoint - `GET /releases/{id}/features` - and this server has always wrapped it
- * as the `aha://release/{release_id}/features` resource. That is unreachable on a tool-only
- * client, which is the same asymmetry `record-tools.ts` exists to fix: every read a client
- * needs has to be reachable as a tool.
+ * Aha has the endpoints - `GET /releases/{id}/features` and `GET /releases/{id}/epics` - and
+ * this server has always wrapped both as `aha://release/{release_id}/features` and
+ * `.../epics`. Those are unreachable on a tool-only client, which is the same asymmetry
+ * `record-tools.ts` exists to fix.
+ *
+ * Both types are listed because a release is not organised the same way in every workspace:
+ * one that plans in epics is as invisible through the features tool as it was through search.
  */
 
-/** Aha's own page size for this endpoint, measured; used in the description, not as a default. */
-const AHA_DEFAULT_PER_PAGE = 30;
-
-/** What this tool asks for unless told otherwise, so one call enumerates most releases whole. */
+/** What these tools ask for unless told otherwise, so one call enumerates most releases whole. */
 const DEFAULT_PER_PAGE = 200;
 
+interface MembershipConfig {
+  /** Tool name, e.g. `aha_list_release_features`. */
+  tool: string;
+  /** Display title, used for both `title` and `annotations.title`. */
+  title: string;
+  /** Plural noun as it reads in prose, e.g. "features". */
+  plural: string;
+  /** Singular noun, for the count line and the follow-up tool it names. */
+  singular: string;
+  /** Resource type for the `aha://` link per record. */
+  recordType: LinkableRecordType;
+  /** Key the records arrive under in Aha's response. */
+  collectionKey: "features" | "epics";
+  /** The single-record read tool to point at for state this endpoint does not carry. */
+  readerTool: string;
+  /**
+   * Aha's own page size on this route, when it has been measured. Omitted rather than guessed:
+   * a description that names a number nobody measured is worse than one that stays quiet.
+   */
+  ahaDefault?: string;
+  outputSchema: z.ZodObject<z.ZodRawShape>;
+  fetch: (releaseId: string, page: number | undefined, perPage: number) => Promise<unknown>;
+}
+
+const MEMBERSHIP: MembershipConfig[] = [
+  {
+    tool: "aha_list_release_features",
+    title: "List features in a release",
+    plural: "features",
+    singular: "feature",
+    recordType: "feature",
+    collectionKey: "features",
+    readerTool: "aha_get_feature",
+    // Measured: a 59-feature release answers with 30 when asked for no page size.
+    ahaDefault: "30",
+    outputSchema: releaseFeaturesListOutputSchema,
+    fetch: (releaseId, page, perPage) =>
+      services.AhaService.getReleaseFeatures(releaseId, page, perPage)
+  },
+  {
+    tool: "aha_list_release_epics",
+    title: "List epics in a release",
+    plural: "epics",
+    singular: "epic",
+    recordType: "epic",
+    collectionKey: "epics",
+    readerTool: "aha_get_epic",
+    // Left unset, because it has not been measured: the largest release reachable on the
+    // account probed holds 4 epics, so the endpoint never had to page unasked. Do not copy the
+    // features endpoint's 30 across - it is a different route. The tool always sends an
+    // explicit per_page, so Aha's default does not decide what a caller gets either way.
+    ahaDefault: undefined,
+    outputSchema: releaseEpicsListOutputSchema,
+    fetch: (releaseId, page, perPage) =>
+      services.AhaService.getReleaseEpics(releaseId, page, perPage)
+  }
+];
+
 export function registerReleaseTools(server: McpServer) {
-  server.registerTool(
-    "aha_list_release_features",
-    {
-      title: "List features in a release",
-      description:
-        "List the features assigned to a release in Aha.io. This is the only way to enumerate " +
-        "a release: aha_search is relevance-ranked, returns no release membership on a hit, and " +
-        "cannot be asked for every record in a scope, so a search-built list of a release is " +
-        `partial without saying so. Requests ${DEFAULT_PER_PAGE} features per page by default ` +
-        `(Aha's own default is ${AHA_DEFAULT_PER_PAGE}); returns each feature with a link to it, ` +
-        "plus Aha's pagination block naming the total on the release so a caller can tell a " +
-        "complete list from the front of a longer one. Aha returns identity fields only here - " +
-        "no workflow status - so follow up with aha_get_feature for the state of one.",
-      inputSchema: {
-        releaseId: z
-          .string()
-          .describe("Reference number (e.g. PRJ1-R-18) or internal id of the release"),
-        page: z.number().min(1).optional().describe("1-based page number"),
-        perPage: z
-          .number()
-          .min(1)
-          .max(200)
-          .optional()
-          .describe(`Features per page, up to 200. Defaults to ${DEFAULT_PER_PAGE}`)
+  for (const config of MEMBERSHIP) {
+    server.registerTool(
+      config.tool,
+      {
+        title: config.title,
+        description:
+          `List the ${config.plural} assigned to a release in Aha.io. This is the only way to ` +
+          `enumerate a release's ${config.plural}: aha_search is relevance-ranked, returns no ` +
+          "release membership on a hit, and cannot be asked for every record in a scope, so a " +
+          `search-built list is partial without saying so. Requests ${DEFAULT_PER_PAGE} ` +
+          `${config.plural} per page by default` +
+          (config.ahaDefault ? ` (Aha's own default is ${config.ahaDefault})` : "") +
+          `; returns each ${config.singular} with a link to it, plus Aha's pagination block naming ` +
+          "the total on the release so a caller can tell a complete list from the front of a " +
+          "longer one. Aha returns identity fields only here - no workflow status - so follow " +
+          `up with ${config.readerTool} for the state of one.`,
+        inputSchema: {
+          releaseId: z
+            .string()
+            .describe("Reference number (e.g. PRJ1-R-18) or internal id of the release"),
+          page: z.number().min(1).optional().describe("1-based page number"),
+          perPage: z
+            .number()
+            .min(1)
+            .max(200)
+            .optional()
+            .describe(
+              `${config.plural[0].toUpperCase()}${config.plural.slice(1)} per page, up to 200. ` +
+                `Defaults to ${DEFAULT_PER_PAGE}`
+            )
+        },
+        outputSchema: config.outputSchema,
+        annotations: {
+          title: config.title,
+          readOnlyHint: true,
+          // destructiveHint and idempotentHint are omitted deliberately: the spec only gives
+          // them meaning for tools that write.
+          openWorldHint: true
+        }
       },
-      outputSchema: releaseFeaturesListOutputSchema,
-      annotations: {
-        title: "List features in a release",
-        readOnlyHint: true,
-        // destructiveHint and idempotentHint are omitted deliberately: the spec only gives
-        // them meaning for tools that write.
-        openWorldHint: true
-      }
-    },
-    async (params: { releaseId: string; page?: number; perPage?: number }) => {
-      try {
-        const perPage = params.perPage ?? DEFAULT_PER_PAGE;
-        const response = await services.AhaService.getReleaseFeatures(
-          params.releaseId,
-          params.page,
-          perPage
-        );
-        const features = Array.isArray(response?.features) ? response.features : [];
-        const pagination = response?.pagination as Record<string, unknown> | undefined;
+      async (params: { releaseId: string; page?: number; perPage?: number }) => {
+        try {
+          const perPage = params.perPage ?? DEFAULT_PER_PAGE;
+          const response = (await config.fetch(params.releaseId, params.page, perPage)) as
+            | Record<string, unknown>
+            | undefined;
 
-        const lines = features.map(feature => {
-          const record = feature as Record<string, unknown>;
-          return `- ${record.reference_num ?? record.id} "${record.name ?? "(unnamed)"}"`;
-        });
+          const raw = response?.[config.collectionKey];
+          const records = (Array.isArray(raw) ? raw : []) as Record<string, unknown>[];
+          const pagination = response?.pagination as Record<string, unknown> | undefined;
 
-        return {
-          content: [
-            {
-              type: "text" as const,
-              // The count line states coverage rather than leaving it to be inferred, and names
-              // the next page when there is one: the failure this tool exists to prevent is a
-              // caller treating a page as the release.
-              text:
-                features.length === 0
-                  ? `Release ${params.releaseId} has no features on this page`
-                  : `${coverage(features.length, pagination)} in release ${params.releaseId}:\n${lines.join("\n")}${nextPageHint(pagination)}`
-            },
-            // One link per feature. Coverage is complete - every record here is a feature, and
-            // features have a single-record resource template - which is the same test
-            // aha_list_key_results passes and aha_search fails. The block count is bounded by
-            // perPage, so it is the caller's to control rather than a silent cap here.
-            ...features.flatMap(feature => recordLinks("feature", feature as Record<string, unknown>))
-          ],
-          structuredContent: {
-            release_id: params.releaseId,
-            features: features as Record<string, unknown>[],
-            ...(pagination ? { pagination } : {})
-          }
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Error listing release features: ${describeAhaError(error, params.releaseId)}`
+          const lines = records.map(
+            record => `- ${record.reference_num ?? record.id} "${record.name ?? "(unnamed)"}"`
+          );
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                // The count line states coverage rather than leaving it to be inferred, and
+                // names the next page when there is one: the failure these tools exist to
+                // prevent is a caller treating a page as the release.
+                text:
+                  records.length === 0
+                    ? `Release ${params.releaseId} has no ${config.plural} on this page`
+                    : `${coverage(records.length, pagination, config.singular)} in release ${params.releaseId}:\n${lines.join("\n")}${nextPageHint(pagination)}`
+              },
+              // One link per record. Coverage is complete - every record here is the same type
+              // and that type has a single-record resource template - which is the test
+              // aha_list_key_results passes and aha_search fails. The block count is bounded by
+              // perPage, so it is the caller's to control rather than a silent cap here.
+              ...records.flatMap(record => recordLinks(config.recordType, record))
+            ],
+            structuredContent: {
+              release_id: params.releaseId,
+              [config.collectionKey]: records,
+              ...(pagination ? { pagination } : {})
             }
-          ],
-          isError: true
-        };
+          };
+        } catch (error) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error listing release ${config.plural}: ${describeAhaError(error, params.releaseId)}`
+              }
+            ],
+            isError: true
+          };
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
  * "16 features" when the page is the release, "30 of 59 features" when it is not.
  *
  * Only claims a total when Aha sent one and it disagrees with what arrived; a total that
- * matches the page is not worth the words, and inventing one would be the very thing this
- * tool is here to stop.
+ * matches the page is not worth the words, and inventing one would be the very thing these
+ * tools are here to stop.
  */
-function coverage(returned: number, pagination: Record<string, unknown> | undefined): string {
+function coverage(
+  returned: number,
+  pagination: Record<string, unknown> | undefined,
+  singular: string
+): string {
   const total = pagination?.total_records;
-  const plural = (n: number) => `${n} feature${n === 1 ? "" : "s"}`;
+  const plural = (n: number) => `${n} ${singular}${n === 1 ? "" : "s"}`;
 
   if (typeof total === "number" && total !== returned) {
     return `${returned} of ${plural(total)}`;

--- a/test/release-tools.test.ts
+++ b/test/release-tools.test.ts
@@ -34,7 +34,17 @@ const feature = (n: number) => ({
   created_at: '2026-08-01T10:00:00.000Z'
 });
 
-describe('Release feature listing', () => {
+/** An epic as this endpoint returns one - measured: six fields, one fewer than a feature. */
+const epic = (n: number) => ({
+  id: `746970887307929302${n}`,
+  reference_num: `APPO11Y-E-${n}`,
+  name: `Epic ${n}`,
+  resource: `https://test.aha.io/api/v1/epics/APPO11Y-E-${n}`,
+  url: `https://test.aha.io/epics/APPO11Y-E-${n}`,
+  created_at: '2025-02-10T08:45:24.825Z'
+});
+
+describe('Release membership listing', () => {
   const patched: string[] = [];
 
   const patch = (method: keyof typeof AhaService, impl: (...args: any[]) => Promise<any>) => {
@@ -183,17 +193,86 @@ describe('Release feature listing', () => {
     }
   });
 
-  it('is declared read-only, reaches Aha, and describes its output', async () => {
+  it('enumerates a release\'s epics too, under their own key', async () => {
+    // A release is not organised the same way in every workspace: one planned in epics was as
+    // invisible through the features tool as it was through search.
+    patch('getReleaseEpics', async () => ({
+      epics: [epic(3), epic(4)],
+      pagination: { total_records: 4, total_pages: 2, current_page: 1 }
+    }));
     const client = await connected();
-    const tool = (await client.listTools()).tools.find(t => t.name === 'aha_list_release_features')!;
 
-    expect(tool.annotations?.readOnlyHint).toBe(true);
-    expect(tool.annotations?.openWorldHint).toBe(true);
-    // Meaningless for a reader, per the spec, so they must stay absent.
-    expect(tool.annotations?.destructiveHint).toBeUndefined();
-    expect(tool.annotations?.idempotentHint).toBeUndefined();
-    // Titles live in both spec locations and must agree.
-    expect(tool.title).toBe(tool.annotations?.title);
-    expect(tool.outputSchema).toBeDefined();
+    const result: any = await client.callTool({
+      name: 'aha_list_release_epics',
+      arguments: { releaseId: 'APPO11Y-R-3', perPage: 2 }
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('2 of 4 epics in release APPO11Y-R-3');
+    expect(result.content[0].text).toContain('Call again with page: 2');
+    // `epics`, not `features`: a caller reading one key should never have to work out whether
+    // the other is absent because the release has none or because it called the other tool.
+    expect(result.structuredContent.epics).toHaveLength(2);
+    expect(result.structuredContent).not.toHaveProperty('features');
+    expect(
+      result.content.filter((c: any) => c.type === 'resource_link').map((l: any) => l.uri)
+    ).toEqual(['aha://epic/APPO11Y-E-3', 'aha://epic/APPO11Y-E-4']);
+  });
+
+  it('names epics, not features, when an epic listing fails or comes back empty', async () => {
+    patch('getReleaseEpics', async () => ({ epics: [] }));
+    const client = await connected();
+
+    const empty: any = await client.callTool({
+      name: 'aha_list_release_epics',
+      arguments: { releaseId: 'PRJ1-R-9' }
+    });
+    expect(empty.content[0].text).toBe('Release PRJ1-R-9 has no epics on this page');
+
+    (AhaService as any).getReleaseEpics = async () => {
+      throw new Error('Request failed with status code 403');
+    };
+    const failed: any = await client.callTool({
+      name: 'aha_list_release_epics',
+      arguments: { releaseId: 'PRJ1-R-9' }
+    });
+    expect(failed.isError).toBe(true);
+    expect(failed.content[0].text).toContain('Error listing release epics');
+  });
+
+  it('passes the page size through to the epics endpoint as well', async () => {
+    const calls: any[] = [];
+    patch('getReleaseEpics', async (releaseId: string, page?: number, perPage?: number) => {
+      calls.push({ releaseId, page, perPage });
+      return { epics: [] };
+    });
+    const client = await connected();
+
+    await client.callTool({ name: 'aha_list_release_epics', arguments: { releaseId: 'PRJ1-R-1' } });
+
+    // Aha's default page size on this route is unmeasured - the largest release probed holds 4
+    // epics - so the tool asks explicitly rather than inheriting whatever it turns out to be.
+    expect(calls[0]).toEqual({ releaseId: 'PRJ1-R-1', page: undefined, perPage: 200 });
+  });
+
+  it('declares both listings read-only, reaching Aha, with an output schema', async () => {
+    const client = await connected();
+    const tools = (await client.listTools()).tools;
+
+    expect(tools.map(t => t.name).sort()).toEqual([
+      'aha_list_release_epics',
+      'aha_list_release_features'
+    ]);
+
+    for (const tool of tools) {
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+      expect(tool.annotations?.openWorldHint).toBe(true);
+      // Meaningless for a reader, per the spec, so they must stay absent.
+      expect(tool.annotations?.destructiveHint).toBeUndefined();
+      expect(tool.annotations?.idempotentHint).toBeUndefined();
+      // Titles live in both spec locations and must agree.
+      expect(tool.title).toBe(tool.annotations?.title);
+      expect(tool.outputSchema).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
The sibling of `aha_list_release_features` (#329), and the follow-up flagged there. A release
organised around epics was enumerable only as a resource, so on a tool-only client it was as
invisible as it had been through search. Both types are listed now, because a release is not
planned the same way in every workspace.

## Measured on this route, not carried over

| behaviour | measurement |
| --- | --- |
| Pages | `per_page=2` on a four-epic release → 2 across 2 pages, `total_records: 4` |
| Default page size | **unmeasured, deliberately** — see below |
| Fields returned | `created_at, id, name, reference_num, resource, url` — the features set minus `product_id` |
| Reached via | aha-js, whose operation types `page`/`perPage` as **strings** → `numParam()` |

The largest release reachable on the account probed holds 4 epics, so the endpoint never had to
page unasked and its default never showed itself. The features endpoint's 30 is **not** copied
across — different route, unmeasured number — and `aha_list_release_epics` always sends an
explicit `per_page`, which is what makes the unknown harmless rather than something to guess at.
The tool description says nothing about a default it cannot name, and CLAUDE.md records why the
gap is there so the next reader does not "fix" it with the features number.

## Shape

The two registrations now share one `MEMBERSHIP` table and one handler, so the summary line, the
pagination handling and the link-per-record rule cannot drift apart between them. The output
schemas stay separate: a caller reading `epics` should not have to work out whether `features` is
missing because the release has none or because it called the other tool.

## Verified against a live account

```
aha_list_release_epics APPO11Y-R-3              → 4 epics, 4 links, pagination 4/1/1
aha_list_release_epics APPO11Y-R-3  perPage 2   → "2 of 4 epics" + "Call again with page: 2"
aha_list_release_epics APPO11Y-R-18             → "has no epics on this page" (16 features, no epics)
```

That last case is the point of the wording: an empty page is reported without claiming the
release is empty.

10 tests in `test/release-tools.test.ts` (3 new for epics, including that the error and
empty-page messages name epics rather than features). Full suite: 515 pass, 0 fail.
`manifest.json` regenerated with `bun run manifest:sync` (50 tools); README and CLAUDE.md counts
updated.