### PR TITLE
feat: publish to the official MCP Registry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -164,3 +164,62 @@ jobs:
           curl -f http://localhost:3001/ || exit 1
           # Cleanup
           docker stop aha-mcp-test
+
+  # Publishes metadata only - the registry hosts nothing, it points at the npm package, the
+  # ghcr image and the .mcpb asset. All three must already exist and carry their ownership
+  # marker before the registry will accept the entry, hence `needs` on both publish jobs:
+  # npm is checked for `mcpName` in package.json, ghcr for the image's
+  # io.modelcontextprotocol.server.name label, and the release asset for its SHA-256.
+  mcp-registry:
+    needs: [release-please, publish, docker]
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: read
+      id-token: write # github-oidc login; no stored registry credential
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # server.json is committed with the version release-please bumps, but two fields it
+      # cannot reach are filled in here: the ghcr tag is embedded in a string rather than
+      # being a value of its own, and the .mcpb entry needs a hash of an artifact that does
+      # not exist until the release is built.
+      - name: Pin server.json to the released artifacts
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#aha-mcp-v}"
+          MCPB_URL="https://github.com/cedricziel/aha-mcp/releases/download/${TAG}/aha-mcp-v${VERSION}.mcpb"
+          curl -fsSL -o release.mcpb "$MCPB_URL"
+          MCPB_SHA="$(sha256sum release.mcpb | cut -d' ' -f1)"
+          jq --arg v "$VERSION" --arg url "$MCPB_URL" --arg sha "$MCPB_SHA" '
+            .version = $v
+            | .packages = [
+                .packages[]
+                | if .registryType == "npm" then .version = $v
+                  elif .registryType == "oci" then .identifier = "ghcr.io/cedricziel/aha-mcp:" + $v
+                  else . end
+              ] + [
+                {
+                  registryType: "mcpb",
+                  identifier: $url,
+                  version: $v,
+                  fileSha256: $sha,
+                  transport: { type: "stdio" }
+                }
+              ]
+          ' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP Registry
+        run: ./mcp-publisher publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   `prompts_generated: true` - the schema requires a `text` field on any statically declared
   prompt, which the server generates at runtime instead.
 
+### MCP Registry
+
+`server.json` is the entry in the [official MCP Registry](https://registry.modelcontextprotocol.io),
+published as `io.github.cedricziel/aha-mcp` by the `mcp-registry` job in
+`release-please.yml`. The registry stores metadata only - it points at the npm package, the
+`ghcr.io` image and the `.mcpb` release asset. Validate a change locally with
+`mcp-publisher validate`, which needs no credentials.
+
+- **The name is fixed by the authentication method.** `mcp-publisher login github-oidc`
+  only grants `io.github.<owner>/`, so the name cannot become `com.cedricziel/...` or
+  anything else without moving to DNS auth and an Ed25519 key.
+- **Each package type is verified against the published artifact, by a different marker.**
+  npm: `mcpName` in `package.json`. OCI: the
+  `io.modelcontextprotocol.server.name` label in the `Dockerfile`. MCPB: a `fileSha256` of
+  the asset. All of them must equal `name` in `server.json`, so renaming the server means
+  changing three files at once - `test/server-json.test.ts` pins them together rather than
+  letting a release discover it.
+- **The registry job therefore runs after `publish` and `docker`.** It reads what those two
+  jobs uploaded; running it first fails validation on artifacts that do not exist yet. For
+  the same reason the first registry entry can only be the **next** release: npm 5.0.1 was
+  published before `mcpName` existed, and the marker is read from the package, not the repo.
+- **Two fields in `server.json` cannot be bumped by release-please and are rewritten in
+  CI.** Its `extra-files` updater sets a whole JSON value, so it handles `$.version` and
+  `$.packages[0].version` but not the version *inside* the `ghcr.io/...:5.0.1` identifier
+  string; and the `.mcpb` entry needs a hash of an artifact that does not exist until the
+  release is built, which is why that entry is absent from the committed file and appended
+  by `jq`. Do not add a placeholder hash to make the file look complete.
+- `description` is capped at **100 characters** by the schema. `title` is the display name;
+  `name` is the identifier and is not shown.
+
 ### Search
 
 Search goes through Aha's GraphQL API (`POST /api/v2/graphql`, `searchDocuments`), wrapped by

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ RUN bun run build
 # Stage 2: Production stage
 FROM oven/bun:1.2-alpine AS production
 
+# Ownership marker for the MCP Registry: it only accepts the `oci` package entry in
+# server.json if the image carries this label with the same name. Must stay identical to
+# `name` in server.json and `mcpName` in package.json.
+LABEL io.modelcontextprotocol.server.name="io.github.cedricziel/aha-mcp"
+
 # Install runtime dependencies
 RUN apk add --no-cache \
     tini \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ A Model Context Protocol (MCP) server that provides seamless integration with Ah
 
 ## 🔧 Client Configuration
 
+### MCP Registry
+
+This server is published to the [official MCP Registry](https://registry.modelcontextprotocol.io)
+as `io.github.cedricziel/aha-mcp`, so a client that browses the registry can install it
+without any of the configuration below:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.cedricziel/aha-mcp"
+```
+
+The registry holds metadata only. Its entry points at the three artifacts described below —
+the npm package, the `ghcr.io` image and the `.mcpb` desktop extension — and a client picks
+whichever it can run. Either way the server needs `AHA_COMPANY` and `AHA_TOKEN`.
+
 ### Claude Desktop Extension (easiest)
 
 Download `aha-mcp-v<version>.mcpb` from the [latest release](https://github.com/cedricziel/aha-mcp/releases/latest)
@@ -999,7 +1013,14 @@ This project uses [release-please](https://github.com/googleapis/release-please-
 2. **Push to main** - release-please will automatically:
    - Create a release PR with updated version and changelog
    - Once the release PR is merged, it will create a GitHub release
-   - The release will trigger automatic publication to npm
+   - The release will trigger automatic publication to npm, `ghcr.io` and the
+     [MCP Registry](https://registry.modelcontextprotocol.io)
+
+   The registry job runs last, because the registry verifies ownership by reading the
+   already-published artifacts: `mcpName` in the npm package, the
+   `io.modelcontextprotocol.server.name` label on the image, and the SHA-256 of the `.mcpb`
+   asset attached to the release. It authenticates with GitHub OIDC, so no registry
+   credential is stored anywhere.
 
 #### Manual Publishing
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cedricziel/aha-mcp",
+  "mcpName": "io.github.cedricziel/aha-mcp",
   "module": "src/index.ts",
   "type": "module",
   "version": "5.0.1",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,16 @@
           "type": "json",
           "path": "manifest.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
         }
       ]
     }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.cedricziel/aha-mcp",
+  "title": "Aha.io",
+  "description": "Search, read and update Aha.io ideas, features, epics, releases, goals and comments",
+  "version": "5.0.1",
+  "repository": {
+    "url": "https://github.com/cedricziel/aha-mcp",
+    "source": "github"
+  },
+  "websiteUrl": "https://github.com/cedricziel/aha-mcp#readme",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/cedricziel/aha-mcp/main/icon.png",
+      "mimeType": "image/png"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@cedricziel/aha-mcp",
+      "version": "5.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "AHA_COMPANY",
+          "description": "Aha.io company subdomain, e.g. 'mycompany' for mycompany.aha.io",
+          "isRequired": true,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "AHA_TOKEN",
+          "description": "Aha.io API token",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    },
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/cedricziel/aha-mcp:5.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "AHA_COMPANY",
+          "description": "Aha.io company subdomain, e.g. 'mycompany' for mycompany.aha.io",
+          "isRequired": true,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "AHA_TOKEN",
+          "description": "Aha.io API token",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/test/server-json.test.ts
+++ b/test/server-json.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const serverJson = JSON.parse(readFileSync(new URL('../server.json', import.meta.url), 'utf8'));
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const dockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8');
+
+const npmPackage = serverJson.packages.find((p: { registryType: string }) => p.registryType === 'npm');
+const ociPackage = serverJson.packages.find((p: { registryType: string }) => p.registryType === 'oci');
+
+/**
+ * The MCP Registry verifies that we own the artifacts server.json points at, and it does so
+ * per package type by looking for the server name inside the published artifact: `mcpName`
+ * in package.json for npm, an `io.modelcontextprotocol.server.name` label for the ghcr
+ * image. A mismatch is not a degraded listing, it is a rejected publish - and it only shows
+ * up during a release, after npm and ghcr have already been written to.
+ */
+describe('server.json', () => {
+  it('claims the GitHub namespace that github-oidc login can actually authenticate', () => {
+    // With GitHub auth the registry only grants `io.github.<owner>/`; anything else is
+    // refused with "You do not have permission to publish this server".
+    expect(serverJson.name).toBe('io.github.cedricziel/aha-mcp');
+  });
+
+  it('matches the npm ownership marker in package.json', () => {
+    expect(packageJson.mcpName).toBe(serverJson.name);
+  });
+
+  it('matches the OCI ownership marker in the Dockerfile', () => {
+    expect(dockerfile).toContain(`LABEL io.modelcontextprotocol.server.name="${serverJson.name}"`);
+  });
+
+  it('is bumped in step with the package version', () => {
+    // release-please owns both fields via extra-files; this fails if one entry is dropped.
+    expect(serverJson.version).toBe(packageJson.version);
+    expect(npmPackage.version).toBe(packageJson.version);
+  });
+
+  it('points the npm entry at the package this repo publishes', () => {
+    expect(npmPackage.identifier).toBe(packageJson.name);
+  });
+
+  /**
+   * The ghcr tag is not asserted against the current version: it lives inside a string, so
+   * release-please's json updater cannot bump it, and the release workflow rewrites it from
+   * the tag instead. Only the shape is pinned here, so a typo in the image name still fails
+   * before a release rather than during one.
+   */
+  it('points the oci entry at a version-tagged ghcr image', () => {
+    expect(ociPackage.identifier).toMatch(/^ghcr\.io\/cedricziel\/aha-mcp:\d+\.\d+\.\d+$/);
+  });
+
+  it('declares the credentials the server cannot start without', () => {
+    for (const pkg of [npmPackage, ociPackage]) {
+      const names = pkg.environmentVariables.map((v: { name: string }) => v.name);
+      expect(names).toContain('AHA_COMPANY');
+      expect(names).toContain('AHA_TOKEN');
+
+      const token = pkg.environmentVariables.find((v: { name: string }) => v.name === 'AHA_TOKEN');
+      expect(token.isSecret).toBe(true);
+    }
+  });
+
+  it('keeps the description inside the 100-character limit the schema sets', () => {
+    expect(serverJson.description.length).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
Adds this server to the [official MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.cedricziel/aha-mcp`. The registry stores metadata only — the entry points at the npm package, the `ghcr.io` image and the `.mcpb` release asset, and a client picks whichever it can run.

## What is here

- **`server.json`** — the registry entry: npm and OCI packages, both declaring `AHA_COMPANY` and `AHA_TOKEN` (the token marked `isSecret`), plus repository, website and icon. Verified with the real `mcp-publisher validate` against the live registry, both as committed and after the CI rewrite below.
- **Ownership markers, one per package type.** The registry reads the server name back out of each published artifact: `mcpName` in `package.json` for npm, an `io.modelcontextprotocol.server.name` label in the `Dockerfile` for the image, and a SHA-256 for the `.mcpb`. All three must equal `name` in `server.json`.
- **`mcp-registry` job** in `release-please.yml`, authenticating with `github-oidc` — no registry credential is stored anywhere.
- **`test/server-json.test.ts`** — pins the three markers to each other and the versions to `package.json`, so a rename or a dropped `extra-files` entry fails a PR instead of failing mid-release, after npm and ghcr have already been written to.

## Two things worth reviewing

**The job runs last, after `publish` and `docker`.** Validation reads what those jobs uploaded rather than what the repo claims, so running it any earlier fails against artifacts that do not exist yet.

**Two fields cannot be bumped by release-please, and are rewritten in CI.** Its `extra-files` updater sets a whole JSON value, so it covers `$.version` and `$.packages[0].version` but not the version embedded in the `ghcr.io/...:5.0.1` identifier *string*; and the `.mcpb` entry needs a hash of an artifact that does not exist until the release is built, which is why that entry is absent from the committed file and appended with `jq`. No placeholder hash is committed to make the file look complete. The `jq` program was dry-run locally against the real v5.0.1 release asset and its output validates.

## The first entry will be this release, not 5.0.1

npm 5.0.1 was published before `mcpName` existed and the image before the label, and both markers are read from the artifact rather than from the repo — so nothing can be published for the current version. Merging this makes the next release the first one in the registry.